### PR TITLE
Implemented "Shift + Left Click" for ItemDiviner to get previous Ritual

### DIFF
--- a/1.7.10/main/java/WayofTime/alchemicalWizardry/api/rituals/Rituals.java
+++ b/1.7.10/main/java/WayofTime/alchemicalWizardry/api/rituals/Rituals.java
@@ -384,6 +384,27 @@ public class Rituals
 
     	return firstKey;
     }
+
+    public static String getPreviousRitualKey(String key)
+    {
+        boolean hasSpotted = false;
+        String lastKey = keyList.get(keyList.size()-1);
+
+        for(String str : keyList)
+        {
+            if(str.equals(key))
+            {
+                hasSpotted = true;
+            }
+            if(hasSpotted)
+            {
+                return lastKey;
+            }
+            lastKey = str;
+        }
+
+        return lastKey;
+    }
     
     public static MRSRenderer getRendererForKey(String ritualID)
     {

--- a/1.7.10/main/java/WayofTime/alchemicalWizardry/common/items/ItemRitualDiviner.java
+++ b/1.7.10/main/java/WayofTime/alchemicalWizardry/common/items/ItemRitualDiviner.java
@@ -5,6 +5,7 @@ import java.util.List;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -255,6 +256,33 @@ public class ItemRitualDiviner extends EnergyItems
         }
 
         return par1ItemStack;
+    }
+
+    @Override
+    public boolean onEntitySwing(EntityLivingBase entityLiving, ItemStack stack)
+    {
+        if(entityLiving instanceof EntityPlayer)
+        {
+            EntityPlayer player = (EntityPlayer) entityLiving;
+
+            if(player.isSneaking() && !player.isSwingInProgress)
+            {
+                int maxRitualID = Rituals.getNumberOfRituals();
+                String currentRitualID = this.getCurrentRitual(stack);
+
+                this.setCurrentRitual(stack, Rituals.getPreviousRitualKey(currentRitualID));
+
+                if (entityLiving.worldObj.isRemote)
+                {
+                    IChatComponent chatmessagecomponent = new ChatComponentText("Current Ritual: " + Rituals.getNameOfRitual(this.getCurrentRitual(stack)));
+                    //chatmessagecomponent.func_111072_b("Current Essence: " + data.currentEssence + "LP");
+                    //chatmessagecomponent.addText("Current Ritual: " + Rituals.getNameOfRitual(this.getCurrentRitual(par1ItemStack)));
+                    player.addChatComponentMessage(chatmessagecomponent);
+                }
+            }
+        }
+
+        return false;
     }
 
     public String getCurrentRitual(ItemStack par1ItemStack)


### PR DESCRIPTION
Ever got tired of cycling through all the rituals by Shift + Right Clicking the item diviner to just miss the one you wanted and then have to do it all again?

This change allows to "Shift + Left Click" to cycle through the rituals in the opposite direction. The only downside is that you can't quite spam the "Shift + Left Click" as you can for the Right Click, you have to do it one at a time. But I think it's still really useful and others might agree.
