### PR TITLE
Various fixes and improvements (Details in description)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ repositories {
     	name 'TehNut Repo'
     	url 'http://tehnut.info/maven/'
     }
+    maven {
+        name 'tterrag Repo'
+        url 'http://maven.tterrag.com/'
+    }
 	ivy {
 		name "MineTweaker3"
         artifactPattern "http://minetweaker3.powerofbytes.com/download/[module]-[revision].[ext]"
@@ -57,6 +61,7 @@ dependencies {
 	compile name: 'MineTweaker3', version: config.minetweaker_version, ext: 'jar'
 	compile "codechicken:ForgeMultipart:1.7.10-1.1.0.314:dev"
 	compile "info.amerifrance.guideapi:Guide-API:" + config.mc_version + "-" + config.guideapi_version + ":deobf"
+    compile "team.chisel:Chisel:" + config.chisel_version + ":api"
 }
 
 minecraft {

--- a/build.properties
+++ b/build.properties
@@ -1,14 +1,15 @@
 #
-#Wed Aug 12 17:14:26 EDT 2015
+#Tue Oct 06 22:55:47 PDT 2015
 mod_name=BloodMagic
 forge_version=10.13.4.1492-1.7.10
 ccc_version=1.0.7.47
 cclib_version=1.1.3.138
 nei_version=1.0.5.111
 //=Dependency Information
-guideapi_version=1.0.1-20
 package_group=com.wayoftime.bloodmagic
+guideapi_version=1.0.1-20
 mod_version=1.3.3
 minetweaker_version=Dev-1.7.10-3.0.9B
-build_number=14
+chisel_version=2.9.2.8
 mc_version=1.7.10
+build_number=15

--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -387,6 +387,11 @@ public class AlchemicalWizardry
     public static boolean ritualDisabledPhantomHands;
     public static boolean ritualDisabledSphereIsland;
 
+    public static boolean ritualWeakDisabledNight;
+    public static boolean ritualWeakDisabledResistance;
+    public static boolean ritualWeakDisabledThunderstorm;
+    public static boolean ritualWeakDisabledZombie;
+
     public static boolean displayRitualAnimation;
 
     public static boolean potionDisableRegen;

--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -424,6 +424,7 @@ public class AlchemicalWizardry
     public static boolean isThaumcraftLoaded;
     public static boolean isForestryLoaded;
     public static boolean isBotaniaLoaded;
+    public static boolean isChiselLoaded;
     public static boolean isFMPLoaded;
     public static boolean isPneumaticCraftLoaded;
 
@@ -1262,6 +1263,7 @@ public class AlchemicalWizardry
         isBotaniaLoaded = Loader.isModLoaded("Botania");
         isPneumaticCraftLoaded = Loader.isModLoaded("PneumaticCraft");
         isFMPLoaded = Loader.isModLoaded("ForgeMultipart");
+        isChiselLoaded = Loader.isModLoaded("chisel");
 
         BloodMagicConfiguration.loadBlacklist();
 	    BloodMagicConfiguration.blacklistRituals();

--- a/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
@@ -6,6 +6,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 
+import WayofTime.alchemicalWizardry.api.BlockStack;
+import WayofTime.alchemicalWizardry.common.AlchemicalWizardryEventHooks;
+import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.block.Block;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraftforge.common.config.Configuration;
@@ -18,6 +22,7 @@ import WayofTime.alchemicalWizardry.common.items.armour.BoundArmour;
 import WayofTime.alchemicalWizardry.common.summoning.meteor.MeteorParadigm;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
+import net.minecraftforge.oredict.OreDictionary;
 
 /**
  * Created with IntelliJ IDEA.
@@ -178,6 +183,7 @@ public class BloodMagicConfiguration
 	    AlchemicalWizardry.potionDisableDeafness = config.get("Alchemy Potion Blacklist", "Deafness", false).getBoolean(false);
 
         teleposerBlacklist = config.get("Teleposer Blacklist", "Blacklist", blacklist, "Stops specified blocks from being teleposed. Put entries on new lines. Valid syntax is: \nmodid:blockname:meta").getStringList();
+		buildTeleposerBlacklist();
 
 		String tempDemonConfigs = "Demon Configs";
 		TEDemonPortal.buildingGridDelay = config.get(tempDemonConfigs, "Building Grid Delay", 25).getInt();
@@ -295,5 +301,39 @@ public class BloodMagicConfiguration
 	{
 		Rituals.ritualMap.remove(ritualID);
 		Rituals.keyList.remove(ritualID);
+	}
+
+	private static void buildTeleposerBlacklist() {
+		for (String blockSet : BloodMagicConfiguration.teleposerBlacklist) {
+			String[] blockData = blockSet.split(":");
+
+			Block block = GameRegistry.findBlock(blockData[0], blockData[1]);
+			int meta = 0;
+
+			// If the block follows full syntax: modid:blockname:meta
+			if (blockData.length == 3) {
+				// Check if it's an int, if so, parse it. If not, set meta to 0 to avoid crashing.
+				if (isInteger(blockData[2]))
+					meta = Integer.parseInt(blockData[2]);
+				else if (blockData[2].equals("*"))
+					meta = OreDictionary.WILDCARD_VALUE;
+				else
+					meta = 0;
+			}
+
+			AlchemicalWizardryEventHooks.teleposerBlacklist.add(new BlockStack(block, meta));
+		}
+	}
+
+	private static boolean isInteger(String s) {
+		try {
+			Integer.parseInt(s);
+		} catch(NumberFormatException e) {
+			return false;
+		} catch(NullPointerException e) {
+			return false;
+		}
+		// only got here if we didn't return false
+		return true;
 	}
 }

--- a/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
@@ -145,6 +145,11 @@ public class BloodMagicConfiguration
 		AlchemicalWizardry.ritualDisabledPhantomHands = config.get("Ritual Blacklist", "Orchestra of the Phantom Hands", false).getBoolean(false);
 		AlchemicalWizardry.ritualDisabledSphereIsland = config.get("Ritual Blacklist", "Birth of the Bastion", false).getBoolean(false);
 
+		AlchemicalWizardry.ritualWeakDisabledNight = config.get("Ritual Blacklist.Weak", "Night", false).getBoolean(false);
+		AlchemicalWizardry.ritualWeakDisabledResistance = config.get("Ritual Blacklist.Weak", "Resistance", false).getBoolean(false);
+		AlchemicalWizardry.ritualWeakDisabledThunderstorm = config.get("Ritual Blacklist.Weak", "Thunderstorm", false).getBoolean(false);
+		AlchemicalWizardry.ritualWeakDisabledZombie = config.get("Ritual Blacklist.Weak", "Zombie", false).getBoolean(false);
+
 		AlchemicalWizardry.potionDisableRegen = config.get("Alchemy Potion Blacklist", "Regeneration", false).getBoolean(false);
 	    AlchemicalWizardry.potionDisableNightVision = config.get("Alchemy Potion Blacklist", "Night Vision", false).getBoolean(false);
 	    AlchemicalWizardry.potionDisableFireResistance = config.get("Alchemy Potion Blacklist", "Fire Resistance", false).getBoolean(false);

--- a/src/main/java/WayofTime/alchemicalWizardry/api/BlockStack.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/BlockStack.java
@@ -1,0 +1,47 @@
+package WayofTime.alchemicalWizardry.api;
+
+import cpw.mods.fml.common.registry.GameData;
+import net.minecraft.block.Block;
+
+/**
+ * A Block with a set metadata. Similar to an ItemStack.
+ */
+public class BlockStack {
+
+    private Block block;
+    private int meta;
+
+    public BlockStack(Block block, int meta) {
+        this.block = block;
+        this.meta = meta;
+    }
+
+    public BlockStack(Block block) {
+        this(block, 0);
+    }
+
+    public Block getBlock() {
+        return block;
+    }
+
+    public int getMeta() {
+        return meta;
+    }
+
+    @Override
+    public String toString() {
+        return GameData.getBlockRegistry().getNameForObject(block) + ":" + meta;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        BlockStack blockStack = (BlockStack) obj;
+
+        return blockStack.block == this.getBlock() && blockStack.meta == this.getMeta();
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/common/AlchemicalWizardryEventHooks.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/AlchemicalWizardryEventHooks.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import WayofTime.alchemicalWizardry.api.BlockStack;
 import WayofTime.alchemicalWizardry.common.achievements.ModAchievements;
 import WayofTime.alchemicalWizardry.common.demonVillage.demonHoard.demon.IHoardDemon;
 import net.minecraft.block.Block;
@@ -68,6 +69,7 @@ public class AlchemicalWizardryEventHooks
 
 	public static Map<Integer, List<CoordAndRange>> respawnMap = new HashMap();
 	public static Map<Integer, List<CoordAndRange>> forceSpawnMap = new HashMap();
+	public static ArrayList<BlockStack> teleposerBlacklist = new ArrayList<BlockStack>();
 	
 	public static Random rand = new Random();
 
@@ -771,41 +773,62 @@ public class AlchemicalWizardryEventHooks
 		}
 	}
 
-    @SubscribeEvent(priority = EventPriority.LOWEST)
-    public void onTelepose(TeleposeEvent event) {
-        for (int i = 0; i < BloodMagicConfiguration.teleposerBlacklist.length; i++) {
-            String[] blockData = BloodMagicConfiguration.teleposerBlacklist[i].split(":");
+//    @SubscribeEvent(priority = EventPriority.LOWEST)
+//    public void onTelepose(TeleposeEvent event) {
+//
+//		AlchemicalWizardry.logger.info(event.initialBlock + ":" + event.initialMetadata);
+//		AlchemicalWizardry.logger.info(event.finalBlock + ":" + event.finalMetadata);
+//
+//        for (int i = 0; i < BloodMagicConfiguration.teleposerBlacklist.length; i++) {
+//            String[] blockData = BloodMagicConfiguration.teleposerBlacklist[i].split(":");
+//
+//            // If the block follows full syntax: modid:blockname:meta
+//            if (blockData.length == 3) {
+//
+//                Block block = GameRegistry.findBlock(blockData[0], blockData[1]);
+//                int meta;
+//
+//                // Check if it's an int, if so, parse it. If not, set meta to 0 to avoid crashing.
+//                if (isInteger(blockData[2]))
+//                    meta = Integer.parseInt(blockData[2]);
+//                else if (blockData[2].equals("*"))
+//                    meta = OreDictionary.WILDCARD_VALUE;
+//                else
+//                    meta = 0;
+//
+//				AlchemicalWizardry.logger.info(block + ":" + meta);
+//
+//                if (block != null) {
+//					if ((block == event.initialBlock || block == event.finalBlock) && (meta == event.initialMetadata || meta == event.finalMetadata || meta == OreDictionary.WILDCARD_VALUE)) {
+//						event.setCanceled(true);
+//						return;
+//					}
+//				}
+//
+//            // If the block uses shorthand syntax: modid:blockname
+//            } else if (blockData.length == 2) {
+//
+//                Block block = GameRegistry.findBlock(blockData[0], blockData[1]);
+//                int meta = 0;
+//
+//                if (block != null) {
+//					if ((block == event.initialBlock && (meta == event.initialMetadata || meta == OreDictionary.WILDCARD_VALUE)) || (block == event.finalBlock && (meta == event.finalMetadata || meta == OreDictionary.WILDCARD_VALUE))) {
+//						event.setCanceled(true);
+//						return;
+//					}
+//				}
+//            }
+//        }
+//    }
 
-            // If the block follows full syntax: modid:blockname:meta
-            if (blockData.length == 3) {
+	@SubscribeEvent
+	public void onTelepose(TeleposeEvent event) {
+		BlockStack initialBlock = new BlockStack(event.initialBlock, event.initialMetadata);
+		BlockStack finalBlock = new BlockStack(event.finalBlock, event.finalMetadata);
 
-                Block block = GameRegistry.findBlock(blockData[0], blockData[1]);
-                int meta;
-
-                // Check if it's an int, if so, parse it. If not, set meta to 0 to avoid crashing.
-                if (blockData[2].matches("-?\\d+"))
-                    meta = Integer.parseInt(blockData[2]);
-                else if (blockData[2].equals("*"))
-                    meta = OreDictionary.WILDCARD_VALUE;
-                else
-                    meta = 0;
-
-                if (block != null)
-                    if (( block == event.initialBlock || block == event.finalBlock) && (meta == event.initialMetadata || meta == event.finalMetadata || meta == OreDictionary.WILDCARD_VALUE))
-                        event.setCanceled(true);
-
-            // If the block uses shorthand syntax: modid:blockname
-            } else if (blockData.length == 2) {
-
-                Block block = GameRegistry.findBlock(blockData[0], blockData[1]);
-                int meta = 0;
-
-                if (block != null)
-                    if (( block == event.initialBlock || block == event.finalBlock) && (meta == event.initialMetadata || meta == event.finalMetadata || meta == OreDictionary.WILDCARD_VALUE))
-                        event.setCanceled(true);
-            }
-        }
-    }
+		if (teleposerBlacklist.contains(initialBlock) || teleposerBlacklist.contains(finalBlock))
+			event.setCanceled(true);
+	}
 
 	@SubscribeEvent
 	public void onEntityDeath(LivingDeathEvent event)

--- a/src/main/java/WayofTime/alchemicalWizardry/common/LifeBucketHandler.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/LifeBucketHandler.java
@@ -5,6 +5,7 @@ import WayofTime.alchemicalWizardry.ModItems;
 import cpw.mods.fml.common.eventhandler.Event.Result;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraft.block.Block;
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
@@ -15,12 +16,13 @@ public class LifeBucketHandler
     @SubscribeEvent
     public void onBucketFill(FillBucketEvent event)
     {
+        if (event.current.getItem() != Items.bucket)
+            return;
+
         ItemStack result = fillCustomBucket(event.world, event.target);
 
         if (result == null)
-        {
             return;
-        }
 
         event.result = result;
         event.setResult(Result.ALLOW);

--- a/src/main/java/WayofTime/alchemicalWizardry/common/block/ImperfectRitualStone.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/block/ImperfectRitualStone.java
@@ -44,7 +44,7 @@ public class ImperfectRitualStone extends Block
         {
             Block block = world.getBlock(x, y + 1, z);
 
-            if (block == Blocks.water)
+            if (block == Blocks.water && !AlchemicalWizardry.ritualWeakDisabledThunderstorm)
             {
                 if (!player.capabilities.isCreativeMode && !world.isRemote)
                 {
@@ -67,8 +67,7 @@ public class ImperfectRitualStone extends Block
                 world.getWorldInfo().setThunderTime(0);
                 world.getWorldInfo().setThundering(true);
                 return true;
-            } else if (block == Blocks.coal_block)
-            {
+            } else if (block == Blocks.coal_block && !AlchemicalWizardry.ritualWeakDisabledZombie) {
                 if (!player.capabilities.isCreativeMode && !world.isRemote)
                 {
                     EnergyItems.drainPlayerNetwork(player, 5000);
@@ -87,7 +86,7 @@ public class ImperfectRitualStone extends Block
                 }
 
                 return true;
-            } else if (block == Blocks.lapis_block)
+            } else if (block == Blocks.lapis_block && !AlchemicalWizardry.ritualWeakDisabledNight)
             {
                 if (!player.capabilities.isCreativeMode && !world.isRemote)
                 {
@@ -99,7 +98,7 @@ public class ImperfectRitualStone extends Block
                     world.addWeatherEffect(new EntityLightningBolt(world, x, y + 2, z));
                     world.setWorldTime((world.getWorldTime() / 24000) * 24000 + 13800);
                 }
-            } else if (block == Blocks.bedrock)
+            } else if (block == Blocks.bedrock && !AlchemicalWizardry.ritualWeakDisabledResistance)
             {
                 if (!player.capabilities.isCreativeMode && !world.isRemote)
                 {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/CompatChecks.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/CompatChecks.java
@@ -1,0 +1,26 @@
+package WayofTime.alchemicalWizardry.common.bloodAltarUpgrade;
+
+import WayofTime.alchemicalWizardry.api.BlockStack;
+import com.cricketcraft.chisel.api.carving.CarvingUtils;
+import com.cricketcraft.chisel.api.carving.ICarvingGroup;
+import com.google.common.base.Strings;
+
+public class CompatChecks {
+
+    public static boolean checkChiselBlock(BlockStack blockStack, String groupName) {
+        if (blockStack.getBlock() == null)
+            return false;
+
+        ICarvingGroup group = CarvingUtils.getChiselRegistry().getGroup(blockStack.getBlock(), blockStack.getMeta());
+        if (group != null) {
+            String check = CarvingUtils.getChiselRegistry().getGroup(blockStack.getBlock(), blockStack.getMeta()).getName();
+
+            if (Strings.isNullOrEmpty(check))
+                return false;
+
+            return check.equals(groupName);
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockBeacon;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import WayofTime.alchemicalWizardry.ModBlocks;
@@ -125,10 +126,15 @@ public class UpgradedAltars
                         {
                             return false;
                         }
-                    } else
-                    {
+                    } else {
                         Block block = world.getBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ());
                         int metadata = world.getBlockMetadata(x + ac.getX(), y + ac.getY(), z + ac.getZ());
+
+                        if (ac.getBlock() == Blocks.beacon) {
+
+                            if (block instanceof BlockBeacon)
+                                return true;
+                        }
 
                         if (((ac.getBlock() != block) || (ac.getMetadata() != metadata)) && !(ac.getBlock() == Blocks.stonebrick && !world.isAirBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ())))
                         {

--- a/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
@@ -130,15 +130,10 @@ public class UpgradedAltars
                         Block block = world.getBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ());
                         int metadata = world.getBlockMetadata(x + ac.getX(), y + ac.getY(), z + ac.getZ());
 
-                        if (ac.getBlock() == Blocks.beacon) {
-
-                            if (block instanceof BlockBeacon)
-                                return true;
-                        }
-
                         if (((ac.getBlock() != block) || (ac.getMetadata() != metadata)) && !(ac.getBlock() == Blocks.stonebrick && !world.isAirBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ())))
                         {
-                            return false;
+                            if (!(ac.getBlock() == Blocks.beacon && block instanceof BlockBeacon))
+                                return false;
                         }
                     }
                 }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
@@ -3,6 +3,8 @@ package WayofTime.alchemicalWizardry.common.bloodAltarUpgrade;
 import java.util.ArrayList;
 import java.util.List;
 
+import WayofTime.alchemicalWizardry.AlchemicalWizardry;
+import WayofTime.alchemicalWizardry.api.BlockStack;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockBeacon;
 import net.minecraft.init.Blocks;
@@ -46,10 +48,12 @@ public class UpgradedAltars
                     if (ac.isBloodRune())
                     {
                         Block testBlock = world.getBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ());
+                        int testMeta = world.getBlockMetadata(x + ac.getX(), y + ac.getY(), z + ac.getZ());
 
                         if (!(testBlock instanceof BloodRune))
                         {
-                            return false;
+                            if (!checkRuneSpecials(ac, new BlockStack(testBlock, testMeta)))
+                                return false;
                         }
                     } else
                     {
@@ -58,7 +62,8 @@ public class UpgradedAltars
 
                         if (((ac.getBlock() != block) || (ac.getMetadata() != metadata)) && !(ac.getBlock() == Blocks.stonebrick && !world.isAirBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ())))
                         {
-                            return false;
+                            if (!checkSpecials(ac, new BlockStack(block, metadata)))
+                                return false;
                         }
                     }
                 }
@@ -71,10 +76,12 @@ public class UpgradedAltars
                     if (ac.isBloodRune())
                     {
                         Block testBlock = world.getBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ());
+                        int testMeta = world.getBlockMetadata(x + ac.getX(), y + ac.getY(), z + ac.getZ());
 
                         if (!(testBlock instanceof BloodRune))
                         {
-                            return false;
+                            if (!checkRuneSpecials(ac, new BlockStack(testBlock, testMeta)))
+                                return false;
                         }
                     } else
                     {
@@ -83,7 +90,8 @@ public class UpgradedAltars
 
                         if (((ac.getBlock() != block) || (ac.getMetadata() != metadata)) && !(ac.getBlock() == Blocks.stonebrick && !world.isAirBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ())))
                         {
-                            return false;
+                            if (!checkSpecials(ac, new BlockStack(block, metadata)))
+                                return false;
                         }
                     }
                 }
@@ -96,10 +104,12 @@ public class UpgradedAltars
                     if (ac.isBloodRune())
                     {
                         Block testBlock = world.getBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ());
+                        int testMeta = world.getBlockMetadata(x + ac.getX(), y + ac.getY(), z + ac.getZ());
 
                         if (!(testBlock instanceof BloodRune))
                         {
-                            return false;
+                            if (!checkRuneSpecials(ac, new BlockStack(testBlock, testMeta)))
+                                return false;
                         }
                     } else
                     {
@@ -108,7 +118,8 @@ public class UpgradedAltars
 
                         if (((ac.getBlock() != block) || (ac.getMetadata() != metadata)) && !(ac.getBlock() == Blocks.stonebrick && !world.isAirBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ())))
                         {
-                            return false;
+                            if (!checkSpecials(ac, new BlockStack(block, metadata)))
+                                return false;
                         }
                     }
                 }
@@ -121,10 +132,12 @@ public class UpgradedAltars
                     if (ac.isBloodRune())
                     {
                         Block testBlock = world.getBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ());
+                        int testMeta = world.getBlockMetadata(x + ac.getX(), y + ac.getY(), z + ac.getZ());
 
                         if (!(testBlock instanceof BloodRune))
                         {
-                            return false;
+                            if (!checkRuneSpecials(ac, new BlockStack(testBlock, testMeta)))
+                                return false;
                         }
                     } else {
                         Block block = world.getBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ());
@@ -132,7 +145,7 @@ public class UpgradedAltars
 
                         if (((ac.getBlock() != block) || (ac.getMetadata() != metadata)) && !(ac.getBlock() == Blocks.stonebrick && !world.isAirBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ())))
                         {
-                            if (!(ac.getBlock() == Blocks.beacon && block instanceof BlockBeacon))
+                            if (!checkSpecials(ac, new BlockStack(block, metadata)))
                                 return false;
                         }
                     }
@@ -146,10 +159,12 @@ public class UpgradedAltars
                     if (ac.isBloodRune())
                     {
                         Block testBlock = world.getBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ());
+                        int testMeta = world.getBlockMetadata(x + ac.getX(), y + ac.getY(), z + ac.getZ());
 
                         if (!(testBlock instanceof BloodRune))
                         {
-                            return false;
+                            if (!checkRuneSpecials(ac, new BlockStack(testBlock, testMeta)))
+                                return false;
                         }
                     } else
                     {
@@ -158,7 +173,8 @@ public class UpgradedAltars
 
                         if (((ac.getBlock() != block) || (ac.getMetadata() != metadata)) && !(ac.getBlock() == Blocks.stonebrick && !world.isAirBlock(x + ac.getX(), y + ac.getY(), z + ac.getZ())))
                         {
-                            return false;
+                            if (!checkSpecials(ac, new BlockStack(block, metadata)))
+                                return false;
                         }
                     }
                 }
@@ -337,6 +353,31 @@ public class UpgradedAltars
             sixthTierAltar.add(new AltarComponent(i, -5, 11, ModBlocks.bloodRune, 0, true, true));
             sixthTierAltar.add(new AltarComponent(i, -5, -11, ModBlocks.bloodRune, 0, true, true));
         }
+    }
+
+    private static boolean checkRuneSpecials(AltarComponent altarComponent, BlockStack blockStack) {
+        if (AlchemicalWizardry.isChiselLoaded) {
+            if (altarComponent.getBlock() == ModBlocks.bloodRune && CompatChecks.checkChiselBlock(blockStack, "bloodRune"))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static boolean checkSpecials(AltarComponent altarComponent, BlockStack blockStack) {
+
+        if (AlchemicalWizardry.isChiselLoaded) {
+            if (altarComponent.getBlock() == Blocks.glowstone && CompatChecks.checkChiselBlock(blockStack, "glowstone"))
+                return true;
+
+            if (altarComponent.getBlock() == ModBlocks.largeBloodStoneBrick && CompatChecks.checkChiselBlock(blockStack, "bloodBrick"))
+                return true;
+        }
+
+        if (altarComponent.getBlock() == Blocks.beacon && blockStack.getBlock() instanceof BlockBeacon)
+            return true;
+
+        return false;
     }
 
     public static List<AltarComponent> getAltarUpgradeListForTier(int tier)

--- a/src/main/java/WayofTime/alchemicalWizardry/common/renderer/block/TEAltarRenderer.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/renderer/block/TEAltarRenderer.java
@@ -36,11 +36,14 @@ public class TEAltarRenderer extends TileEntitySpecialRenderer
     @Override
     public void renderTileEntityAt(TileEntity tileEntity, double d0, double d1, double d2, float f)
     {
-        modelBloodAltar.renderBloodAltar((TEAltar) tileEntity, d0, d1, d2);
-        modelBloodAltar.renderBloodLevel((TEAltar) tileEntity, d0, d1, d2);
-
         if (tileEntity instanceof TEAltar)
         {
+
+            modelBloodAltar.renderBloodAltar((TEAltar) tileEntity, d0, d1, d2);
+
+            if (((TEAltar)tileEntity).getCurrentBlood() > 0)
+                modelBloodAltar.renderBloodLevel((TEAltar) tileEntity, d0, d1, d2);
+
             TEAltar tileAltar = (TEAltar) tileEntity;
             GL11.glPushMatrix();
 


### PR DESCRIPTION
* Allow the altar to accept any instanceof BlockBeacon. Fixes #459 (Chisel-2/Chisel-2#415)
* Allow disabling of Weak Rituals. Resubmission of #182
* Fixes the Z-fighting issue when a Blood Altar was empty. It would still render blood at the same level as the bottom of the basin. Fixes #441
* Attempted fix at getting free Iron Buckets when non-Iron Buckets were used. Basically just disallows all non-Iron Buckets. Fixes (?) #420 (hehe)
* Drastically improve the Teleposer Blacklist feature. In this new implementation, wildcards are not accepted. I'll attempt to fix that soon. Fixes #421.