### PR TITLE
Well of suffering ritual with multiple target altars behavior

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectWellOfSuffering.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectWellOfSuffering.java
@@ -45,7 +45,7 @@ public class RitualEffectWellOfSuffering extends RitualEffect
             {
                 for (int k = -10; k <= 10; k++)
                 {
-                    if (world.getTileEntity(x + i, y + k, z + j) instanceof TEAltar)
+                    if (world.getTileEntity(x + i, y + k, z + j) instanceof TEAltar) && !testFlag
                     {
                         tileAltar = (TEAltar) world.getTileEntity(x + i, y + k, z + j);
                         testFlag = true;


### PR DESCRIPTION
Well of suffering ritual should deliver blood to the first altar it finds within its range, rather than the last.