### PR TITLE
 Compacted Enchantment Checking

### DIFF
--- a/1.7.10/main/java/WayofTime/alchemicalWizardry/common/items/BoundAxe.java
+++ b/1.7.10/main/java/WayofTime/alchemicalWizardry/common/items/BoundAxe.java
@@ -27,6 +27,7 @@ import WayofTime.alchemicalWizardry.api.items.interfaces.IBindable;
 import WayofTime.alchemicalWizardry.common.spell.complex.effect.SpellHelper;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.enchantment.EnchantmentHelper;
 
 public class BoundAxe extends ItemAxe implements IBindable
 {
@@ -144,33 +145,8 @@ public class BoundAxe extends ItemAxe implements IBindable
         int posX = (int)(blockVec.xCoord);
         int posY = (int)(blockVec.yCoord);
         int posZ = (int)(blockVec.zCoord);
-        boolean silkTouch = false;
-        int so = Enchantment.silkTouch.effectId;
-        int fortune = Enchantment.fortune.effectId;
-        int fortuneLvl = 0;
-        NBTTagList enchants = par1ItemStack.getEnchantmentTagList();
-
-        if (enchants != null)
-        {
-            for (int i = 0; i < enchants.tagCount(); i++)
-            {
-                if (enchants.getCompoundTagAt(i) instanceof NBTTagCompound)
-                {
-                    NBTTagCompound nbt = (NBTTagCompound) enchants.getCompoundTagAt(i);
-                    int id = nbt.getShort("id");
-
-                    if (id == so)
-                    {
-                        silkTouch = true;
-                    }
-
-                    if (id == fortune)
-                    {
-                        fortuneLvl = nbt.getShort("lvl");
-                    }
-                }
-            }
-        }
+        boolean silkTouch = EnchantmentHelper.getSilkTouchModifier(par3EntityPlayer);
+        int fortuneLvl = EnchantmentHelper.getFortuneModifier(par3EntityPlayer);
 
         for (int i = -5; i <= 5; i++)
         {

--- a/1.7.10/main/java/WayofTime/alchemicalWizardry/common/items/BoundPickaxe.java
+++ b/1.7.10/main/java/WayofTime/alchemicalWizardry/common/items/BoundPickaxe.java
@@ -23,6 +23,7 @@ import WayofTime.alchemicalWizardry.api.items.interfaces.IBindable;
 import WayofTime.alchemicalWizardry.common.spell.complex.effect.SpellHelper;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.enchantment.EnchantmentHelper;
 
 public class BoundPickaxe extends ItemPickaxe implements IBindable
 {
@@ -141,33 +142,8 @@ public class BoundPickaxe extends ItemPickaxe implements IBindable
         int posX = (int)(blockVec.xCoord);
         int posY = (int)(blockVec.yCoord);
         int posZ = (int)(blockVec.zCoord);
-        boolean silkTouch = false;
-        int so = Enchantment.silkTouch.effectId;
-        int fortune = Enchantment.fortune.effectId;
-        int fortuneLvl = 0;
-        NBTTagList enchants = par1ItemStack.getEnchantmentTagList();
-
-        if (enchants != null)
-        {
-            for (int i = 0; i < enchants.tagCount(); i++)
-            {
-                if (enchants.getCompoundTagAt(i) instanceof NBTTagCompound)
-                {
-                    NBTTagCompound nbt = (NBTTagCompound) enchants.getCompoundTagAt(i);
-                    int id = nbt.getShort("id");
-
-                    if (id == so)
-                    {
-                        silkTouch = true;
-                    }
-
-                    if (id == fortune)
-                    {
-                        fortuneLvl = nbt.getShort("lvl");
-                    }
-                }
-            }
-        }
+        boolean silkTouch = EnchantmentHelper.getSilkTouchModifier(par3EntityPlayer);
+        int fortuneLvl = EnchantmentHelper.getFortuneModifier(par3EntityPlayer);
 
         for (int i = -5; i <= 5; i++)
         {

--- a/1.7.10/main/java/WayofTime/alchemicalWizardry/common/items/BoundShovel.java
+++ b/1.7.10/main/java/WayofTime/alchemicalWizardry/common/items/BoundShovel.java
@@ -23,6 +23,7 @@ import net.minecraftforge.common.ForgeHooks;
 import WayofTime.alchemicalWizardry.AlchemicalWizardry;
 import WayofTime.alchemicalWizardry.api.items.interfaces.IBindable;
 import WayofTime.alchemicalWizardry.common.spell.complex.effect.SpellHelper;
+import net.minecraft.enchantment.EnchantmentHelper;
 
 import com.google.common.collect.Multimap;
 
@@ -145,33 +146,8 @@ public class BoundShovel extends ItemSpade implements IBindable
         int posX = (int)(blockVec.xCoord);
         int posY = (int)(blockVec.yCoord);
         int posZ = (int)(blockVec.zCoord);
-        boolean silkTouch = false;
-        int so = Enchantment.silkTouch.effectId;
-        int fortune = Enchantment.fortune.effectId;
-        int fortuneLvl = 0;
-        NBTTagList enchants = par1ItemStack.getEnchantmentTagList();
-
-        if (enchants != null)
-        {
-            for (int i = 0; i < enchants.tagCount(); i++)
-            {
-                if (enchants.getCompoundTagAt(i) instanceof NBTTagCompound)
-                {
-                    NBTTagCompound nbt = (NBTTagCompound) enchants.getCompoundTagAt(i);
-                    int id = nbt.getShort("id");
-
-                    if (id == so)
-                    {
-                        silkTouch = true;
-                    }
-
-                    if (id == fortune)
-                    {
-                        fortuneLvl = nbt.getShort("lvl");
-                    }
-                }
-            }
-        }
+		boolean silkTouch = EnchantmentHelper.getSilkTouchModifier(par3EntityPlayer);
+        int fortuneLvl = EnchantmentHelper.getFortuneModifier(par3EntityPlayer);
 
         for (int i = -5; i <= 5; i++)
         {


### PR DESCRIPTION
I changed the Tool classes to use the EnchantmentHelper class as opposed to the previous method of crawling the NBTTagList of the ItemStack for enchantments. This has benefits in future-proofing the methods, in case the Enchantment system changes how they are stored in the compound.
