### PR TITLE
Add Teleposer blacklist

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -372,6 +372,8 @@ public class AlchemicalWizardry
 	public static boolean ritualDisabledVeilOfEvil;
 	public static boolean ritualDisabledFullStomach;
 
+    public static String[] teleposerBlacklist;
+
     public static boolean isThaumcraftLoaded;
     public static boolean isForestryLoaded;
     public static boolean isBotaniaLoaded;
@@ -1548,7 +1550,7 @@ public class AlchemicalWizardry
         					continue;
         				}
         				
-        				strLine = strLine.replace('”', '"').replace('“','"');
+        				strLine = strLine.replace('ï¿½', '"').replace('ï¿½','"');
         				
         				if(Minecraft.getMinecraft() != null && Minecraft.getMinecraft().fontRenderer != null)
         				{

--- a/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
@@ -33,6 +33,7 @@ public class BloodMagicConfiguration
 	public static Configuration config;
 	public static final String CATEGORY_GAMEPLAY = "gameplay";
 
+	public static String[] blacklist = {};
 
 	public static void init(File configFile)
 	{
@@ -136,7 +137,10 @@ public class BloodMagicConfiguration
 		AlchemicalWizardry.ritualDisabledSpawnWard = config.get("Ritual Blacklist", "Ward of Sacrosanctity", false).getBoolean(false);
 		AlchemicalWizardry.ritualDisabledVeilOfEvil = config.get("Ritual Blacklist", "Veil of Evil", false).getBoolean(false);
 		AlchemicalWizardry.ritualDisabledFullStomach = config.get("Ritual Blacklist", "Requiem of the Satiated Stomach", false).getBoolean(false);
-		
+
+		AlchemicalWizardry.teleposerBlacklist = config.get("Teleposer Blacklist", "Blacklist", blacklist, "Stops specified blocks from being teleposed. Put entries on new lines. Valid syntax is: \nmodid:blockname:meta").getStringList();
+
+
 		String tempDemonConfigs = "Demon Configs";
 		TEDemonPortal.buildingGridDelay = config.get(tempDemonConfigs, "Building Grid Delay", 25).getInt();
 		TEDemonPortal.roadGridDelay = config.get(tempDemonConfigs, "Road Grid Delay", 10).getInt();

--- a/src/main/java/WayofTime/alchemicalWizardry/common/AlchemicalWizardryEventHooks.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/AlchemicalWizardryEventHooks.java
@@ -6,6 +6,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import WayofTime.alchemicalWizardry.api.event.TeleposeEvent;
+import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.IProjectile;
@@ -672,6 +674,29 @@ public class AlchemicalWizardryEventHooks
 			if (entityLiving.getActivePotionEffect(AlchemicalWizardry.customPotionFireFuse).getDuration() <= 2)
 			{
 				entityLiving.worldObj.createExplosion(null, x, y, z, radius, false);
+			}
+		}
+	}
+
+	@SubscribeEvent(priority = EventPriority.LOWEST)
+	public void onTelepose(TeleposeEvent event) {
+		for (int i = 0; i < AlchemicalWizardry.teleposerBlacklist.length; i++) {
+			String[] blockData = AlchemicalWizardry.teleposerBlacklist[i].split(":");
+
+			if (blockData.length == 3) {
+
+				Block block = GameRegistry.findBlock(blockData[0], blockData[1]);
+				int meta;
+
+				// Check if it's an int, if so, parse it. If not, set to 0 to avoid crashing.
+				if (blockData[2].matches("-?\\d+"))
+					meta = Integer.parseInt(blockData[2]);
+				else
+					meta = 0;
+
+				if (block != null)
+					if ((event.initialBlock == block || event.finalBlock == block) && (event.initialMetadata == meta || event.finalMetadata == meta))
+						event.setCanceled(true);
 			}
 		}
 	}


### PR DESCRIPTION
Allows blacklisting by using the `modid:blockname:meta` format.

Example:

`minecraft:stone:0` will stop Vanilla stone from being teleposed.