### PR TITLE
Blacklist Tile Accelerators

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -9,10 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
+import java.lang.reflect.*;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -1158,6 +1155,22 @@ public class AlchemicalWizardry
         {
             FMLInterModComms.sendMessage("Torcherino", "blacklist-tile", TEAltar.class.getName());
             FMLInterModComms.sendMessage("Torcherino", "blacklist-tile", TEMasterStone.class.getName());
+        }
+        if (Loader.isModLoaded("ChromatiCraft"))
+        {
+            try
+            {
+                Class api = Class.forName("Reika.ChromatiCraft.API.AcceleratorBlacklist");
+                Class reason = Class.forName("Reika.ChromatiCraft.API.AcceleratorBlacklist$BlacklistReason");
+                Object exploit = Enum.valueOf(reason,"EXPLOIT");
+                Method add = api.getMethod("addBlacklist", Class.class, String.class, reason);
+                add.invoke(null, TEAltar.class, TEAltar.class.getSimpleName(),exploit);
+                add.invoke(null, TEMasterStone.class, TEMasterStone.class.getSimpleName(),exploit);
+            } catch (Exception e)
+            {
+                logger.log(Level.ERROR, "ChromatiCraft Accelerator Blacklist Failure");
+            }
+
         }
     }
 

--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -771,6 +771,8 @@ public class AlchemicalWizardry
 
         this.blacklistDemons();
 
+        this.blacklistAccelerators();
+
         MinecraftForge.EVENT_BUS.register(new ModLivingDropsEvent());
         proxy.InitRendering();
         NetworkRegistry.INSTANCE.registerGuiHandler(this, new GuiHandler());
@@ -1148,6 +1150,15 @@ public class AlchemicalWizardry
 	    	this.parseTextFile();
 	    
 //	    this.createItemTextureFiles();
+    }
+
+    public static void blacklistAccelerators()
+    {
+        if (Loader.isModLoaded("Torcherino"))
+        {
+            FMLInterModComms.sendMessage("Torcherino", "blacklist-tile", TEAltar.class.getName());
+            FMLInterModComms.sendMessage("Torcherino", "blacklist-tile", TEMasterStone.class.getName());
+        }
     }
 
     public static void blacklistDemons()


### PR DESCRIPTION
Torcherino's Time Torch and ChromatiCraft's Tile Accelerator - the 2 ones that wok in 1.7.10 - master ritual stone is also blacklisted as it allowed multiple ritual firings per interval (might not be something you want, if you wanted to be able to speed up a ritual for example)