### PR TITLE
Fix phantom bridge blocks being one block too high on the client

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/sigil/SigilOfTheBridge.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/sigil/SigilOfTheBridge.java
@@ -257,6 +257,11 @@ public class SigilOfTheBridge extends EnergyItems implements ArmourUpgrade
         {
             verticalOffset--;
         }
+        
+        if (world.isRemote)
+        {
+            verticalOffset--;
+        }
 
         int posX = (int) Math.round(player.posX - 0.5f);
         int posY = (int) player.posY;


### PR DESCRIPTION
When the phantom bridge sigil is used in bound armor, it would spawn the blocks one block higher on the client side than it is supposed to, due to the player's eyeheight being accounted for in the player's position only on the client side.