### PR TITLE
Make item dropping from bound tools more efficient

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/ItemType.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/ItemType.java
@@ -1,0 +1,87 @@
+package WayofTime.alchemicalWizardry.common;
+
+import java.util.Objects;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+/**
+ * Represents an item together with metadata and NBT tag.
+ * 
+ * @author ljfa-ag
+ */
+public class ItemType
+{
+    public final Item item;
+    public final int meta;
+    public final NBTTagCompound nbtTag;
+    
+    public ItemType(Item item, int meta, NBTTagCompound nbtTag)
+    {
+        this.item = Objects.requireNonNull(item);
+        this.meta = meta;
+        this.nbtTag = nbtTag;
+    }
+    
+    public ItemType(Item item, int meta)
+    {
+        this(item, meta, null);
+    }
+    
+    public ItemType(Item item)
+    {
+        this(item, 0, null);
+    }
+    
+    public ItemType(Block block, int meta, NBTTagCompound nbtTag)
+    {
+        this(Item.getItemFromBlock(block), meta, nbtTag);
+    }
+    
+    public ItemType(Block block, int meta)
+    {
+        this(block, meta, null);
+    }
+    
+    public ItemType(Block block)
+    {
+        this(block, 0, null);
+    }
+    
+    public ItemStack createStack(int count)
+    {
+        ItemStack result = new ItemStack(item, count, meta);
+        result.stackTagCompound = nbtTag;
+        return result;
+    }
+    
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        ItemType other = (ItemType) obj;
+        return item == other.item && meta == other.meta && Objects.equals(nbtTag, other.nbtTag);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + item.hashCode();
+        result = prime * result + meta;
+        result = prime * result + ((nbtTag == null) ? 0 : nbtTag.hashCode());
+        return result;
+    }
+    
+    public static ItemType fromStack(ItemStack stack)
+    {
+        return new ItemType(stack.getItem(), stack.getItemDamage(), stack.stackTagCompound);
+    }
+    
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundAxe.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundAxe.java
@@ -115,6 +115,11 @@ public class BoundAxe extends ItemAxe implements IBindable
             par1ItemStack.getTagCompound().setInteger("worldTimeDelay", (int) (par2World.getWorldTime() - 1) % 200);
             return par1ItemStack;
         }
+        
+        if (par2World.isRemote)
+        {
+            return par1ItemStack;
+        }
 
         if (!getActivated(par1ItemStack) || SpellHelper.isFakePlayer(par2World, par3EntityPlayer))
         {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundAxe.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundAxe.java
@@ -2,6 +2,7 @@ package WayofTime.alchemicalWizardry.common.items;
 
 import WayofTime.alchemicalWizardry.AlchemicalWizardry;
 import WayofTime.alchemicalWizardry.api.items.interfaces.IBindable;
+import WayofTime.alchemicalWizardry.common.ItemType;
 import WayofTime.alchemicalWizardry.common.spell.complex.effect.SpellHelper;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -24,6 +25,8 @@ import net.minecraftforge.common.ForgeHooks;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import com.google.common.collect.HashMultiset;
 
 public class BoundAxe extends ItemAxe implements IBindable
 {
@@ -135,6 +138,8 @@ public class BoundAxe extends ItemAxe implements IBindable
         boolean silkTouch = EnchantmentHelper.getSilkTouchModifier(par3EntityPlayer);
         int fortuneLvl = EnchantmentHelper.getFortuneModifier(par3EntityPlayer);
 
+        HashMultiset<ItemType> dropMultiset = HashMultiset.create();
+        
         for (int i = -5; i <= 5; i++)
         {
             for (int j = 0; j <= 10; j++)
@@ -152,27 +157,18 @@ public class BoundAxe extends ItemAxe implements IBindable
                         {
                             if (silkTouch && block.canSilkHarvest(par2World, par3EntityPlayer, posX + i, posY + j, posZ + k, meta))
                             {
-                                ItemStack droppedItem = new ItemStack(block, 1, meta);
-
-                                if (!par2World.isRemote)
-                                {
-                                    par2World.spawnEntityInWorld(new EntityItem(par2World, posX, posY + par3EntityPlayer.getEyeHeight(), posZ, droppedItem));
-                                }
+                                dropMultiset.add(new ItemType(block, meta));
                             } else
                             {
                                 ArrayList<ItemStack> itemDropList = block.getDrops(par2World, posX + i, posY + j, posZ + k, meta, fortuneLvl);
 
                                 if (itemDropList != null)
                                 {
-                                    for (ItemStack item : itemDropList)
-                                    {
-                                        if (!par2World.isRemote)
-                                        {
-                                            par2World.spawnEntityInWorld(new EntityItem(par2World, posX, posY + par3EntityPlayer.getEyeHeight(), posZ, item));
-                                        }
-                                    }
+                                    for (ItemStack stack : itemDropList)
+                                        dropMultiset.add(ItemType.fromStack(stack), stack.stackSize);
                                 }
                             }
+
                             par2World.setBlockToAir(posX + i, posY + j, posZ + k);
                         }
                     }
@@ -180,7 +176,8 @@ public class BoundAxe extends ItemAxe implements IBindable
             }
         }
 
-        
+        BoundPickaxe.dropMultisetStacks(dropMultiset, par2World, posX, posY + par3EntityPlayer.getEyeHeight(), posZ);
+
         return par1ItemStack;
     }
 

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundPickaxe.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundPickaxe.java
@@ -1,10 +1,8 @@
 package WayofTime.alchemicalWizardry.common.items;
 
-import WayofTime.alchemicalWizardry.AlchemicalWizardry;
-import WayofTime.alchemicalWizardry.api.items.interfaces.IBindable;
-import WayofTime.alchemicalWizardry.common.spell.complex.effect.SpellHelper;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+import java.util.ArrayList;
+import java.util.List;
+
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -20,9 +18,16 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
+import WayofTime.alchemicalWizardry.AlchemicalWizardry;
+import WayofTime.alchemicalWizardry.api.items.interfaces.IBindable;
+import WayofTime.alchemicalWizardry.common.ItemType;
+import WayofTime.alchemicalWizardry.common.spell.complex.effect.SpellHelper;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multiset;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 public class BoundPickaxe extends ItemPickaxe implements IBindable
 {
@@ -142,6 +147,8 @@ public class BoundPickaxe extends ItemPickaxe implements IBindable
         boolean silkTouch = EnchantmentHelper.getSilkTouchModifier(par3EntityPlayer);
         int fortuneLvl = EnchantmentHelper.getFortuneModifier(par3EntityPlayer);
 
+        HashMultiset<ItemType> dropMultiset = HashMultiset.create();
+        
         for (int i = -5; i <= 5; i++)
         {
             for (int j = -5; j <= 5; j++)
@@ -159,25 +166,15 @@ public class BoundPickaxe extends ItemPickaxe implements IBindable
                         {
                             if (silkTouch && block.canSilkHarvest(par2World, par3EntityPlayer, posX + i, posY + j, posZ + k, meta))
                             {
-                                ItemStack droppedItem = new ItemStack(block, 1, meta);
-
-                                if (!par2World.isRemote)
-                                {
-                                    par2World.spawnEntityInWorld(new EntityItem(par2World, posX, posY + par3EntityPlayer.getEyeHeight(), posZ, droppedItem));
-                                }
+                                dropMultiset.add(new ItemType(block, meta));
                             } else
                             {
                                 ArrayList<ItemStack> itemDropList = block.getDrops(par2World, posX + i, posY + j, posZ + k, meta, fortuneLvl);
 
                                 if (itemDropList != null)
                                 {
-                                    for (ItemStack item : itemDropList)
-                                    {
-                                        if (!par2World.isRemote)
-                                        {
-                                            par2World.spawnEntityInWorld(new EntityItem(par2World, posX, posY + par3EntityPlayer.getEyeHeight(), posZ, item));
-                                        }
-                                    }
+                                    for (ItemStack stack : itemDropList)
+                                        dropMultiset.add(ItemType.fromStack(stack), stack.stackSize);
                                 }
                             }
 
@@ -188,6 +185,23 @@ public class BoundPickaxe extends ItemPickaxe implements IBindable
             }
         }
 
+        for (Multiset.Entry<ItemType> entry : dropMultiset.entrySet())
+        {
+            int count = entry.getCount();
+            ItemType type = entry.getElement();
+            int maxStackSize = type.item.getItemStackLimit(type.createStack(1));
+            
+            //Drop in groups of maximum size
+            while (count >= maxStackSize)
+            {
+                par2World.spawnEntityInWorld(new EntityItem(par2World, posX, posY + par3EntityPlayer.getEyeHeight(), posZ, type.createStack(maxStackSize)));
+                count -= maxStackSize;
+            }
+            //Drop remainder
+            if (count > 0)
+                par2World.spawnEntityInWorld(new EntityItem(par2World, posX, posY + par3EntityPlayer.getEyeHeight(), posZ, type.createStack(count)));
+        }
+        
         return par1ItemStack;
     }
 

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundPickaxe.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundPickaxe.java
@@ -119,6 +119,11 @@ public class BoundPickaxe extends ItemPickaxe implements IBindable
             par1ItemStack.getTagCompound().setInteger("worldTimeDelay", (int) (par2World.getWorldTime() - 1) % 200);
             return par1ItemStack;
         }
+        
+        if (par2World.isRemote)
+        {
+            return par1ItemStack;
+        }
 
         if (!getActivated(par1ItemStack) || SpellHelper.isFakePlayer(par2World, par3EntityPlayer))
         {
@@ -126,11 +131,6 @@ public class BoundPickaxe extends ItemPickaxe implements IBindable
         }
 
         if (par3EntityPlayer.isPotionActive(AlchemicalWizardry.customPotionInhibit))
-        {
-            return par1ItemStack;
-        }
-
-        if (par2World.isRemote)
         {
             return par1ItemStack;
         }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundPickaxe.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundPickaxe.java
@@ -184,7 +184,14 @@ public class BoundPickaxe extends ItemPickaxe implements IBindable
                 }
             }
         }
-
+        
+        dropMultisetStacks(dropMultiset, par2World, posX, posY + par3EntityPlayer.getEyeHeight(), posZ);
+        
+        return par1ItemStack;
+    }
+    
+    public static void dropMultisetStacks(Multiset<ItemType> dropMultiset, World world, double x, double y, double z)
+    {
         for (Multiset.Entry<ItemType> entry : dropMultiset.entrySet())
         {
             int count = entry.getCount();
@@ -194,15 +201,13 @@ public class BoundPickaxe extends ItemPickaxe implements IBindable
             //Drop in groups of maximum size
             while (count >= maxStackSize)
             {
-                par2World.spawnEntityInWorld(new EntityItem(par2World, posX, posY + par3EntityPlayer.getEyeHeight(), posZ, type.createStack(maxStackSize)));
+                world.spawnEntityInWorld(new EntityItem(world, x, y, z, type.createStack(maxStackSize)));
                 count -= maxStackSize;
             }
             //Drop remainder
             if (count > 0)
-                par2World.spawnEntityInWorld(new EntityItem(par2World, posX, posY + par3EntityPlayer.getEyeHeight(), posZ, type.createStack(count)));
+                world.spawnEntityInWorld(new EntityItem(world, x, y, z, type.createStack(count)));
         }
-        
-        return par1ItemStack;
     }
 
     @Override

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundShovel.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundShovel.java
@@ -2,8 +2,10 @@ package WayofTime.alchemicalWizardry.common.items;
 
 import WayofTime.alchemicalWizardry.AlchemicalWizardry;
 import WayofTime.alchemicalWizardry.api.items.interfaces.IBindable;
+import WayofTime.alchemicalWizardry.common.ItemType;
 import WayofTime.alchemicalWizardry.common.spell.complex.effect.SpellHelper;
 
+import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multimap;
 
 import cpw.mods.fml.relauncher.Side;
@@ -141,6 +143,8 @@ public class BoundShovel extends ItemSpade implements IBindable
         boolean silkTouch = EnchantmentHelper.getSilkTouchModifier(par3EntityPlayer);
         int fortuneLvl = EnchantmentHelper.getFortuneModifier(par3EntityPlayer);
 
+        HashMultiset<ItemType> dropMultiset = HashMultiset.create();
+        
         for (int i = -5; i <= 5; i++)
         {
             for (int j = 0; j <= 10; j++)
@@ -158,25 +162,15 @@ public class BoundShovel extends ItemSpade implements IBindable
                         {
                             if (silkTouch && block.canSilkHarvest(par2World, par3EntityPlayer, posX + i, posY + j, posZ + k, meta))
                             {
-                                ItemStack droppedItem = new ItemStack(block, 1, meta);
-
-                                if (!par2World.isRemote)
-                                {
-                                    par2World.spawnEntityInWorld(new EntityItem(par2World, posX, posY + par3EntityPlayer.getEyeHeight(), posZ, droppedItem));
-                                }
+                                dropMultiset.add(new ItemType(block, meta));
                             } else
                             {
                                 ArrayList<ItemStack> itemDropList = block.getDrops(par2World, posX + i, posY + j, posZ + k, meta, fortuneLvl);
 
                                 if (itemDropList != null)
                                 {
-                                    for (ItemStack item : itemDropList)
-                                    {
-                                        if (!par2World.isRemote)
-                                        {
-                                            par2World.spawnEntityInWorld(new EntityItem(par2World, posX, posY + par3EntityPlayer.getEyeHeight(), posZ, item));
-                                        }
-                                    }
+                                    for (ItemStack stack : itemDropList)
+                                        dropMultiset.add(ItemType.fromStack(stack), stack.stackSize);
                                 }
                             }
 
@@ -186,6 +180,8 @@ public class BoundShovel extends ItemSpade implements IBindable
                 }
             }
         }
+        
+        BoundPickaxe.dropMultisetStacks(dropMultiset, par2World, posX, posY + par3EntityPlayer.getEyeHeight(), posZ);
 
         return par1ItemStack;
     }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundShovel.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundShovel.java
@@ -120,6 +120,11 @@ public class BoundShovel extends ItemSpade implements IBindable
             par1ItemStack.getTagCompound().setInteger("worldTimeDelay", (int) (par2World.getWorldTime() - 1) % 200);
             return par1ItemStack;
         }
+        
+        if (par2World.isRemote)
+        {
+            return par1ItemStack;
+        }
 
         if (!getActivated(par1ItemStack) || SpellHelper.isFakePlayer(par2World, par3EntityPlayer))
         {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TEInventory.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TEInventory.java
@@ -10,144 +10,146 @@ import net.minecraftforge.common.util.Constants;
 
 /**
  * Base class for tile entities with inventory
+ * 
  * @author ljfa-ag
  */
 public abstract class TEInventory extends TileEntity implements IInventory
 {
-	protected ItemStack[] inv;
-	
-	public TEInventory(int size)
-	{
-		inv = new ItemStack[size];
-	}
+    protected ItemStack[] inv;
 
-	@Override
-	public int getSizeInventory()
-	{
-		return inv.length;
-	}
+    public TEInventory(int size)
+    {
+        inv = new ItemStack[size];
+    }
 
-	public ItemStack[] getSlots()
-	{
-		return inv;
-	}
+    @Override
+    public int getSizeInventory()
+    {
+        return inv.length;
+    }
 
-	@Override
-	public ItemStack getStackInSlot(int slot)
-	{
-		return inv[slot];
-	}
+    public ItemStack[] getSlots()
+    {
+        return inv;
+    }
 
-	@Override
-	public ItemStack decrStackSize(int slot, int amt)
-	{
-		ItemStack stack = getStackInSlot(slot);
-		if (stack != null)
-		{
-			if (stack.stackSize <= amt)
-				setInventorySlotContents(slot, null);
-			else
-			{
-				stack = stack.splitStack(amt);
-				if (stack.stackSize == 0)
-					setInventorySlotContents(slot, null);
-			}
-		}
-		return stack;
-	}
+    @Override
+    public ItemStack getStackInSlot(int slot)
+    {
+        return inv[slot];
+    }
 
-	@Override
-	public ItemStack getStackInSlotOnClosing(int slot)
-	{
-		ItemStack stack = getStackInSlot(slot);
-		if (stack != null)
-			setInventorySlotContents(slot, null);
-		return stack;
-	}
+    @Override
+    public ItemStack decrStackSize(int slot, int amt)
+    {
+        ItemStack stack = getStackInSlot(slot);
+        if (stack != null)
+        {
+            if (stack.stackSize <= amt)
+                setInventorySlotContents(slot, null);
+            else
+            {
+                stack = stack.splitStack(amt);
+                if (stack.stackSize == 0)
+                    setInventorySlotContents(slot, null);
+            }
+        }
+        return stack;
+    }
 
-	@Override
-	public void setInventorySlotContents(int slot, ItemStack stack)
-	{
-		inv[slot] = stack;
-		worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
-		if (stack != null && stack.stackSize > getInventoryStackLimit())
-			stack.stackSize = getInventoryStackLimit();
-	}
+    @Override
+    public ItemStack getStackInSlotOnClosing(int slot)
+    {
+        ItemStack stack = getStackInSlot(slot);
+        if (stack != null)
+            setInventorySlotContents(slot, null);
+        return stack;
+    }
 
-	@Override
-	public abstract String getInventoryName();
+    @Override
+    public void setInventorySlotContents(int slot, ItemStack stack)
+    {
+        inv[slot] = stack;
+        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+        if (stack != null && stack.stackSize > getInventoryStackLimit())
+            stack.stackSize = getInventoryStackLimit();
+    }
 
-	@Override
-	public boolean hasCustomInventoryName()
-	{
-		return false;
-	}
+    @Override
+    public abstract String getInventoryName();
 
-	@Override
-	public int getInventoryStackLimit()
-	{
-		return 64;
-	}
+    @Override
+    public boolean hasCustomInventoryName()
+    {
+        return false;
+    }
 
-	@Override
-	public boolean isUseableByPlayer(EntityPlayer player)
-	{
-		return worldObj.getTileEntity(xCoord, yCoord, zCoord) == this
-				&& player.getDistanceSq(xCoord + 0.5, yCoord + 0.5, zCoord + 0.5) < 64;
-	}
+    @Override
+    public int getInventoryStackLimit()
+    {
+        return 64;
+    }
 
-	@Override
-	public void openInventory()
-	{
-	}
+    @Override
+    public boolean isUseableByPlayer(EntityPlayer player)
+    {
+        return worldObj.getTileEntity(xCoord, yCoord, zCoord) == this
+                && player.getDistanceSq(xCoord + 0.5, yCoord + 0.5, zCoord + 0.5) < 64;
+    }
 
-	@Override
-	public void closeInventory()
-	{
-	}
+    @Override
+    public void openInventory()
+    {
+    }
 
-	@Override
-	public boolean isItemValidForSlot(int slot, ItemStack stack)
-	{
-		return true;
-	}
+    @Override
+    public void closeInventory()
+    {
+    }
 
-	@Override
-	public void writeToNBT(NBTTagCompound tag)
-	{
-		super.writeToNBT(tag);
-		NBTTagList invList = new NBTTagList();
-		for (int i = 0; i < inv.length; i++)
-		{
-			if (inv[i] != null)
-			{
-				NBTTagCompound stackTag = new NBTTagCompound();
-				stackTag.setByte("Slot", (byte) i);
-				inv[i].writeToNBT(stackTag);
-				invList.appendTag(stackTag);
-			}
-		}
+    @Override
+    public boolean isItemValidForSlot(int slot, ItemStack stack)
+    {
+        return true;
+    }
 
-		tag.setTag("Inventory", invList);
-	}
-	
-	@Override
-	public void readFromNBT(NBTTagCompound tag)
-	{
-		super.readFromNBT(tag);
-		NBTTagList invList = tag.getTagList("Inventory", Constants.NBT.TAG_COMPOUND);
-        for(int i = 0; i < invList.tagCount(); i++)
+    @Override
+    public void writeToNBT(NBTTagCompound tag)
+    {
+        super.writeToNBT(tag);
+        NBTTagList invList = new NBTTagList();
+        for (int i = 0; i < inv.length; i++)
+        {
+            if (inv[i] != null)
+            {
+                NBTTagCompound stackTag = new NBTTagCompound();
+                stackTag.setByte("Slot", (byte) i);
+                inv[i].writeToNBT(stackTag);
+                invList.appendTag(stackTag);
+            }
+        }
+
+        tag.setTag("Inventory", invList);
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound tag)
+    {
+        super.readFromNBT(tag);
+        NBTTagList invList = tag.getTagList("Inventory",
+                Constants.NBT.TAG_COMPOUND);
+        for (int i = 0; i < invList.tagCount(); i++)
         {
             NBTTagCompound stackTag = invList.getCompoundTagAt(i);
             int slot = stackTag.getByte("Slot");
-            
-            if(slot >= 0 && slot < inv.length)
+
+            if (slot >= 0 && slot < inv.length)
                 inv[slot] = ItemStack.loadItemStackFromNBT(stackTag);
         }
-	}
-	
-	public void clear()
-	{
+    }
+
+    public void clear()
+    {
         inv = new ItemStack[inv.length];
     }
 }


### PR DESCRIPTION
The bound pickaxe, shovel and axe will no longer drop each harvested item individually. Instead, the drops are collected in a multiset and then dropped in groups of maximum stack size.
This should reduce lag caused by creation and merging of over 1000 item entities and help with #292.