### PR TITLE
Fix Invisible Items

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/renderer/block/RenderPedestal.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/renderer/block/RenderPedestal.java
@@ -52,7 +52,11 @@ public class RenderPedestal extends TileEntitySpecialRenderer
             if (tileAltar.getStackInSlot(0) != null)
             {
                 float scaleFactor = getGhostItemScaleFactor(tileAltar.getStackInSlot(0));
-                float rotationAngle = (float) (720.0 * (System.currentTimeMillis() & 0x3FFFL) / 0x3FFFL);
+                float rotationAngle;
+                if(FMLClientHandler.instance().getClient().gameSettings.fancyGraphics==true)
+                	rotationAngle = (float) (720.0 * (System.currentTimeMillis() & 0x3FFFL) / 0x3FFFL);
+                else
+                	rotationAngle = 0;
                 EntityItem ghostEntityItem = new EntityItem(tileAltar.getWorldObj());
                 ghostEntityItem.hoverStart = 0.0F;
                 ghostEntityItem.setEntityItemStack(tileAltar.getStackInSlot(0));


### PR DESCRIPTION
When the clients graphics are set to be "fast" the client renders items as 2d plains always facing the player and not as rotating 3d objects. So if the item rotates it is invisible half of the time because it has no backside. I don't know where else you used this code but please consider fixing it.
-Necr0