### PR TITLE
Should fix(? someone check) a minor bug with imperfect ritual stones

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/block/ImperfectRitualStone.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/block/ImperfectRitualStone.java
@@ -34,8 +34,13 @@ public class ImperfectRitualStone extends Block
     }
 
     @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float xOff, float yOff, float zOff)
-    {
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float xOff, float yOff, float zOff)    {
+{        
+        if (SpellHelper.isFakePlayer(world, player))
+        {
+            return false;
+        }
+        else
         {
             Block block = world.getBlock(x, y + 1, z);
 


### PR DESCRIPTION
There was a bug involving Thaumcraft golems being able to activate imperfect ritual stones without usage of LP, this -->might fix it, don't know for sure, someone has to check and see.

--added a isFakePlayer check