### PR TITLE
MineTweaker additions

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/harvest/GenericItemStackHarvestHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/harvest/GenericItemStackHarvestHandler.java
@@ -1,0 +1,111 @@
+package WayofTime.alchemicalWizardry.common.harvest;
+
+import WayofTime.alchemicalWizardry.api.harvest.IHarvestHandler;
+import net.minecraft.block.Block;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.common.IPlantable;
+
+import java.util.List;
+
+public class GenericItemStackHarvestHandler implements IHarvestHandler
+{
+
+    public Block harvestBlock;
+    public int harvestMeta;
+    public ItemStack harvestItem;
+    public IPlantable harvestSeed;
+
+    public GenericItemStackHarvestHandler(Block block, int meta, ItemStack seed)
+    {
+        harvestBlock = block;
+        harvestMeta = meta;
+        harvestItem = seed;
+        if (seed.getItem() instanceof IPlantable) harvestSeed = (IPlantable) seed.getItem();
+    }
+
+    public boolean canHandleBlock(Block block)
+    {
+        return block == harvestBlock;
+    }
+
+    public int getHarvestMeta(Block block)
+    {
+        return harvestMeta;
+    }
+
+    @Override
+    public boolean harvestAndPlant(World world, int xCoord, int yCoord, int zCoord, Block block, int meta)
+    {
+        if (!this.canHandleBlock(block) || meta != this.getHarvestMeta(block))
+        {
+            return false;
+        }
+
+        IPlantable seed = this.getSeedItem(block);
+
+        if (seed == null)
+        {
+            world.func_147480_a(xCoord, yCoord, zCoord, true);
+
+            return true;
+        } else
+        {
+            int fortune = 0;
+
+            List<ItemStack> list = block.getDrops(world, xCoord, yCoord, zCoord, meta, fortune);
+            boolean foundAndRemovedSeed = false;
+
+            for (ItemStack stack : list)
+            {
+                if (stack == null)
+                {
+                    continue;
+                }
+                if (harvestItem.isItemEqual(stack))
+                {
+                    int itemSize = stack.stackSize;
+                    if (itemSize<1)
+                    {
+                        continue;
+                    }
+                    else if (itemSize==1)
+                    {
+                        list.remove(stack);
+                    }
+                    else
+                    {
+                        stack.stackSize--;
+                    }
+                    foundAndRemovedSeed = true;
+                    break;
+                }
+            }
+
+            if (foundAndRemovedSeed)
+            {
+                int plantMeta = seed.getPlantMetadata(world, xCoord, yCoord, zCoord);
+                Block plantBlock = seed.getPlant(world, xCoord, yCoord, zCoord);
+
+                world.func_147480_a(xCoord, yCoord, zCoord, false);
+
+                world.setBlock(xCoord, yCoord, zCoord, plantBlock, plantMeta, 3);
+
+                for (ItemStack stack : list)
+                {
+                    EntityItem itemEnt = new EntityItem(world, xCoord, yCoord, zCoord, stack);
+
+                    world.spawnEntityInWorld(itemEnt);
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public IPlantable getSeedItem(Block block)
+    {
+        return harvestSeed;
+    }
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/FallingTower.java
@@ -1,0 +1,139 @@
+package WayofTime.alchemicalWizardry.common.tweaker;
+
+import WayofTime.alchemicalWizardry.common.summoning.meteor.MeteorParadigm;
+import WayofTime.alchemicalWizardry.common.summoning.meteor.MeteorRegistry;
+import minetweaker.IUndoableAction;
+import minetweaker.MineTweakerAPI;
+import minetweaker.api.item.IItemStack;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import java.util.Iterator;
+
+import static WayofTime.alchemicalWizardry.common.tweaker.MTHelper.toStack;
+
+/**
+ * MineTweaker3 Falling Tower Paradigm Handler by hilburn *
+ */
+@ZenClass("mods.bloodmagic.FallingTower")
+public class FallingTower
+{
+    @ZenMethod
+    public static void addFocus(IItemStack stack, int radius, String[] components)
+    {
+        MineTweakerAPI.apply(new Add(toStack(stack),radius, components));
+    }
+
+    @ZenMethod
+    public static void addFocus(IItemStack stack, int radius, String components)
+    {
+        MineTweakerAPI.apply(new Add(toStack(stack),radius, components.split("\\s*,\\s*")));
+    }
+
+    @ZenMethod
+    public static void removeFocus(IItemStack output) {
+        MineTweakerAPI.apply(new Remove(toStack(output)));
+    }
+
+    private static class Add implements IUndoableAction
+    {
+        private MeteorParadigm paradigm;
+
+        public Add(ItemStack stack, int radius, String[] components)
+        {
+            paradigm = new MeteorParadigm(stack,radius);
+            paradigm.parseStringArray(components);
+        }
+
+        @Override
+        public void apply()
+        {
+            MeteorRegistry.registerMeteorParadigm(paradigm);
+        }
+
+        @Override
+        public boolean canUndo()
+        {
+            return MeteorRegistry.paradigmList!= null;
+        }
+
+        @Override
+        public void undo()
+        {
+            MeteorRegistry.paradigmList.remove(paradigm);
+        }
+
+        @Override
+        public String describe() {
+            return "Adding Falling Tower Focus for " + paradigm.focusStack.getDisplayName();
+        }
+
+        @Override
+        public String describeUndo()
+        {
+            return "Removing Falling Tower Focus for " + paradigm.focusStack.getDisplayName();
+        }
+
+        @Override
+        public Object getOverrideKey()
+        {
+            return null;
+        }
+    }
+
+    private static class Remove implements IUndoableAction {
+        private final ItemStack focus;
+        private MeteorParadigm paradigm;
+
+        public Remove(ItemStack focus)
+        {
+            this.focus = focus;
+        }
+
+        @Override
+        public void apply()
+        {
+            for (Iterator<MeteorParadigm> itr = MeteorRegistry.paradigmList.iterator(); itr.hasNext();)
+            {
+                MeteorParadigm paradigm = itr.next();
+                if (OreDictionary.itemMatches(paradigm.focusStack,focus,false))
+                {
+                    this.paradigm = paradigm;
+                    itr.remove();
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public boolean canUndo()
+        {
+            return MeteorRegistry.paradigmList!= null && paradigm != null;
+        }
+
+        @Override
+        public void undo()
+        {
+            MeteorRegistry.paradigmList.add(paradigm);
+        }
+
+        @Override
+        public String describe() {
+            return "Removing Falling Tower Focus for " + focus.getDisplayName();
+        }
+
+        @Override
+        public String describeUndo()
+        {
+            return "Restoring Falling Tower Focus for " + focus.getDisplayName();
+        }
+
+        @Override
+        public Object getOverrideKey()
+        {
+            return null;
+        }
+    }
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/HarvestMoon.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/HarvestMoon.java
@@ -1,0 +1,90 @@
+package WayofTime.alchemicalWizardry.common.tweaker;
+
+import WayofTime.alchemicalWizardry.api.harvest.HarvestRegistry;
+import WayofTime.alchemicalWizardry.api.harvest.IHarvestHandler;
+import WayofTime.alchemicalWizardry.common.harvest.GenericItemStackHarvestHandler;
+import minetweaker.IUndoableAction;
+import minetweaker.MineTweakerAPI;
+import minetweaker.api.item.IItemStack;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.IPlantable;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+/**
+ * MineTweaker3 Harvest Moon Handler by hilburn *
+ */
+@ZenClass("mods.bloodmagic.HarvestMoon")
+public class HarvestMoon
+{
+
+    @ZenMethod
+    public static void addHarvestable(IItemStack block, IItemStack seed)
+    {
+        addHarvestable(block,block.getDamage(),seed);
+    }
+
+    @ZenMethod
+    public static void addHarvestable(IItemStack block, int meta, IItemStack seed)
+    {
+        ItemStack seedStack = MTHelper.toStack(seed);
+        Block plantBlock = Block.getBlockFromItem(MTHelper.toStack(block).getItem());
+        if (!(plantBlock==null || plantBlock== Blocks.air || seedStack==null || !(seedStack.getItem() instanceof IPlantable)))
+        {
+            MineTweakerAPI.apply(new Add(plantBlock, meta, seedStack));
+        }
+        else
+        {
+            throw new IllegalArgumentException("Invalid Harvest Block or Seed");
+        }
+    }
+
+    private static class Add implements IUndoableAction
+    {
+        private IHarvestHandler handler;
+        private String name;
+
+        public Add(Block block, int meta, ItemStack seed)
+        {
+            handler = new GenericItemStackHarvestHandler(block,meta,seed);
+            name = seed.getDisplayName();
+        }
+
+        @Override
+        public void apply()
+        {
+            HarvestRegistry.registerHarvestHandler(handler);
+        }
+
+        @Override
+        public boolean canUndo()
+        {
+            return HarvestRegistry.handlerList!=null;
+        }
+
+        @Override
+        public void undo()
+        {
+            HarvestRegistry.handlerList.remove(handler);
+        }
+
+        @Override
+        public String describe() {
+            return "Adding Harvest Moon Support for " + name;
+        }
+
+        @Override
+        public String describeUndo()
+        {
+            return "Removing Harvest Moon Support for " + name;
+        }
+
+        @Override
+        public Object getOverrideKey()
+        {
+            return null;
+        }
+    }
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/MineTweakerIntegration.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tweaker/MineTweakerIntegration.java
@@ -13,5 +13,7 @@ public class MineTweakerIntegration
         MineTweakerAPI.registerClass(Binding.class);
         MineTweakerAPI.registerClass(BloodAltar.class);
         MineTweakerAPI.registerClass(BloodOrb.class);
+        MineTweakerAPI.registerClass(FallingTower.class);
+        MineTweakerAPI.registerClass(HarvestMoon.class);
     }
 }


### PR DESCRIPTION
Harvest Moon gets an add custom crop type that's itemstack sensitive for
crops that share an item for seeds., it's not perfect but it works
pretty well. - Also gets a MT method to interface with this new harvest type

MT functions to add/remove focus items for falling tower as well as
define the meteor size and distribution.