### PR TITLE
Allow Bound Tool Harvest Levels to be Altered

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundAxe.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundAxe.java
@@ -46,6 +46,7 @@ public class BoundAxe extends ItemAxe implements IBindable
         this.damageVsEntity = 5;
         setCreativeTab(AlchemicalWizardry.tabBloodMagic);
         setEnergyUsed(5);
+        this.setHarvestLevel("axe", 5);
     }
 
     public void setEnergyUsed(int i)
@@ -321,11 +322,6 @@ public class BoundAxe extends ItemAxe implements IBindable
     @Override
     public int getHarvestLevel(ItemStack stack, String toolClass)
     {
-        if (getActivated(stack) && "axe".equals(toolClass))
-        {
-            return 5;
-        }
-
-        return 0;
+        return getActivated(stack) ? super.getHarvestLevel(stack, toolClass) : -1;
     }
 }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundPickaxe.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundPickaxe.java
@@ -48,6 +48,7 @@ public class BoundPickaxe extends ItemPickaxe implements IBindable
         this.damageVsEntity = 5;
         setCreativeTab(AlchemicalWizardry.tabBloodMagic);
         this.setEnergyUsed(5);
+        setHarvestLevel("pickaxe", 5);
     }
 
     public void setEnergyUsed(int i)
@@ -351,11 +352,6 @@ public class BoundPickaxe extends ItemPickaxe implements IBindable
     @Override
     public int getHarvestLevel(ItemStack stack, String toolClass)
     {
-        if (getActivated(stack) && "pickaxe".equals(toolClass))
-        {
-            return 5;
-        }
-
-        return 0;
+        return getActivated(stack) ? super.getHarvestLevel(stack, toolClass) : -1;
     }
 }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundShovel.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/items/BoundShovel.java
@@ -50,6 +50,7 @@ public class BoundShovel extends ItemSpade implements IBindable
         this.damageVsEntity = 5;
         setCreativeTab(AlchemicalWizardry.tabBloodMagic);
         setEnergyUsed(5);
+        setHarvestLevel("shovel", 5);
     }
 
     public void setEnergyUsed(int i)
@@ -332,11 +333,6 @@ public class BoundShovel extends ItemSpade implements IBindable
     @Override
     public int getHarvestLevel(ItemStack stack, String toolClass)
     {
-        if (getActivated(stack) && "shovel".equals(toolClass))
-        {
-            return 5;
-        }
-
-        return 0;
+        return getActivated(stack) ? super.getHarvestLevel(stack, toolClass) : -1;
     }
 }


### PR DESCRIPTION
This way, they'll be 5 by default, but since they now follow Forge's normal way of getting/setting the harvest level on tools, other mods - such as Iguana Tinker Tweaks - can alter their harvest levels as desired.  When the tools are not activated, they will now return a -1 instead of 0, which results in not being able to be used as a tool at all, rather than the equivalent of a wooden tool.