### PR TITLE
Updated Alchemy Handler + BloodOrbRecipe Addition

### DIFF
--- a/1.7.2/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/1.7.2/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
+import joshie.alchemicalWizardy.ShapedBloodOrbRecipe;
+import joshie.alchemicalWizardy.ShapelessBloodOrbRecipe;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -20,6 +22,8 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidContainerRegistry;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.oredict.RecipeSorter;
+import net.minecraftforge.oredict.RecipeSorter.Category;
 import thaumcraft.api.ItemApi;
 import WayofTime.alchemicalWizardry.api.alchemy.AlchemicalPotionCreationHandler;
 import WayofTime.alchemicalWizardry.api.alchemy.AlchemyRecipeRegistry;
@@ -271,6 +275,9 @@ public class AlchemicalWizardry
         
         ModItems.registerItems();
         
+        RecipeSorter.INSTANCE.register("AWWayofTime:shapedorb", ShapedBloodOrbRecipe.class, Category.SHAPED, "before:minecraft:shapeless");
+        RecipeSorter.INSTANCE.register("AWWayofTime:shapelessorb", ShapelessBloodOrbRecipe.class, Category.SHAPELESS, "after:minecraft:shapeless");
+        
         //FMLCommonHandler.instance().bus().register(new AlchemicalWizardryEventHooks());
         MinecraftForge.EVENT_BUS.register(new AlchemicalWizardryEventHooks());
         NewPacketHandler.INSTANCE.ordinal();
@@ -401,59 +408,59 @@ public class AlchemicalWizardry
         GameRegistry.addRecipe(sacrificialDaggerStack, "ggg", " dg", "i g", 'g', glassStack, 'd', goldIngotStack, 'i', ironIngotStack);
         //GameRegistry.addRecipe(blankSlateStack, "sgs", "gig", "sgs", 's', stoneStack, 'g', goldNuggetStack, 'i', ironIngotStack);
         //GameRegistry.addRecipe(reinforcedSlateStack, "rir", "ibi", "gig", 'r', redstoneStack, 'i', ironIngotStack, 'b', blankSlateStack, 'g', glowstoneBlockStack);
-        GameRegistry.addRecipe(lavaCrystalStackCrafted, "glg", "lbl", "odo", 'g', glassStack, 'l', lavaBucketStack, 'b', weakBloodOrbStack, 'd', diamondStack, 'o', obsidianStack);
-        GameRegistry.addRecipe(waterSigilStackCrafted, "www", "wbw", "wow", 'w', waterBucketStack, 'b', blankSlateStack, 'o', weakBloodOrbStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(lavaCrystalStackCrafted, "glg", "lbl", "odo", 'g', glassStack, 'l', lavaBucketStack, 'b', weakBloodOrbStack, 'd', diamondStack, 'o', obsidianStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(waterSigilStackCrafted, "www", "wbw", "wow", 'w', waterBucketStack, 'b', blankSlateStack, 'o', weakBloodOrbStack));
         GameRegistry.addRecipe(lavaSigilStackCrafted, "lml", "lbl", "lcl", 'l', lavaBucketStack, 'b', blankSlateStack, 'm', magmaCreamStack, 'c', lavaCrystalStack);
-        GameRegistry.addRecipe(voidSigilStackCrafted, "ese", "ere", "eoe", 'e', emptyBucketStack, 'r', reinforcedSlateStack, 'o', apprenticeBloodOrbStack, 's', stringStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(voidSigilStackCrafted, "ese", "ere", "eoe", 'e', emptyBucketStack, 'r', reinforcedSlateStack, 'o', apprenticeBloodOrbStack, 's', stringStack));
         GameRegistry.addRecipe(bloodAltarStack, "s s", "scs", "gdg", 's', stoneStack, 'c', furnaceStack, 'd', diamondStack, 'g', goldIngotStack);
         //GameRegistry.addRecipe(energySwordStack, " o ", " o ", " s ", 'o', weakBloodOrbStack, 's', diamondSwordStack);
         //GameRegistry.addRecipe(energyBlasterStack, "oi ", "gdi", " rd", 'o', weakBloodOrbStack, 'i', ironIngotStack, 'd', diamondStack, 'r', reinforcedSlateStack, 'g', goldIngotStack);
-        GameRegistry.addRecipe(bloodRuneCraftedStack, "sss", "ror", "sss", 's', stoneStack, 'o', weakBloodOrbStack, 'r', blankSlateStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(bloodRuneCraftedStack, "sss", "ror", "sss", 's', stoneStack, 'o', weakBloodOrbStack, 'r', blankSlateStack));
         GameRegistry.addRecipe(speedRuneStack, "sbs", "uru", "sbs", 'u', sugarStack, 's', stoneStack, 'r', bloodRuneStack, 'b', blankSlateStack);
         //GameRegistry.addRecipe(efficiencyRuneStack, "sbs", "rur", "sbs", 'r', redstoneStack, 's', stoneStack, 'u', bloodRuneStack,'b',blankSlateStack);
-        GameRegistry.addRecipe(new ItemStack(ModBlocks.bloodRune, 1, 1), "sbs", "bob", "srs", 's', stoneStack, 'o', magicianBloodOrbStack, 'b', emptyBucketStack, 'r', new ItemStack(ModItems.imbuedSlate));
-        GameRegistry.addRecipe(new ItemStack(ModBlocks.bloodRune, 1, 2), "sbs", "bob", "srs", 's', stoneStack, 'o', magicianBloodOrbStack, 'b', waterBucketStack, 'r', new ItemStack(ModItems.imbuedSlate));
-        GameRegistry.addRecipe(new ItemStack(ModBlocks.bloodRune, 1, 3), "sws", "ror", "sws", 's', stoneStack, 'o', new ItemStack(ModItems.masterBloodOrb), 'w', weakBloodOrbStack, 'r', new ItemStack(ModItems.demonicSlate));
-        GameRegistry.addRecipe(airSigilStack, "fgf", "fsf", "fof", 'f', featherStack, 'g', ghastTearStack, 's', reinforcedSlateStack, 'o', apprenticeBloodOrbStack);
-        GameRegistry.addRecipe(miningSigilStackCrafted, "sps", "hra", "sos", 'o', apprenticeBloodOrbStack, 's', stoneStack, 'p', ironPickaxeStack, 'h', ironShovelStack, 'a', ironAxeStack, 'r', reinforcedSlateStack);
-        GameRegistry.addRecipe(runeOfSacrificeStack, "srs", "gog", "srs", 's', stoneStack, 'g', goldIngotStack, 'o', apprenticeBloodOrbStack, 'r', reinforcedSlateStack);
-        GameRegistry.addRecipe(runeOfSelfSacrificeStack, "srs", "gog", "srs", 's', stoneStack, 'g', glowstoneDustStack, 'o', apprenticeBloodOrbStack, 'r', reinforcedSlateStack);
-        GameRegistry.addRecipe(divinationSigilStackCrafted, "ggg", "gsg", "gog", 'g', glassStack, 's', blankSlateStack, 'o', weakBloodOrbStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(new ItemStack(ModBlocks.bloodRune, 1, 1), "sbs", "bob", "srs", 's', stoneStack, 'o', magicianBloodOrbStack, 'b', emptyBucketStack, 'r', new ItemStack(ModItems.imbuedSlate)));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(new ItemStack(ModBlocks.bloodRune, 1, 2), "sbs", "bob", "srs", 's', stoneStack, 'o', magicianBloodOrbStack, 'b', waterBucketStack, 'r', new ItemStack(ModItems.imbuedSlate)));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(new ItemStack(ModBlocks.bloodRune, 1, 3), "sws", "ror", "sws", 's', stoneStack, 'o', new ItemStack(ModItems.masterBloodOrb), 'w', weakBloodOrbStack, 'r', new ItemStack(ModItems.demonicSlate)));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(airSigilStack, "fgf", "fsf", "fof", 'f', featherStack, 'g', ghastTearStack, 's', reinforcedSlateStack, 'o', apprenticeBloodOrbStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(miningSigilStackCrafted, "sps", "hra", "sos", 'o', apprenticeBloodOrbStack, 's', stoneStack, 'p', ironPickaxeStack, 'h', ironShovelStack, 'a', ironAxeStack, 'r', reinforcedSlateStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(runeOfSacrificeStack, "srs", "gog", "srs", 's', stoneStack, 'g', goldIngotStack, 'o', apprenticeBloodOrbStack, 'r', reinforcedSlateStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(runeOfSelfSacrificeStack, "srs", "gog", "srs", 's', stoneStack, 'g', glowstoneDustStack, 'o', apprenticeBloodOrbStack, 'r', reinforcedSlateStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(divinationSigilStackCrafted, "ggg", "gsg", "gog", 'g', glassStack, 's', blankSlateStack, 'o', weakBloodOrbStack));
 //        GameRegistry.addRecipe(waterScribeToolStack, "f", "i", 'f', featherStack, 'i', elementalInkWaterStack);
 //        GameRegistry.addRecipe(fireScribeToolStack, "f", "i", 'f', featherStack, 'i', elementalInkFireStack);
 //        GameRegistry.addRecipe(earthScribeToolStack, "f", "i", 'f', featherStack, 'i', elementalInkEarthStack);
 //        GameRegistry.addRecipe(airScribeToolStack, "f", "i", 'f', featherStack, 'i', elementalInkAirStack);
-        GameRegistry.addRecipe(ritualStoneStackCrafted, "srs", "ror", "srs", 's', obsidianStack, 'o', apprenticeBloodOrbStack, 'r', reinforcedSlateStack);
-        GameRegistry.addRecipe(masterRitualStoneStack, "brb", "ror", "brb", 'b', obsidianStack, 'o', magicianBloodOrbStack, 'r', ritualStoneStack);
-        GameRegistry.addRecipe(imperfectRitualStoneStack, "bsb", "sos", "bsb", 's', stoneStack, 'b', obsidianStack, 'o', weakBloodOrbStack);
-        GameRegistry.addRecipe(sigilOfElementalAffinityStackCrafted, "oao", "wsl", "oro", 'o', obsidianStack, 'a', airSigilStack, 'w', waterSigilStack, 'l', lavaSigilStack, 'r', magicianBloodOrbStack, 's', imbuedSlateStack);
-        GameRegistry.addRecipe(sigilOfHoldingStack, "asa", "srs", "aoa", 'a', blankSlateStack, 's', stoneStack, 'r', imbuedSlateStack, 'o', magicianBloodOrbStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(ritualStoneStackCrafted, "srs", "ror", "srs", 's', obsidianStack, 'o', apprenticeBloodOrbStack, 'r', reinforcedSlateStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(masterRitualStoneStack, "brb", "ror", "brb", 'b', obsidianStack, 'o', magicianBloodOrbStack, 'r', ritualStoneStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(imperfectRitualStoneStack, "bsb", "sos", "bsb", 's', stoneStack, 'b', obsidianStack, 'o', weakBloodOrbStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(sigilOfElementalAffinityStackCrafted, "oao", "wsl", "oro", 'o', obsidianStack, 'a', airSigilStack, 'w', waterSigilStack, 'l', lavaSigilStack, 'r', magicianBloodOrbStack, 's', imbuedSlateStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(sigilOfHoldingStack, "asa", "srs", "aoa", 'a', blankSlateStack, 's', stoneStack, 'r', imbuedSlateStack, 'o', magicianBloodOrbStack));
         GameRegistry.addRecipe(emptySocketStack, "bgb", "gdg", "bgb", 'b', weakBloodShardStack, 'g', glassStack, 'd', diamondStack);
-        GameRegistry.addRecipe(armourForgeStack, "sfs", "fof", "sfs", 'f', bloodSocketStack, 's', stoneStack, 'o', magicianBloodOrbStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(armourForgeStack, "sfs", "fof", "sfs", 'f', bloodSocketStack, 's', stoneStack, 'o', magicianBloodOrbStack));
         GameRegistry.addShapelessRecipe(largeBloodStoneBrickStackCrafted, weakBloodShardStack, stoneStack);
         GameRegistry.addRecipe(bloodStoneBrickStackCrafted, "bb", "bb", 'b', largeBloodStoneBrickStack);
-        GameRegistry.addRecipe(growthSigilStack, "srs", "rer", "sos", 's', saplingStack, 'r', reedStack, 'o', apprenticeBloodOrbStack, 'e', reinforcedSlateStack);
-        GameRegistry.addRecipe(blockHomHeartStack, "www", "srs", "sos", 'w', redWoolStack, 's', stoneStack, 'r', bloodRuneStack, 'o', apprenticeBloodOrbStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(growthSigilStack, "srs", "rer", "sos", 's', saplingStack, 'r', reedStack, 'o', apprenticeBloodOrbStack, 'e', reinforcedSlateStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(blockHomHeartStack, "www", "srs", "sos", 'w', redWoolStack, 's', stoneStack, 'r', bloodRuneStack, 'o', apprenticeBloodOrbStack));
         GameRegistry.addShapelessRecipe(new ItemStack(Items.skull, 1, 2), new ItemStack(Items.skull, 1, 1), new ItemStack(Items.rotten_flesh), new ItemStack(Items.iron_ingot), new ItemStack(Items.leather));
         GameRegistry.addShapelessRecipe(new ItemStack(Items.skull, 1, 0), new ItemStack(Items.skull, 1, 1), new ItemStack(Items.bow, 1, 0), new ItemStack(Items.arrow, 1, 0), new ItemStack(Items.bone));
         GameRegistry.addShapelessRecipe(new ItemStack(Items.skull, 1, 4), new ItemStack(Items.skull, 1, 1), new ItemStack(Items.gunpowder), new ItemStack(Blocks.dirt), new ItemStack(Blocks.sand));
-        GameRegistry.addRecipe(new ItemStack(ModBlocks.blockWritingTable), " s ", "ror", 's', new ItemStack(Items.brewing_stand), 'r', obsidianStack, 'o', weakBloodOrbStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(new ItemStack(ModBlocks.blockWritingTable), " s ", "ror", 's', new ItemStack(Items.brewing_stand), 'r', obsidianStack, 'o', weakBloodOrbStack));
         GameRegistry.addRecipe(new ItemStack(ModBlocks.blockPedestal), "ooo", " c ", "ooo", 'o', obsidianStack, 'c', weakBloodShardStack);
         GameRegistry.addRecipe(new ItemStack(ModBlocks.blockPlinth), "iii", " p ", "iii", 'i', ironBlockStack, 'p', new ItemStack(ModBlocks.blockPedestal));
         GameRegistry.addShapelessRecipe(new ItemStack(ModItems.alchemyFlask, 1, 0), new ItemStack(ModItems.alchemyFlask, 1, craftingConstant), new ItemStack(Items.nether_wart), redstoneStack, glowstoneDustStack);
-        GameRegistry.addRecipe(new ItemStack(ModItems.sigilOfHaste), "csc", "sts", "ror", 'c', new ItemStack(Items.cookie), 's', new ItemStack(Items.sugar), 't', ModItems.demonicSlate, 'r', obsidianStack, 'o', new ItemStack(ModItems.masterBloodOrb));
-        GameRegistry.addRecipe(new ItemStack(ModItems.sigilOfWind), "faf", "grg", "fof", 'f', featherStack, 'g', ghastTearStack, 'a', new ItemStack(ModItems.airSigil), 'o', new ItemStack(ModItems.masterBloodOrb), 'r', ModItems.demonicSlate);
-        GameRegistry.addShapelessRecipe(new ItemStack(ModItems.weakBloodShard, 5, 0), new ItemStack(ModItems.masterBloodOrb), new ItemStack(ModItems.weakBloodShard), imbuedSlateStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(new ItemStack(ModItems.sigilOfHaste), "csc", "sts", "ror", 'c', new ItemStack(Items.cookie), 's', new ItemStack(Items.sugar), 't', ModItems.demonicSlate, 'r', obsidianStack, 'o', new ItemStack(ModItems.masterBloodOrb)));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(new ItemStack(ModItems.sigilOfWind), "faf", "grg", "fof", 'f', featherStack, 'g', ghastTearStack, 'a', new ItemStack(ModItems.airSigil), 'o', new ItemStack(ModItems.masterBloodOrb), 'r', ModItems.demonicSlate));
+        GameRegistry.addRecipe(new ShapelessBloodOrbRecipe(new ItemStack(ModItems.weakBloodShard, 5, 0), new ItemStack(ModItems.masterBloodOrb), new ItemStack(ModItems.weakBloodShard), imbuedSlateStack));
         GameRegistry.addRecipe(new ItemStack(ModBlocks.blockTeleposer), "ggg", "efe", "ggg", 'g', goldIngotStack, 'f', new ItemStack(ModItems.telepositionFocus), 'e', new ItemStack(Items.ender_pearl));
         GameRegistry.addShapelessRecipe(new ItemStack(ModItems.reinforcedTelepositionFocus), new ItemStack(ModItems.enhancedTelepositionFocus), new ItemStack(ModItems.weakBloodShard));
         GameRegistry.addShapelessRecipe(new ItemStack(ModItems.demonicTelepositionFocus), new ItemStack(ModItems.reinforcedTelepositionFocus), new ItemStack(ModItems.demonBloodShard));
-        GameRegistry.addRecipe(new ItemStack(ModItems.sigilOfTheBridge), "nnn", "nsn", "ror", 'n', stoneStack, 'r', new ItemStack(Blocks.soul_sand), 's', imbuedSlateStack, 'o', magicianBloodOrbStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(new ItemStack(ModItems.sigilOfTheBridge), "nnn", "nsn", "ror", 'n', stoneStack, 'r', new ItemStack(Blocks.soul_sand), 's', imbuedSlateStack, 'o', magicianBloodOrbStack));
         GameRegistry.addRecipe(new ItemStack(ModItems.armourInhibitor), " gg", "gsg", "gg ", 'g', goldIngotStack, 's', new ItemStack(ModItems.weakBloodShard));
         GameRegistry.addRecipe(new ItemStack(ModItems.itemRitualDiviner), "d1d", "2e3", "d4d", '1', new ItemStack(ModItems.airScribeTool), '2', new ItemStack(ModItems.waterScribeTool), '3', new ItemStack(ModItems.fireScribeTool), '4', new ItemStack(ModItems.earthScribeTool), 'd', diamondStack, 'e', new ItemStack(Items.emerald));
         GameRegistry.addRecipe(duskRitualDivinerStack, " d ", "srs", " d ", 'd', new ItemStack(ModItems.duskScribeTool), 's', new ItemStack(ModItems.demonicSlate), 'r', new ItemStack(ModItems.itemRitualDiviner));
-        GameRegistry.addRecipe(new ItemStack(ModItems.sigilOfMagnetism), "bgb", "gsg", "bob", 'b', new ItemStack(Blocks.iron_block), 'g', goldIngotStack, 's', new ItemStack(ModItems.imbuedSlate), 'o', magicianBloodOrbStack);
-        GameRegistry.addRecipe(new ItemStack(ModItems.energyBazooka), "Ocd", "cb ", "d w", 'O', archmageBloodOrbStack, 'c', crepitousStack, 'b', new ItemStack(ModItems.energyBlaster), 'd', diamondStack, 'w', new ItemStack(ModItems.weakBloodShard));
-        GameRegistry.addRecipe(new ItemStack(ModItems.itemBloodLightSigil), "btb", "sss", "bob", 'o', magicianBloodOrbStack, 'b', glowstoneBlockStack, 't', new ItemStack(Blocks.torch), 's', imbuedSlateStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(new ItemStack(ModItems.sigilOfMagnetism), "bgb", "gsg", "bob", 'b', new ItemStack(Blocks.iron_block), 'g', goldIngotStack, 's', new ItemStack(ModItems.imbuedSlate), 'o', magicianBloodOrbStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(new ItemStack(ModItems.energyBazooka), "Ocd", "cb ", "d w", 'O', archmageBloodOrbStack, 'c', crepitousStack, 'b', new ItemStack(ModItems.energyBlaster), 'd', diamondStack, 'w', new ItemStack(ModItems.weakBloodShard)));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(new ItemStack(ModItems.itemBloodLightSigil), "btb", "sss", "bob", 'o', magicianBloodOrbStack, 'b', glowstoneBlockStack, 't', new ItemStack(Blocks.torch), 's', imbuedSlateStack));
         GameRegistry.addRecipe(new ItemStack(ModItems.itemKeyOfDiablo), " gw", "gdg", "wg ", 'w', weakBloodShardStack, 'g', goldIngotStack, 'd', diamondStack);
         customPotionDrowning = (new PotionDrowning(customPotionDrowningID, true, 0)).setIconIndex(0, 0).setPotionName("Drowning");
         customPotionBoost = (new PotionBoost(customPotionBoostID, false, 0)).setIconIndex(0, 0).setPotionName("Boost");
@@ -694,27 +701,27 @@ public class AlchemicalWizardry
         GameRegistry.addRecipe(stoneBraceStack," is","isi","si ",'i', ironIngotStack,'s',reinforcedSlateStack);
         GameRegistry.addRecipe(obsidianBraceStack," is","ibi","si ",'i', obsidianStack,'s',reinforcedSlateStack,'b',stoneBraceStack);
         
-        GameRegistry.addRecipe(projectileCoreStack, "mbm","aca","mom",'c', emptyCoreStack,'b',weakBloodShardStack,'m', magicalesStack,'o', magicianBloodOrbStack,'a',new ItemStack(Items.arrow));
-        GameRegistry.addRecipe(selfCoreStack,"sbs","ncn","sos",'c', emptyCoreStack, 's',sanctusStack,'b', weakBloodShardStack,'o', magicianBloodOrbStack,'n',glowstoneDustStack);
-        GameRegistry.addRecipe(meleeCoreStack,"sbs","ncn","sos",'c', emptyCoreStack, 's',incendiumStack,'b', weakBloodShardStack,'o', magicianBloodOrbStack,'n',new ItemStack(Items.fire_charge));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(projectileCoreStack, "mbm","aca","mom",'c', emptyCoreStack,'b',weakBloodShardStack,'m', magicalesStack,'o', magicianBloodOrbStack,'a',new ItemStack(Items.arrow)));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(selfCoreStack,"sbs","ncn","sos",'c', emptyCoreStack, 's',sanctusStack,'b', weakBloodShardStack,'o', magicianBloodOrbStack,'n',glowstoneDustStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(meleeCoreStack,"sbs","ncn","sos",'c', emptyCoreStack, 's',incendiumStack,'b', weakBloodShardStack,'o', magicianBloodOrbStack,'n',new ItemStack(Items.fire_charge)));
         GameRegistry.addRecipe(paradigmBackPlateStack,"isi","rgr","isi",'i',ironIngotStack,'r',stoneStack,'g',goldIngotStack,'s',reinforcedSlateStack);
         GameRegistry.addRecipe(outputCableStack, " si","s c"," si",'s',stoneStack,'i',ironIngotStack,'c',simpleCatalystStack); 
         
-        GameRegistry.addRecipe(flameCoreStack,"mdm","scs","mom",'m',incendiumStack,'c',emptyCoreStack,'o',magicianBloodOrbStack,'d',diamondStack,'s',weakBloodShardStack);
-        GameRegistry.addRecipe(iceCoreStack,"mdm","scs","mom",'m',crystallosStack,'c',emptyCoreStack,'o',magicianBloodOrbStack,'d',diamondStack,'s',weakBloodShardStack);
-        GameRegistry.addRecipe(windCoreStack,"mdm","scs","mom",'m',aetherStack,'c',emptyCoreStack,'o',magicianBloodOrbStack,'d',diamondStack,'s',weakBloodShardStack);
-        GameRegistry.addRecipe(earthCoreStack,"mdm","scs","mom",'m',terraeStack,'c',emptyCoreStack,'o',magicianBloodOrbStack,'d',diamondStack,'s',weakBloodShardStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(flameCoreStack,"mdm","scs","mom",'m',incendiumStack,'c',emptyCoreStack,'o',magicianBloodOrbStack,'d',diamondStack,'s',weakBloodShardStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(iceCoreStack,"mdm","scs","mom",'m',crystallosStack,'c',emptyCoreStack,'o',magicianBloodOrbStack,'d',diamondStack,'s',weakBloodShardStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(windCoreStack,"mdm","scs","mom",'m',aetherStack,'c',emptyCoreStack,'o',magicianBloodOrbStack,'d',diamondStack,'s',weakBloodShardStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(earthCoreStack,"mdm","scs","mom",'m',terraeStack,'c',emptyCoreStack,'o',magicianBloodOrbStack,'d',diamondStack,'s',weakBloodShardStack));
 
         GameRegistry.addRecipe(inputCableStack, "ws ","rcs","ws ",'w',blankSlateStack,'s',stoneStack,'r',imbuedSlateStack,'c',simpleCatalystStack);
         
-        GameRegistry.addRecipe(defaultCoreStack,"msm","geg","mom",'m', strengthenedCatalystStack,'e', emptyCoreStack, 'o', magicianBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack);
-        GameRegistry.addRecipe(offenseCoreStack,"msm","geg","mom",'m', offensaStack,'e', emptyCoreStack, 'o', magicianBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack);
-        GameRegistry.addRecipe(defensiveCoreStack,"msm","geg","mom",'m', praesidiumStack,'e', emptyCoreStack, 'o', magicianBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack);
-        GameRegistry.addRecipe(environmentalCoreStack,"msm","geg","mom",'m', orbisTerraeStack,'e', emptyCoreStack, 'o', magicianBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(defaultCoreStack,"msm","geg","mom",'m', strengthenedCatalystStack,'e', emptyCoreStack, 'o', magicianBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(offenseCoreStack,"msm","geg","mom",'m', offensaStack,'e', emptyCoreStack, 'o', magicianBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(defensiveCoreStack,"msm","geg","mom",'m', praesidiumStack,'e', emptyCoreStack, 'o', magicianBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(environmentalCoreStack,"msm","geg","mom",'m', orbisTerraeStack,'e', emptyCoreStack, 'o', magicianBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack));
         
-        GameRegistry.addRecipe(powerCoreStack,"msm","geg","mom",'m', virtusStack,'e', emptyCoreStack, 'o', masterBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack);
-        GameRegistry.addRecipe(costCoreStack,"msm","geg","mom",'m', reductusStack,'e', emptyCoreStack, 'o', masterBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack);
-        GameRegistry.addRecipe(potencyCoreStack,"msm","geg","mom",'m', potentiaStack,'e', emptyCoreStack, 'o', masterBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack);
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(powerCoreStack,"msm","geg","mom",'m', virtusStack,'e', emptyCoreStack, 'o', masterBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(costCoreStack,"msm","geg","mom",'m', reductusStack,'e', emptyCoreStack, 'o', masterBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(potencyCoreStack,"msm","geg","mom",'m', potentiaStack,'e', emptyCoreStack, 'o', masterBloodOrbStack, 's',weakBloodShardStack, 'g', goldIngotStack));
         
         AlchemyRecipeRegistry.registerRecipe(crackedRunicPlateStackCrafted, 10, new ItemStack[]{imbuedSlateStack,imbuedSlateStack,concentratedCatalystStack}, 4);
         AlchemyRecipeRegistry.registerRecipe(runicPlateStack, 30, new ItemStack[]{crackedRunicPlateStack,terraeStack}, 5);
@@ -749,8 +756,8 @@ public class AlchemicalWizardry
         
         GameRegistry.addShapelessRecipe(new ItemStack(Items.dye,5,15),fracturedBoneStack);
         
-        GameRegistry.addRecipe(new ItemStack(ModItems.itemSigilOfSupression),"wtl","wvl","wol",'v',new ItemStack(ModItems.voidSigil),'t',new ItemStack(ModBlocks.blockTeleposer),'o',masterBloodOrbStack,'l',lavaBucketStack,'w',waterBucketStack);
-        GameRegistry.addRecipe(new ItemStack(ModItems.itemSigilOfEnderSeverance),"ptp","ese","pop",'s',new ItemStack(ModItems.demonicSlate),'t',weakBloodShardStack,'o',masterBloodOrbStack,'e',new ItemStack(Items.ender_eye),'p', new ItemStack(Items.ender_pearl));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(new ItemStack(ModItems.itemSigilOfSupression),"wtl","wvl","wol",'v',new ItemStack(ModItems.voidSigil),'t',new ItemStack(ModBlocks.blockTeleposer),'o',masterBloodOrbStack,'l',lavaBucketStack,'w',waterBucketStack));
+        GameRegistry.addRecipe(new ShapedBloodOrbRecipe(new ItemStack(ModItems.itemSigilOfEnderSeverance),"ptp","ese","pop",'s',new ItemStack(ModItems.demonicSlate),'t',weakBloodShardStack,'o',masterBloodOrbStack,'e',new ItemStack(Items.ender_eye),'p', new ItemStack(Items.ender_pearl)));
         
         AlchemyRecipeRegistry.registerRecipe(new ItemStack(Items.flint,2,0), 1, new ItemStack[]{new ItemStack(Blocks.gravel),new ItemStack(Items.flint)}, 1);
         AlchemyRecipeRegistry.registerRecipe(new ItemStack(Blocks.grass), 2, new ItemStack[]{new ItemStack(Blocks.dirt),new ItemStack(Items.dye,1,15),new ItemStack(Items.wheat_seeds),new ItemStack(Items.wheat_seeds)}, 1);

--- a/1.7.2/main/java/joshie/alchemicalWizardy/ShapedBloodOrbRecipe.java
+++ b/1.7.2/main/java/joshie/alchemicalWizardy/ShapedBloodOrbRecipe.java
@@ -1,0 +1,227 @@
+package joshie.alchemicalWizardy;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import net.minecraft.block.Block;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.ShapedRecipes;
+import net.minecraft.world.World;
+import net.minecraftforge.oredict.OreDictionary;
+import WayofTime.alchemicalWizardry.api.items.interfaces.IBloodOrb;
+
+/** Shaped Blood Orb Recipe Handler by joshie **/
+public class ShapedBloodOrbRecipe implements IRecipe {		
+	private static final int MAX_CRAFT_GRID_WIDTH = 3;
+	private static final int MAX_CRAFT_GRID_HEIGHT = 3;
+
+	private ItemStack output = null;
+	private Object[] input = null;
+	private int width = 0;
+	private int height = 0;
+	private boolean mirrored = true;
+
+	public ShapedBloodOrbRecipe(Block result, Object... recipe) {
+		this(new ItemStack(result), recipe);
+	}
+
+	public ShapedBloodOrbRecipe(Item result, Object... recipe) {
+		this(new ItemStack(result), recipe);
+	}
+
+	public ShapedBloodOrbRecipe(ItemStack result, Object... recipe) {
+		output = result.copy();
+
+		String shape = "";
+		int idx = 0;
+
+		if (recipe[idx] instanceof Boolean) {
+			mirrored = (Boolean) recipe[idx];
+			if (recipe[idx + 1] instanceof Object[]) {
+				recipe = (Object[]) recipe[idx + 1];
+			} else {
+				idx = 1;
+			}
+		}
+
+		if (recipe[idx] instanceof String[]) {
+			String[] parts = ((String[]) recipe[idx++]);
+
+			for (String s : parts) {
+				width = s.length();
+				shape += s;
+			}
+
+			height = parts.length;
+		} else {
+			while (recipe[idx] instanceof String) {
+				String s = (String) recipe[idx++];
+				shape += s;
+				width = s.length();
+				height++;
+			}
+		}
+
+		if (width * height != shape.length()) {
+			String ret = "Invalid shaped ore recipe: ";
+			for (Object tmp : recipe) {
+				ret += tmp + ", ";
+			}
+			ret += output;
+			throw new RuntimeException(ret);
+		}
+
+		HashMap<Character, Object> itemMap = new HashMap<Character, Object>();
+
+		for (; idx < recipe.length; idx += 2) {
+			Character chr = (Character) recipe[idx];
+			Object in = recipe[idx + 1];
+
+			if (in instanceof IBloodOrb || (in instanceof ItemStack && ((ItemStack)in).getItem() instanceof IBloodOrb)) { //If the item is an instanceof IBloodOrb then save the level of the orb
+				if(in instanceof ItemStack) itemMap.put(chr, (Integer)(((IBloodOrb)((ItemStack)in).getItem()).getOrbLevel()));
+				else itemMap.put(chr, (Integer)(((IBloodOrb)in).getOrbLevel()));
+			} else if (in instanceof ItemStack) {
+				itemMap.put(chr, ((ItemStack) in).copy());
+			} else if (in instanceof Item) {
+				itemMap.put(chr, new ItemStack((Item) in));
+			} else if (in instanceof Block) {
+				itemMap.put(chr, new ItemStack((Block) in, 1, OreDictionary.WILDCARD_VALUE));
+			} else if (in instanceof String) {
+				itemMap.put(chr, OreDictionary.getOres((String) in));
+			} else {
+				String ret = "Invalid shaped ore recipe: ";
+				for (Object tmp : recipe) {
+					ret += tmp + ", ";
+				}
+				ret += output;
+				throw new RuntimeException(ret);
+			}
+		}
+
+		input = new Object[width * height];
+		int x = 0;
+		for (char chr : shape.toCharArray()) {
+			input[x++] = itemMap.get(chr);
+		}
+	}
+
+	ShapedBloodOrbRecipe(ShapedRecipes recipe, Map<ItemStack, String> replacements) {
+		output = recipe.getRecipeOutput();
+		width = recipe.recipeWidth;
+		height = recipe.recipeHeight;
+
+		input = new Object[recipe.recipeItems.length];
+
+		for (int i = 0; i < input.length; i++) {
+			ItemStack ingred = recipe.recipeItems[i];
+
+			if (ingred == null)
+				continue;
+
+			input[i] = recipe.recipeItems[i];
+
+			for (Entry<ItemStack, String> replace : replacements.entrySet()) {
+				if (OreDictionary.itemMatches(replace.getKey(), ingred, true)) {
+					input[i] = OreDictionary.getOres(replace.getValue());
+					break;
+				}
+			}
+		}
+	}
+
+	@Override
+	public ItemStack getCraftingResult(InventoryCrafting var1) {
+		return output.copy();
+	}
+
+	@Override
+	public int getRecipeSize() {
+		return input.length;
+	}
+
+	@Override
+	public ItemStack getRecipeOutput() {
+		return output;
+	}
+
+	@Override
+	public boolean matches(InventoryCrafting inv, World world) {
+		for (int x = 0; x <= MAX_CRAFT_GRID_WIDTH - width; x++) {
+			for (int y = 0; y <= MAX_CRAFT_GRID_HEIGHT - height; ++y) {
+				if (checkMatch(inv, x, y, false)) {
+					return true;
+				}
+
+				if (mirrored && checkMatch(inv, x, y, true)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	@SuppressWarnings("unchecked")
+	private boolean checkMatch(InventoryCrafting inv, int startX, int startY, boolean mirror) {
+		for (int x = 0; x < MAX_CRAFT_GRID_WIDTH; x++) {
+			for (int y = 0; y < MAX_CRAFT_GRID_HEIGHT; y++) {
+				int subX = x - startX;
+				int subY = y - startY;
+				Object target = null;
+
+				if (subX >= 0 && subY >= 0 && subX < width && subY < height) {
+					if (mirror) {
+						target = input[width - subX - 1 + subY * width];
+					} else {
+						target = input[subX + subY * width];
+					}
+				}
+				
+				ItemStack slot = inv.getStackInRowAndColumn(x, y);
+				//If target is integer, then we should be check the blood orb value of the item instead
+				if(target instanceof Integer) {
+					if(slot != null && slot.getItem() instanceof IBloodOrb) {
+						IBloodOrb orb = (IBloodOrb) slot.getItem();
+						if(orb.getOrbLevel() < (Integer)target) {
+							return false;
+						}
+					} else return false;
+				} else if (target instanceof ItemStack) {
+					if (!OreDictionary.itemMatches((ItemStack) target, slot, false)) {
+						return false;
+					}
+				} else if (target instanceof ArrayList) {
+					boolean matched = false;
+
+					Iterator<ItemStack> itr = ((ArrayList<ItemStack>) target).iterator();
+					while (itr.hasNext() && !matched) {
+						matched = OreDictionary.itemMatches(itr.next(), slot, false);
+					}
+
+					if (!matched) {
+						return false;
+					}
+				} else if (target == null && slot != null) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	public ShapedBloodOrbRecipe setMirrored(boolean mirror) {
+		mirrored = mirror;
+		return this;
+	}
+
+	public Object[] getInput() {
+		return this.input;
+	}
+}

--- a/1.7.2/main/java/joshie/alchemicalWizardy/ShapelessBloodOrbRecipe.java
+++ b/1.7.2/main/java/joshie/alchemicalWizardy/ShapelessBloodOrbRecipe.java
@@ -1,0 +1,140 @@
+package joshie.alchemicalWizardy;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import net.minecraft.block.Block;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.ShapelessRecipes;
+import net.minecraft.world.World;
+import net.minecraftforge.oredict.OreDictionary;
+import WayofTime.alchemicalWizardry.api.items.interfaces.IBloodOrb;
+
+/** Shapeless Blood Orb Recipe Handler by joshie **/
+public class ShapelessBloodOrbRecipe implements IRecipe {
+	private ItemStack output = null;
+	private ArrayList<Object> input = new ArrayList<Object>();
+
+	public ShapelessBloodOrbRecipe(Block result, Object... recipe) {
+		this(new ItemStack(result), recipe);
+	}
+
+	public ShapelessBloodOrbRecipe(Item result, Object... recipe) {
+		this(new ItemStack(result), recipe);
+	}
+
+	public ShapelessBloodOrbRecipe(ItemStack result, Object... recipe) {
+		output = result.copy();
+		for (Object in : recipe) {
+			if (in instanceof ItemStack) {
+				input.add(((ItemStack) in).copy());
+			} else if (in instanceof IBloodOrb) { //If the item is an instanceof IBloodOrb then save the level of the orb
+				input.add((Integer)(((IBloodOrb)in).getOrbLevel()));
+			} else if (in instanceof Item) {
+				input.add(new ItemStack((Item) in));
+			} else if (in instanceof Block) {
+				input.add(new ItemStack((Block) in));
+			} else if (in instanceof String) {
+				input.add(OreDictionary.getOres((String) in));
+			} else {
+				String ret = "Invalid shapeless ore recipe: ";
+				for (Object tmp : recipe) {
+					ret += tmp + ", ";
+				}
+				ret += output;
+				throw new RuntimeException(ret);
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	ShapelessBloodOrbRecipe(ShapelessRecipes recipe, Map<ItemStack, String> replacements) {
+		output = recipe.getRecipeOutput();
+
+		for (ItemStack ingred : ((List<ItemStack>) recipe.recipeItems)) {
+			Object finalObj = ingred;
+			for (Entry<ItemStack, String> replace : replacements.entrySet()) {
+				if (OreDictionary.itemMatches(replace.getKey(), ingred, false)) {
+					finalObj = OreDictionary.getOres(replace.getValue());
+					break;
+				}
+			}
+			input.add(finalObj);
+		}
+	}
+
+	@Override
+	public int getRecipeSize() {
+		return input.size();
+	}
+
+	@Override
+	public ItemStack getRecipeOutput() {
+		return output;
+	}
+
+	@Override
+	public ItemStack getCraftingResult(InventoryCrafting var1) {
+		return output.copy();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean matches(InventoryCrafting var1, World world) {
+		ArrayList<Object> required = new ArrayList<Object>(input);
+
+		for (int x = 0; x < var1.getSizeInventory(); x++) {
+			ItemStack slot = var1.getStackInSlot(x);
+
+			if (slot != null) {
+				boolean inRecipe = false;
+				Iterator<Object> req = required.iterator();
+
+				while (req.hasNext()) {
+					boolean match = false;
+
+					Object next = req.next();
+
+					//If target is integer, then we should be check the blood orb value of the item instead
+					if(next instanceof Integer) {
+						if(slot != null && slot.getItem() instanceof IBloodOrb) {
+							IBloodOrb orb = (IBloodOrb) slot.getItem();
+							if(orb.getOrbLevel() < (Integer)next) {
+								return false;
+							}
+						} else return false;
+					} else if (next instanceof ItemStack) {
+						match = OreDictionary.itemMatches((ItemStack) next, slot, false);
+					} else if (next instanceof ArrayList) {
+						Iterator<ItemStack> itr = ((ArrayList<ItemStack>) next).iterator();
+						while (itr.hasNext() && !match) {
+							match = OreDictionary.itemMatches(itr.next(), slot, false);
+						}
+					}
+
+					if (match) {
+						inRecipe = true;
+						required.remove(next);
+						break;
+					}
+				}
+
+				if (!inRecipe) {
+					return false;
+				}
+			}
+		}
+
+		return required.isEmpty();
+	}
+
+	public ArrayList<Object> getInput() {
+		return this.input;
+	}
+}

--- a/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIBloodOrbShapedHandler.java
+++ b/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIBloodOrbShapedHandler.java
@@ -1,0 +1,141 @@
+package joshie.alchemicalWizardy.nei;
+
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.List;
+
+import joshie.alchemicalWizardy.ShapedBloodOrbRecipe;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.CraftingManager;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.util.StatCollector;
+import WayofTime.alchemicalWizardry.api.items.interfaces.IBloodOrb;
+import codechicken.core.ReflectionManager;
+import codechicken.nei.NEIServerUtils;
+import codechicken.nei.PositionedStack;
+import codechicken.nei.recipe.ShapedRecipeHandler;
+import codechicken.nei.recipe.TemplateRecipeHandler.RecipeTransferRect;
+
+/** Extended from the default recipe handler **/
+public class NEIBloodOrbShapedHandler extends ShapedRecipeHandler {
+	public class CachedBloodOrbRecipe extends CachedShapedRecipe {
+		public CachedBloodOrbRecipe(int width, int height, Object[] items, ItemStack out) {
+			super(width, height, items, out);
+		}
+
+		@Override
+		public void setIngredients(int width, int height, Object[] items) {
+			for (int x = 0; x < width; x++) {
+				for (int y = 0; y < height; y++) {
+					if (items[y * width + x] == null)
+						continue;
+
+					Object o = items[y * width + x];
+					if (o instanceof ItemStack) {
+						PositionedStack stack = new PositionedStack(items[y * width + x], 25 + x * 18, 6 + y * 18, false);
+						stack.setMaxSize(1);
+						ingredients.add(stack);
+					} else if (o instanceof Integer) {
+						ArrayList<ItemStack> orbs = new ArrayList();
+						for (Item item : NEIConfig.bloodOrbs) {
+							if (((IBloodOrb) item).getOrbLevel() >= (Integer) o) {
+								orbs.add(new ItemStack(item));
+							}
+						}
+
+						PositionedStack stack = new PositionedStack(orbs, 25 + x * 18, 6 + y * 18, false);
+						stack.setMaxSize(1);
+						ingredients.add(stack);
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public void loadCraftingRecipes(String outputId, Object... results) {
+		if (outputId.equals("orbCrafting") && getClass() == NEIBloodOrbShapedHandler.class) {
+			for (IRecipe irecipe : (List<IRecipe>) CraftingManager.getInstance().getRecipeList()) {
+				if (irecipe instanceof ShapedBloodOrbRecipe) {
+					CachedBloodOrbRecipe recipe = forgeShapedRecipe((ShapedBloodOrbRecipe) irecipe);
+					if (recipe == null)
+						continue;
+
+					recipe.computeVisuals();
+					arecipes.add(recipe);
+				}
+			}
+		} else {
+			super.loadCraftingRecipes(outputId, results);
+		}
+	}
+
+	@Override
+	public void loadCraftingRecipes(ItemStack result) {
+		for (IRecipe irecipe : (List<IRecipe>) CraftingManager.getInstance().getRecipeList()) {
+			if (irecipe instanceof ShapedBloodOrbRecipe) {
+				CachedBloodOrbRecipe recipe = forgeShapedRecipe((ShapedBloodOrbRecipe) irecipe);
+				if (recipe == null || !NEIServerUtils.areStacksSameTypeCrafting(recipe.result.item, result))
+					continue;
+
+				recipe.computeVisuals();
+				arecipes.add(recipe);
+			}
+		}
+	}
+
+	@Override
+	public void loadUsageRecipes(ItemStack ingredient) {
+		for (IRecipe irecipe : (List<IRecipe>) CraftingManager.getInstance().getRecipeList()) {
+			CachedShapedRecipe recipe = null;
+			if (irecipe instanceof ShapedBloodOrbRecipe)
+				recipe = forgeShapedRecipe((ShapedBloodOrbRecipe) irecipe);
+
+			if (recipe == null || !recipe.contains(recipe.ingredients, ingredient.getItem()))
+				continue;
+
+			recipe.computeVisuals();
+			if (recipe.contains(recipe.ingredients, ingredient)) {
+				recipe.setIngredientPermutation(recipe.ingredients, ingredient);
+				arecipes.add(recipe);
+			}
+		}
+	}
+
+	private CachedBloodOrbRecipe forgeShapedRecipe(ShapedBloodOrbRecipe recipe) {
+		int width;
+		int height;
+		try {
+			width = ReflectionManager.getField(ShapedBloodOrbRecipe.class, Integer.class, recipe, 4);
+			height = ReflectionManager.getField(ShapedBloodOrbRecipe.class, Integer.class, recipe, 5);
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+
+		Object[] items = recipe.getInput();
+		for (Object item : items)
+			if (item instanceof List && ((List<?>) item).isEmpty())// ore
+																	// handler,
+																	// no ores
+				return null;
+
+		return new CachedBloodOrbRecipe(width, height, items, recipe.getRecipeOutput());
+	}
+	
+	@Override
+    public void loadTransferRects() {
+        transferRects.add(new RecipeTransferRect(new Rectangle(84, 23, 24, 18), "orbCrafting"));
+    }
+
+	@Override
+	public String getOverlayIdentifier() {
+		return "orbCrafting";
+	}
+
+	@Override
+	public String getRecipeName() {
+		return StatCollector.translateToLocal("bm.string.crafting.orb.shaped");
+	}
+}

--- a/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIBloodOrbShapelessHandler.java
+++ b/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIBloodOrbShapelessHandler.java
@@ -1,0 +1,130 @@
+package joshie.alchemicalWizardy.nei;
+
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.List;
+
+import joshie.alchemicalWizardy.ShapelessBloodOrbRecipe;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.CraftingManager;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.ShapelessRecipes;
+import net.minecraft.util.StatCollector;
+import net.minecraftforge.oredict.ShapelessOreRecipe;
+import WayofTime.alchemicalWizardry.api.items.interfaces.IBloodOrb;
+import codechicken.nei.NEIServerUtils;
+import codechicken.nei.PositionedStack;
+import codechicken.nei.recipe.ShapelessRecipeHandler;
+import codechicken.nei.recipe.ShapelessRecipeHandler.CachedShapelessRecipe;
+
+public class NEIBloodOrbShapelessHandler extends ShapelessRecipeHandler {
+	public class CachedBloodOrbRecipe extends CachedShapelessRecipe {
+		public CachedBloodOrbRecipe(ArrayList<Object> items, ItemStack recipeOutput) {
+			super(items, recipeOutput);
+		}
+
+		@Override
+		public void setIngredients(List<?> items) {
+            ingredients.clear();
+            for (int ingred = 0; ingred < items.size(); ingred++) {
+                Object o = items.get(ingred);
+				if (o instanceof ItemStack) {
+					PositionedStack stack = new PositionedStack(items.get(ingred), 25 + stackorder[ingred][0] * 18, 6 + stackorder[ingred][1] * 18);
+					stack.setMaxSize(1);
+					ingredients.add(stack);
+				} else if (o instanceof Integer) {
+					ArrayList<ItemStack> orbs = new ArrayList();
+					for (Item item : NEIConfig.bloodOrbs) {
+						if (((IBloodOrb) item).getOrbLevel() >= (Integer) o) {
+							orbs.add(new ItemStack(item));
+						}
+					}
+
+					PositionedStack stack = new PositionedStack(orbs, 25 + stackorder[ingred][0] * 18, 6 + stackorder[ingred][1] * 18);
+					stack.setMaxSize(1);
+					ingredients.add(stack);
+				}
+            }
+        }
+	}
+	
+	@Override
+    public void loadCraftingRecipes(String outputId, Object... results) {
+        if (outputId.equals("orbCrafting") && getClass() == NEIBloodOrbShapelessHandler.class) {
+            List<IRecipe> allrecipes = CraftingManager.getInstance().getRecipeList();
+            for (IRecipe irecipe : allrecipes) {
+            	CachedBloodOrbRecipe recipe = null;
+                if (irecipe instanceof ShapelessBloodOrbRecipe)
+                    recipe = forgeShapelessRecipe((ShapelessBloodOrbRecipe) irecipe);
+
+                if (recipe == null)
+                    continue;
+
+                arecipes.add(recipe);
+            }
+        } else {
+            super.loadCraftingRecipes(outputId, results);
+        }
+    }
+	
+	@Override
+    public void loadCraftingRecipes(ItemStack result) {
+        List<IRecipe> allrecipes = CraftingManager.getInstance().getRecipeList();
+        for (IRecipe irecipe : allrecipes) {
+            if (NEIServerUtils.areStacksSameTypeCrafting(irecipe.getRecipeOutput(), result)) {
+            	CachedBloodOrbRecipe recipe = null;
+                if (irecipe instanceof ShapelessBloodOrbRecipe)
+                    recipe = forgeShapelessRecipe((ShapelessBloodOrbRecipe) irecipe);
+
+                if (recipe == null)
+                    continue;
+
+                arecipes.add(recipe);
+            }
+        }
+    }
+	
+	@Override
+    public void loadUsageRecipes(ItemStack ingredient) {
+        List<IRecipe> allrecipes = CraftingManager.getInstance().getRecipeList();
+        for (IRecipe irecipe : allrecipes) {
+        	CachedBloodOrbRecipe recipe = null;
+            if (irecipe instanceof ShapelessBloodOrbRecipe)
+                recipe = forgeShapelessRecipe((ShapelessBloodOrbRecipe) irecipe);
+
+            if (recipe == null)
+                continue;
+
+            if (recipe.contains(recipe.ingredients, ingredient)) {
+                recipe.setIngredientPermutation(recipe.ingredients, ingredient);
+                arecipes.add(recipe);
+            }
+        }
+    }
+	
+	public CachedBloodOrbRecipe forgeShapelessRecipe(ShapelessBloodOrbRecipe recipe) {
+        ArrayList<Object> items = recipe.getInput();
+
+        for (Object item : items)
+            if (item instanceof List && ((List<?>) item).isEmpty())//ore handler, no ores
+                return null;
+
+        return new CachedBloodOrbRecipe(items, recipe.getRecipeOutput());
+    }
+	
+	@Override
+    public void loadTransferRects() {
+        transferRects.add(new RecipeTransferRect(new Rectangle(84, 23, 24, 18), "orbCrafting"));
+    }
+
+	@Override
+	public String getOverlayIdentifier() {
+		return "orbCrafting";
+	}
+
+	@Override
+	public String getRecipeName() {
+		return StatCollector.translateToLocal("bm.string.crafting.orb.shapeless");
+	}
+}

--- a/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIConfig.java
+++ b/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIConfig.java
@@ -3,24 +3,22 @@ package joshie.alchemicalWizardy.nei;
 import java.util.ArrayList;
 
 import net.minecraft.item.Item;
-import WayofTime.alchemicalWizardry.ModItems;
 import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
 
 public class NEIConfig implements IConfigureNEI {	
+	public static ArrayList<Item> bloodOrbs = new ArrayList<Item>();
+	
 	@Override
 	public void loadConfig() {
 		API.registerRecipeHandler(new NEIAlchemyRecipeHandler());
 		API.registerUsageHandler(new NEIAlchemyRecipeHandler());
 		API.registerRecipeHandler(new NEIAltarRecipeHandler());
 		API.registerUsageHandler(new NEIAltarRecipeHandler());
-		
-		NEIAlchemyRecipeHandler.bloodOrbs = new ArrayList<Item>();
-		NEIAlchemyRecipeHandler.bloodOrbs.add(ModItems.weakBloodOrb);
-		NEIAlchemyRecipeHandler.bloodOrbs.add(ModItems.apprenticeBloodOrb);
-		NEIAlchemyRecipeHandler.bloodOrbs.add(ModItems.magicianBloodOrb);
-		NEIAlchemyRecipeHandler.bloodOrbs.add(ModItems.masterBloodOrb);
-		NEIAlchemyRecipeHandler.bloodOrbs.add(ModItems.archmageBloodOrb);
+		API.registerRecipeHandler(new NEIBloodOrbShapedHandler());
+		API.registerUsageHandler(new NEIBloodOrbShapedHandler());
+		API.registerRecipeHandler(new NEIBloodOrbShapelessHandler());
+		API.registerUsageHandler(new NEIBloodOrbShapelessHandler());
 	}
 
 	@Override
@@ -30,6 +28,6 @@ public class NEIConfig implements IConfigureNEI {
 
 	@Override
 	public String getVersion() {
-		return "1.1";
+		return "1.2";
 	}
 }

--- a/1.7.2/main/resources/assets/alchemicalwizardry/lang/en_US.lang
+++ b/1.7.2/main/resources/assets/alchemicalwizardry/lang/en_US.lang
@@ -177,3 +177,5 @@ itemGroup.tabBloodMagic=Blood Magic
 bm.string.consume=Usage
 bm.string.drain=Drain
 bm.string.tier=Tier
+bm.string.crafting.orb.shaped=Shaped Orb Crafting
+bm.string.crafting.orb.shapeless=Shapeless Orb Crafting


### PR DESCRIPTION
Updated the Alchemy Handler to use IBloodOrb, instead of the fixed method from before. Added Shaped and Shapeless Blood Orb recipes, (Specifying the itemstack/item) of something that implements IBloodOrb, the recipe handler will save that data as an integer instead. Comparing the blood orb level of items, when matching the items, instead of checking the item itself. You just need to make sure to wrap your recipes in the ShapedBloodOrbRecipe/ShapelessBloodOrbRecipe, before adding to the recipelist. (I've adjusted all that I saw of the blood orb recipes to use this in the main class). If I missed any feel free to fix ;p
