### PR TITLE
Only reflect Projectiles that fly in the direction of the player

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/AlchemicalWizardryEventHooks.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/AlchemicalWizardryEventHooks.java
@@ -548,6 +548,14 @@ public class AlchemicalWizardryEventHooks
 				double delY = projectile.posY - entity.posY;
 				double delZ = projectile.posZ - entity.posZ;
 
+				double angle = (delX*projectile.motionX + delY*projectile.motionY + delZ*projectile.motionZ)/
+						(Math.sqrt(delX * delX + delY * delY + delZ * delZ)*Math.sqrt(projectile.motionX*projectile.motionX + projectile.motionY* projectile.motionY + projectile.motionZ*projectile.motionZ));
+				angle = Math.acos(angle);
+				if (angle < 3*(Math.PI/4)) {
+					//angle is < 135 degrees
+					continue;
+				}
+
 				if (throwingEntity != null)
 				{
 					delX = -projectile.posX + throwingEntity.posX;


### PR DESCRIPTION
I tested this by setting `throwingEntity` to `null` and then firing Vanilla Arrows around. 

The change allowed me to shoot arrows then (except when aiming very low to the ground).

Sadly my Computer does not appear to have enough memory to handle 2 Clients and a Server, so i could not really test if it still deflects all the incoming projectiles. (It did work with skeletons, though)
