### PR TITLE
Alchemy handler 'bug' fix :P

### DIFF
--- a/BM_src/joshie/alchemicalWizardy/nei/NEIAlchemyRecipeHandler.java
+++ b/BM_src/joshie/alchemicalWizardy/nei/NEIAlchemyRecipeHandler.java
@@ -86,6 +86,7 @@ public class NEIAlchemyRecipeHandler extends TemplateRecipeHandler {
 			for(ItemStack stack: stacks) {
 				if(NEIServerUtils.areStacksSameTypeCrafting(stack, ingredient)) {
 					arecipes.add(new CachedAlchemyRecipe(recipe));
+					break;
 				}
 			}
 			


### PR DESCRIPTION
Just added a break so that the for loop when going through the items when searching uses, exits when it has found the ingredient. This fixes the bug where searching usages on an item that's used up more than once in a recipe results in multiple copies of the recipe.

Thanks to mrvideo for letting me know of this 'bug' :p
