### PR TITLE
Add overload of syphonAndDamageFromNetwork that takes a String

### DIFF
--- a/1.7.10/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
+++ b/1.7.10/main/java/WayofTime/alchemicalWizardry/api/soulNetwork/SoulNetworkHandler.java
@@ -86,6 +86,20 @@ public class SoulNetworkHandler
 
         return true;
     }
+    
+    public static boolean syphonAndDamageFromNetwork(String ownerName, EntityPlayer player, int damageToBeDone)
+    {
+        if (player.worldObj.isRemote)
+        {
+            return false;
+        }
+
+        int amount = SoulNetworkHandler.syphonFromNetwork(ownerName, damageToBeDone);
+
+        hurtPlayer(player, damageToBeDone - amount);
+
+        return true;
+    }
 
     public static boolean canSyphonFromOnlyNetwork(ItemStack ist, int damageToBeDone)
     {


### PR DESCRIPTION
Accepts a String instead of an ItemStack, as I have just encountered a situation where I have access to the Owner's name, but not the ItemStack being used
