### PR TITLE
Fixed Obfuscated Names

### DIFF
--- a/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIAltarRecipeHandler.java
+++ b/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIAltarRecipeHandler.java
@@ -92,7 +92,7 @@ public class NEIAltarRecipeHandler extends TemplateRecipeHandler {
 			return (Integer) f.get(gui);
 		} catch (NoSuchFieldException e) {
 			try {
-				Field f = gui.getClass().getField("field_73880_f");
+				Field f = gui.getClass().getField("field_146294_l");
 				return (Integer) f.get(gui);
 			} catch (Exception e2) {
 				return 0;
@@ -110,7 +110,7 @@ public class NEIAltarRecipeHandler extends TemplateRecipeHandler {
 			return (Integer) f.get(gui);
 		} catch (NoSuchFieldException e) {
 			try {
-				Field f = gui.getClass().getField("field_73881_g");
+				Field f = gui.getClass().getField("field_146295_m");
 				return (Integer) f.get(gui);
 			} catch (Exception e2) {
 				return 0;


### PR DESCRIPTION
Fixing the obfuscated names... Was still using the names from 1.6... Fixes the tooltips not working in normal minecraft for the drain/consume.
