### PR TITLE
Make Alchemy flasks non-repairable

### DIFF
--- a/1.7.2/java/WayofTime/alchemicalWizardry/common/items/potion/AlchemyFlask.java
+++ b/1.7.2/java/WayofTime/alchemicalWizardry/common/items/potion/AlchemyFlask.java
@@ -42,6 +42,7 @@ public class AlchemyFlask extends Item
         this.setMaxDamage(8);
         this.setMaxStackSize(1);
         setCreativeTab(AlchemicalWizardry.tabBloodMagic);
+        setNoRepair();
         // TODO Auto-generated constructor stub
     }
 


### PR DESCRIPTION
setting alchemy flasks to be non-repairable, will stop items such as the ars magica repairer and my anvil from being able to repair flasks, which should be what you'd want from what I understand, since they have their own special repair method.
