### PR TITLE
Added more biome control in BiomeChanger ritual

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectBiomeChanger.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectBiomeChanger.java
@@ -140,6 +140,7 @@ public class RitualEffectBiomeChanger extends RitualEffect
             float temperature = 0.5f;
             float humidity = 0.5f;
             float acceptableRange = 0.1f;
+            int biomeSkip = 0;
 
             for (int i = -1; i <= 1; i++)
             {
@@ -202,6 +203,11 @@ public class RitualEffectBiomeChanger extends RitualEffect
                                 {
                                     temperature -= 0.2f;
                                     isItemConsumed = true;
+                                } else if (item == (Blocks.wool))
+                                {
+                                    int skip = itemStack.getItemDamage() + 1;
+                                    biomeSkip += skip;
+                                    isItemConsumed = true;
                                 }
                             } else if (itemTest.equals(Items.dye) && itemStack.getItemDamage() == 4)
                             {
@@ -257,7 +263,10 @@ public class RitualEffectBiomeChanger extends RitualEffect
                 if (Math.abs(rainfall - humidity) < acceptableRange && Math.abs(temperature - temp) < acceptableRange)
                 {
                     biomeID = iteration;
-                    break;
+                    if (biomeSkip == 0)
+                        break;
+                    else
+                        biomeSkip--;
                 }
 
                 iteration++;

--- a/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectBiomeChanger.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectBiomeChanger.java
@@ -264,12 +264,21 @@ public class RitualEffectBiomeChanger extends RitualEffect
                 {
                     biomeID = iteration;
                     if (biomeSkip == 0)
+                    {
                         break;
-                    else
+                    } else
+                    {
                         biomeSkip--;
+                    }
                 }
 
                 iteration++;
+            }
+            
+            // Default to Plains if too much biome skip is used
+            if (biomeSkip != 0)
+            {
+                biomeID = 1;
             }
 
             for (int i = 0; i < 2 * range + 1; i++)


### PR DESCRIPTION
Added the ability to select between matching biomes in the biome changer ritual (Ritual of Gaia's Transformation). Previously, the ritual would always select the first biome that (approximately) matches the given temperature/humidity. However, especially with a mod like Biomes O' Plenty or similar installed, many biomes may match such a specification, and thus many are inaccessible to this ritual.

The added specificity is based a class of additional control items, colored wool, to be placed on the plinths. If one or more colored wool are present, they combine together to yield a "biome skip count," which indicates how many matching biome IDs to skip before settling on one. Since the absence of any wool counts as a skip value of 0, a wool with damage value of 0 counts as 1 skip, a damage value of 1 counts as 2, etc. Multiple wools sum together. If the biome skip count is greater than the number of matching biomes, the ritual defaults to plains, just as if no matching biome were found.

While it's not expected that a player will know the exact skip count to use, trial-and-error can enable fine-grained control, as opposed to the task of specific biome selection often being impossible before.

Example:
* 2 coal and 3 lapis are placed on the plinths, yielding 0.7 temperature and 0.8 humidity.
* Normally, this would always evaluate to biome ID 4, vanilla Forest.
* However, we additionally add one Orange Wool (damage value 1), adding 2 to the biome skip counter. Equivalently, we could have added two White Wools (damage value 0).
* Now, the first two matching biomes will be skipped, and the third is used (likely biome ID 29, Roofed Forest, depending on modpack).