### PR TITLE
Added 'Recipes' NEI button to the Alchemic Chemistry Set

### DIFF
--- a/1.7.10/main/java/joshie/alchemicalWizardy/nei/NEIAlchemyRecipeHandler.java
+++ b/1.7.10/main/java/joshie/alchemicalWizardy/nei/NEIAlchemyRecipeHandler.java
@@ -2,10 +2,12 @@ package joshie.alchemicalWizardy.nei;
 
 import static joshie.alchemicalWizardy.nei.NEIConfig.bloodOrbs;
 
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -13,6 +15,7 @@ import net.minecraft.util.StatCollector;
 import WayofTime.alchemicalWizardry.api.alchemy.AlchemyRecipe;
 import WayofTime.alchemicalWizardry.api.alchemy.AlchemyRecipeRegistry;
 import WayofTime.alchemicalWizardry.api.items.interfaces.IBloodOrb;
+import WayofTime.alchemicalWizardry.common.tileEntity.gui.GuiWritingTable;
 import codechicken.nei.ItemList;
 import codechicken.nei.NEIServerUtils;
 import codechicken.nei.PositionedStack;
@@ -89,6 +92,32 @@ public class NEIAlchemyRecipeHandler extends TemplateRecipeHandler {
 		
         return super.newInstance();
     }
+	
+	@Override
+	public String getOverlayIdentifier() {
+		return "alchemicalwizardry.alchemy";
+	}
+	
+	@Override
+	public void loadTransferRects() {
+		transferRects.add(new RecipeTransferRect(new Rectangle(134, 22, 16, 24), "alchemicalwizardry.alchemy"));
+	}
+	
+	@Override
+	public Class<? extends GuiContainer> getGuiClass() {
+		return GuiWritingTable.class;
+	}
+	
+	@Override
+	public void loadCraftingRecipes(String outputId, Object... results) {
+		if (outputId.equals("alchemicalwizardry.alchemy") && getClass() == NEIAlchemyRecipeHandler.class) {
+			for(AlchemyRecipe recipe: AlchemyRecipeRegistry.recipes) {
+				if(recipe.getResult() != null) arecipes.add(new CachedAlchemyRecipe(recipe));
+			}
+		} else {
+			super.loadCraftingRecipes(outputId, results);
+		}
+	}
 	
 	@Override
 	public void loadCraftingRecipes(ItemStack result) {

--- a/1.7.10/main/java/joshie/alchemicalWizardy/nei/NEIAltarRecipeHandler.java
+++ b/1.7.10/main/java/joshie/alchemicalWizardy/nei/NEIAltarRecipeHandler.java
@@ -49,7 +49,7 @@ public class NEIAltarRecipeHandler extends TemplateRecipeHandler {
 	
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		if (outputId.equals("altarrecipes") && getClass() == NEIAltarRecipeHandler.class) {
+		if (outputId.equals("alchemicalwizardry.bloodaltar") && getClass() == NEIAltarRecipeHandler.class) {
 			for(AltarRecipe recipe: AltarRecipeRegistry.altarRecipes) {
 				if(recipe.result != null) arecipes.add(new CachedAltarRecipe(recipe));
 			}
@@ -145,12 +145,12 @@ public class NEIAltarRecipeHandler extends TemplateRecipeHandler {
 	
 	@Override
 	public String getOverlayIdentifier() {
-		return "altarrecipes";
+		return "alchemicalwizardry.bloodaltar";
 	}
 	
 	@Override
 	public void loadTransferRects() {
-		transferRects.add(new RecipeTransferRect(new Rectangle(90, 32, 22, 16), "altarrecipes"));
+		transferRects.add(new RecipeTransferRect(new Rectangle(90, 32, 22, 16), "alchemicalwizardry.bloodaltar"));
 	}
 	
 	@Override

--- a/1.7.10/main/java/joshie/alchemicalWizardy/nei/NEIBloodOrbShapedHandler.java
+++ b/1.7.10/main/java/joshie/alchemicalWizardy/nei/NEIBloodOrbShapedHandler.java
@@ -55,7 +55,7 @@ public class NEIBloodOrbShapedHandler extends ShapedRecipeHandler {
 
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		if (outputId.equals("orbCrafting") && getClass() == NEIBloodOrbShapedHandler.class) {
+		if (outputId.equals("crafting") && getClass() == NEIBloodOrbShapedHandler.class) {
 			for (IRecipe irecipe : (List<IRecipe>) CraftingManager.getInstance().getRecipeList()) {
 				if (irecipe instanceof ShapedBloodOrbRecipe) {
 					CachedBloodOrbRecipe recipe = forgeShapedRecipe((ShapedBloodOrbRecipe) irecipe);
@@ -126,12 +126,12 @@ public class NEIBloodOrbShapedHandler extends ShapedRecipeHandler {
 	
 	@Override
     public void loadTransferRects() {
-        transferRects.add(new RecipeTransferRect(new Rectangle(84, 23, 24, 18), "orbCrafting"));
+        transferRects.add(new RecipeTransferRect(new Rectangle(84, 23, 24, 18), "crafting"));
     }
-
+	
 	@Override
 	public String getOverlayIdentifier() {
-		return "orbCrafting";
+		return "crafting";
 	}
 
 	@Override

--- a/1.7.10/main/java/joshie/alchemicalWizardy/nei/NEIBloodOrbShapelessHandler.java
+++ b/1.7.10/main/java/joshie/alchemicalWizardy/nei/NEIBloodOrbShapelessHandler.java
@@ -51,7 +51,7 @@ public class NEIBloodOrbShapelessHandler extends ShapelessRecipeHandler {
 	
 	@Override
     public void loadCraftingRecipes(String outputId, Object... results) {
-        if (outputId.equals("orbCrafting") && getClass() == NEIBloodOrbShapelessHandler.class) {
+        if (outputId.equals("crafting") && getClass() == NEIBloodOrbShapelessHandler.class) {
             List<IRecipe> allrecipes = CraftingManager.getInstance().getRecipeList();
             for (IRecipe irecipe : allrecipes) {
             	CachedBloodOrbRecipe recipe = null;
@@ -115,12 +115,12 @@ public class NEIBloodOrbShapelessHandler extends ShapelessRecipeHandler {
 	
 	@Override
     public void loadTransferRects() {
-        transferRects.add(new RecipeTransferRect(new Rectangle(84, 23, 24, 18), "orbCrafting"));
+        transferRects.add(new RecipeTransferRect(new Rectangle(84, 23, 24, 18), "crafting"));
     }
 
 	@Override
 	public String getOverlayIdentifier() {
-		return "orbCrafting";
+		return "crafting";
 	}
 
 	@Override

--- a/1.7.10/main/java/joshie/alchemicalWizardy/nei/NEIConfig.java
+++ b/1.7.10/main/java/joshie/alchemicalWizardy/nei/NEIConfig.java
@@ -3,12 +3,13 @@ package joshie.alchemicalWizardy.nei;
 import java.util.ArrayList;
 
 import net.minecraft.item.Item;
+import WayofTime.alchemicalWizardry.common.tileEntity.gui.GuiWritingTable;
 import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
 
-public class NEIConfig implements IConfigureNEI {	
+public class NEIConfig implements IConfigureNEI {
 	public static ArrayList<Item> bloodOrbs = new ArrayList<Item>();
-	
+
 	@Override
 	public void loadConfig() {
 		API.registerRecipeHandler(new NEIAlchemyRecipeHandler());
@@ -19,6 +20,8 @@ public class NEIConfig implements IConfigureNEI {
 		API.registerUsageHandler(new NEIBloodOrbShapedHandler());
 		API.registerRecipeHandler(new NEIBloodOrbShapelessHandler());
 		API.registerUsageHandler(new NEIBloodOrbShapelessHandler());
+
+		API.setGuiOffset(GuiWritingTable.class, 18, 62);
 	}
 
 	@Override
@@ -28,6 +31,6 @@ public class NEIConfig implements IConfigureNEI {
 
 	@Override
 	public String getVersion() {
-		return "1.2";
+		return "1.3";
 	}
 }

--- a/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIAlchemyRecipeHandler.java
+++ b/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIAlchemyRecipeHandler.java
@@ -2,10 +2,12 @@ package joshie.alchemicalWizardy.nei;
 
 import static joshie.alchemicalWizardy.nei.NEIConfig.bloodOrbs;
 
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -13,6 +15,7 @@ import net.minecraft.util.StatCollector;
 import WayofTime.alchemicalWizardry.api.alchemy.AlchemyRecipe;
 import WayofTime.alchemicalWizardry.api.alchemy.AlchemyRecipeRegistry;
 import WayofTime.alchemicalWizardry.api.items.interfaces.IBloodOrb;
+import WayofTime.alchemicalWizardry.common.tileEntity.gui.GuiWritingTable;
 import codechicken.nei.ItemList;
 import codechicken.nei.NEIServerUtils;
 import codechicken.nei.PositionedStack;
@@ -89,6 +92,32 @@ public class NEIAlchemyRecipeHandler extends TemplateRecipeHandler {
 		
         return super.newInstance();
     }
+	
+	@Override
+	public String getOverlayIdentifier() {
+		return "alchemicalwizardry.alchemy";
+	}
+	
+	@Override
+	public void loadTransferRects() {
+		transferRects.add(new RecipeTransferRect(new Rectangle(134, 22, 16, 24), "alchemicalwizardry.alchemy"));
+	}
+	
+	@Override
+	public Class<? extends GuiContainer> getGuiClass() {
+		return GuiWritingTable.class;
+	}
+	
+	@Override
+	public void loadCraftingRecipes(String outputId, Object... results) {
+		if (outputId.equals("alchemicalwizardry.alchemy") && getClass() == NEIAlchemyRecipeHandler.class) {
+			for(AlchemyRecipe recipe: AlchemyRecipeRegistry.recipes) {
+				if(recipe.getResult() != null) arecipes.add(new CachedAlchemyRecipe(recipe));
+			}
+		} else {
+			super.loadCraftingRecipes(outputId, results);
+		}
+	}
 	
 	@Override
 	public void loadCraftingRecipes(ItemStack result) {

--- a/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIAltarRecipeHandler.java
+++ b/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIAltarRecipeHandler.java
@@ -49,7 +49,7 @@ public class NEIAltarRecipeHandler extends TemplateRecipeHandler {
 	
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		if (outputId.equals("altarrecipes") && getClass() == NEIAltarRecipeHandler.class) {
+		if (outputId.equals("alchemicalwizardry.bloodaltar") && getClass() == NEIAltarRecipeHandler.class) {
 			for(AltarRecipe recipe: AltarRecipeRegistry.altarRecipes) {
 				if(recipe.result != null) arecipes.add(new CachedAltarRecipe(recipe));
 			}
@@ -145,12 +145,12 @@ public class NEIAltarRecipeHandler extends TemplateRecipeHandler {
 	
 	@Override
 	public String getOverlayIdentifier() {
-		return "altarrecipes";
+		return "alchemicalwizardry.bloodaltar";
 	}
 	
 	@Override
 	public void loadTransferRects() {
-		transferRects.add(new RecipeTransferRect(new Rectangle(90, 32, 22, 16), "altarrecipes"));
+		transferRects.add(new RecipeTransferRect(new Rectangle(90, 32, 22, 16), "alchemicalwizardry.bloodaltar"));
 	}
 	
 	@Override

--- a/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIBloodOrbShapedHandler.java
+++ b/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIBloodOrbShapedHandler.java
@@ -55,7 +55,7 @@ public class NEIBloodOrbShapedHandler extends ShapedRecipeHandler {
 
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		if (outputId.equals("orbCrafting") && getClass() == NEIBloodOrbShapedHandler.class) {
+		if (outputId.equals("crafting") && getClass() == NEIBloodOrbShapedHandler.class) {
 			for (IRecipe irecipe : (List<IRecipe>) CraftingManager.getInstance().getRecipeList()) {
 				if (irecipe instanceof ShapedBloodOrbRecipe) {
 					CachedBloodOrbRecipe recipe = forgeShapedRecipe((ShapedBloodOrbRecipe) irecipe);
@@ -126,12 +126,12 @@ public class NEIBloodOrbShapedHandler extends ShapedRecipeHandler {
 	
 	@Override
     public void loadTransferRects() {
-        transferRects.add(new RecipeTransferRect(new Rectangle(84, 23, 24, 18), "orbCrafting"));
+        transferRects.add(new RecipeTransferRect(new Rectangle(84, 23, 24, 18), "crafting"));
     }
-
+	
 	@Override
 	public String getOverlayIdentifier() {
-		return "orbCrafting";
+		return "crafting";
 	}
 
 	@Override

--- a/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIBloodOrbShapelessHandler.java
+++ b/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIBloodOrbShapelessHandler.java
@@ -51,7 +51,7 @@ public class NEIBloodOrbShapelessHandler extends ShapelessRecipeHandler {
 	
 	@Override
     public void loadCraftingRecipes(String outputId, Object... results) {
-        if (outputId.equals("orbCrafting") && getClass() == NEIBloodOrbShapelessHandler.class) {
+        if (outputId.equals("crafting") && getClass() == NEIBloodOrbShapelessHandler.class) {
             List<IRecipe> allrecipes = CraftingManager.getInstance().getRecipeList();
             for (IRecipe irecipe : allrecipes) {
             	CachedBloodOrbRecipe recipe = null;
@@ -115,12 +115,12 @@ public class NEIBloodOrbShapelessHandler extends ShapelessRecipeHandler {
 	
 	@Override
     public void loadTransferRects() {
-        transferRects.add(new RecipeTransferRect(new Rectangle(84, 23, 24, 18), "orbCrafting"));
+        transferRects.add(new RecipeTransferRect(new Rectangle(84, 23, 24, 18), "crafting"));
     }
 
 	@Override
 	public String getOverlayIdentifier() {
-		return "orbCrafting";
+		return "crafting";
 	}
 
 	@Override

--- a/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIConfig.java
+++ b/1.7.2/main/java/joshie/alchemicalWizardy/nei/NEIConfig.java
@@ -3,12 +3,13 @@ package joshie.alchemicalWizardy.nei;
 import java.util.ArrayList;
 
 import net.minecraft.item.Item;
+import WayofTime.alchemicalWizardry.common.tileEntity.gui.GuiWritingTable;
 import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
 
-public class NEIConfig implements IConfigureNEI {	
+public class NEIConfig implements IConfigureNEI {
 	public static ArrayList<Item> bloodOrbs = new ArrayList<Item>();
-	
+
 	@Override
 	public void loadConfig() {
 		API.registerRecipeHandler(new NEIAlchemyRecipeHandler());
@@ -19,6 +20,8 @@ public class NEIConfig implements IConfigureNEI {
 		API.registerUsageHandler(new NEIBloodOrbShapedHandler());
 		API.registerRecipeHandler(new NEIBloodOrbShapelessHandler());
 		API.registerUsageHandler(new NEIBloodOrbShapelessHandler());
+
+		API.setGuiOffset(GuiWritingTable.class, 18, 62);
 	}
 
 	@Override
@@ -28,6 +31,6 @@ public class NEIConfig implements IConfigureNEI {
 
 	@Override
 	public String getVersion() {
-		return "1.2";
+		return "1.3";
 	}
 }


### PR DESCRIPTION
A small update to the NEI handlers, so that the Alchemic Chemistry Set now has a way of displaying all available recipes.

The recipe list can be reached by clicking in the area above the slot for the Blood Orb in the chemistry set GUI.
