### PR TITLE
Knocking out the Todo list

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import WayofTime.alchemicalWizardry.common.commands.CommandBloodMagic;
 import WayofTime.alchemicalWizardry.common.thread.CommandDownloadGAPI;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
@@ -1911,9 +1912,10 @@ public class AlchemicalWizardry
     @Mod.EventHandler
     public void initCommands(FMLServerStartingEvent event)
     {
-        event.registerServerCommand(new CommandBind());
-        event.registerServerCommand(new CommandUnbind());
-        event.registerServerCommand(new CommandSN());
+//        event.registerServerCommand(new CommandBind());
+//        event.registerServerCommand(new CommandUnbind());
+//        event.registerServerCommand(new CommandSN());
         event.registerServerCommand(new CommandDownloadGAPI());
+        event.registerServerCommand(new CommandBloodMagic());
     }
 }

--- a/src/main/java/WayofTime/alchemicalWizardry/api/command/ISubCommand.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/command/ISubCommand.java
@@ -1,0 +1,21 @@
+package WayofTime.alchemicalWizardry.api.command;
+
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+
+public interface ISubCommand {
+
+    String getSubCommandName();
+
+    ICommand getParentCommand();
+
+    String getArgUsage(ICommandSender commandSender);
+
+    String getHelpText();
+
+    int getRequiredPermissionLevel();
+
+    boolean canSenderUseSubCommand(ICommandSender commandSender);
+
+    void processSubCommand(ICommandSender commandSender, String[] args);
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/api/command/SubCommandBase.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/command/SubCommandBase.java
@@ -1,0 +1,87 @@
+package WayofTime.alchemicalWizardry.api.command;
+
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.PlayerNotFoundException;
+import net.minecraft.command.PlayerSelector;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatStyle;
+import net.minecraft.util.EnumChatFormatting;
+
+import java.util.Locale;
+
+public abstract class SubCommandBase implements ISubCommand {
+
+    private ICommand parent;
+    private String name;
+
+    public SubCommandBase(ICommand parent, String name) {
+        this.parent = parent;
+        this.name = name;
+    }
+
+    @Override
+    public String getSubCommandName() {
+        return name;
+    }
+
+    @Override
+    public ICommand getParentCommand() {
+        return parent;
+    }
+
+    @Override
+    public boolean canSenderUseSubCommand(ICommandSender commandSender) {
+        return commandSender.canCommandSenderUseCommand(getRequiredPermissionLevel(), "op");
+    }
+
+    @Override
+    public void processSubCommand(ICommandSender commandSender, String[] args) {
+
+        if (args.length == 0 && !getSubCommandName().equals("help"))
+            displayErrorString(commandSender, String.format("%s - %s", capitalizeFirstLetter(getSubCommandName()), getArgUsage(commandSender)));
+
+        if (isBounded(0, 2, args.length) && args[0].equals("help"))
+            displayHelpString(commandSender, String.format("%s - %s", capitalizeFirstLetter(getSubCommandName()), getHelpText()));
+    }
+
+    protected EntityPlayerMP getCommandSenderAsPlayer(ICommandSender commandSender) {
+        if (commandSender instanceof EntityPlayerMP)
+            return (EntityPlayerMP)commandSender;
+        else
+            throw new PlayerNotFoundException("You must specify which player you wish to perform this action on.");
+    }
+
+    protected EntityPlayerMP getPlayer(ICommandSender commandSender, String playerName) {
+        EntityPlayerMP entityplayermp = PlayerSelector.matchOnePlayer(commandSender, playerName);
+
+        if (entityplayermp != null)
+            return entityplayermp;
+        else {
+            entityplayermp = MinecraftServer.getServer().getConfigurationManager().func_152612_a(playerName);
+
+            if (entityplayermp == null)
+                throw new PlayerNotFoundException();
+            else
+                return entityplayermp;
+        }
+    }
+
+    protected String capitalizeFirstLetter(String toCapital) {
+        return String.valueOf(toCapital.charAt(0)).toUpperCase(Locale.ENGLISH) + toCapital.substring(1);
+    }
+
+    protected boolean isBounded(int low, int high, int given) {
+        return given > low && given < high;
+    }
+
+    protected void displayHelpString(ICommandSender commandSender, String display) {
+        commandSender.addChatMessage(new ChatComponentText(display).setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN)));
+    }
+
+    protected void displayErrorString(ICommandSender commandSender, String display) {
+        commandSender.addChatMessage(new ChatComponentText(display).setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
+    }
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/api/tile/IAltarComponent.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/api/tile/IAltarComponent.java
@@ -1,0 +1,14 @@
+package WayofTime.alchemicalWizardry.api.tile;
+
+public interface IAltarComponent {
+
+    ComponentType getType();
+
+    enum ComponentType {
+        GLOWSTONE,
+        BLOODSTONE,
+        BEACON,
+        BLOODRUNE,
+        CRYSTAL
+    }
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
@@ -5,8 +5,13 @@ import java.util.List;
 
 import WayofTime.alchemicalWizardry.AlchemicalWizardry;
 import WayofTime.alchemicalWizardry.api.BlockStack;
+import WayofTime.alchemicalWizardry.api.tile.IAltarComponent;
+import WayofTime.alchemicalWizardry.common.block.BlockCrystal;
+import WayofTime.alchemicalWizardry.common.block.BloodStoneBrick;
+import WayofTime.alchemicalWizardry.common.block.LargeBloodStoneBrick;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockBeacon;
+import net.minecraft.block.BlockGlowstone;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import WayofTime.alchemicalWizardry.ModBlocks;
@@ -361,6 +366,10 @@ public class UpgradedAltars
                 return true;
         }
 
+        if (altarComponent.getBlock() == ModBlocks.bloodRune)
+            if ((blockStack.getBlock() instanceof BloodRune) || (blockStack.getBlock() instanceof IAltarComponent && (((IAltarComponent) blockStack.getBlock()).getType() == IAltarComponent.ComponentType.BLOODRUNE)))
+                return true;
+
         return false;
     }
 
@@ -374,8 +383,21 @@ public class UpgradedAltars
                 return true;
         }
 
-        if (altarComponent.getBlock() == Blocks.beacon && blockStack.getBlock() instanceof BlockBeacon)
-            return true;
+        if (altarComponent.getBlock() == ModBlocks.largeBloodStoneBrick)
+            if ((blockStack.getBlock() instanceof BloodStoneBrick || blockStack.getBlock() instanceof LargeBloodStoneBrick) || (blockStack.getBlock() instanceof IAltarComponent && (((IAltarComponent) blockStack.getBlock()).getType() == IAltarComponent.ComponentType.BLOODSTONE)))
+                return true;
+
+        if (altarComponent.getBlock() == ModBlocks.blockCrystal)
+            if ((blockStack.getBlock() instanceof BlockCrystal) || (blockStack.getBlock() instanceof IAltarComponent && (((IAltarComponent) blockStack.getBlock()).getType() == IAltarComponent.ComponentType.CRYSTAL)))
+                return true;
+
+        if (altarComponent.getBlock() == Blocks.glowstone)
+            if ((blockStack.getBlock() instanceof BlockGlowstone) || (blockStack.getBlock() instanceof IAltarComponent && (((IAltarComponent) blockStack.getBlock()).getType() == IAltarComponent.ComponentType.GLOWSTONE)))
+                return true;
+
+        if (altarComponent.getBlock() == Blocks.beacon)
+            if ((blockStack.getBlock() instanceof BlockBeacon) || (blockStack.getBlock() instanceof IAltarComponent && (((IAltarComponent) blockStack.getBlock()).getType() == IAltarComponent.ComponentType.BEACON)))
+                return true;
 
         return false;
     }

--- a/src/main/java/WayofTime/alchemicalWizardry/common/commands/CommandBloodMagic.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/commands/CommandBloodMagic.java
@@ -1,0 +1,71 @@
+package WayofTime.alchemicalWizardry.common.commands;
+
+import WayofTime.alchemicalWizardry.api.command.ISubCommand;
+import WayofTime.alchemicalWizardry.common.commands.sub.SubCommandBind;
+import WayofTime.alchemicalWizardry.common.commands.sub.SubCommandHelp;
+import WayofTime.alchemicalWizardry.common.commands.sub.SubCommandNetwork;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatStyle;
+import net.minecraft.util.EnumChatFormatting;
+
+import java.util.*;
+
+public class CommandBloodMagic extends CommandBase {
+
+    private final List aliases = new ArrayList();
+    private final Map<String, ISubCommand> subCommands = new HashMap<String, ISubCommand>();
+
+    @SuppressWarnings("unchecked")
+    public CommandBloodMagic() {
+        aliases.add("BloodMagic");
+        aliases.add("bloodmagic");
+        aliases.add("bloodMagic");
+        aliases.add("bm");
+
+        subCommands.put("help", new SubCommandHelp(this));
+        subCommands.put("network", new SubCommandNetwork(this));
+        subCommands.put("bind", new SubCommandBind(this));
+    }
+
+    @Override
+    public String getCommandName() {
+        return "/bloodmagic";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 3;
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender commandSender) {
+        return getCommandName() + " help";
+    }
+
+    @Override
+    public List getCommandAliases() {
+        return aliases;
+    }
+
+    @Override
+    public void processCommand(ICommandSender commandSender, String[] args) {
+        if (args.length > 0 && subCommands.containsKey(args[0])) {
+
+            ISubCommand subCommand = subCommands.get(args[0]);
+            String[] subArgs = Arrays.copyOfRange(args, 1, args.length);
+
+            if (subCommand.canSenderUseSubCommand(commandSender))
+                subCommand.processSubCommand(commandSender, subArgs);
+            else
+                commandSender.addChatMessage(new ChatComponentText("You do not have permission to use this command.").setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
+        } else {
+            commandSender.addChatMessage(new ChatComponentText("Unknown command!").setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
+        }
+    }
+
+    public Map<String, ISubCommand> getSubCommands() {
+        return subCommands;
+    }
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/common/commands/sub/SubCommandBind.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/commands/sub/SubCommandBind.java
@@ -1,0 +1,73 @@
+package WayofTime.alchemicalWizardry.common.commands.sub;
+
+import WayofTime.alchemicalWizardry.api.command.SubCommandBase;
+import WayofTime.alchemicalWizardry.api.items.interfaces.IBindable;
+import WayofTime.alchemicalWizardry.common.items.EnergyItems;
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentText;
+
+public class SubCommandBind extends SubCommandBase {
+
+    public SubCommandBind(ICommand parent) {
+        super(parent, "bind");
+    }
+
+    @Override
+    public String getArgUsage(ICommandSender commandSender) {
+        return "/bloodmagic bind [true|false] [player]";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Attempts to (un)bind the currently held item.";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+    @Override
+    public void processSubCommand(ICommandSender commandSender, String[] args) {
+        super.processSubCommand(commandSender, args);
+
+        EntityPlayer player = getCommandSenderAsPlayer(commandSender);
+        String playerName = player.getCommandSenderName();
+        ItemStack held = player.getHeldItem();
+        boolean bind = true;
+
+        if (held != null && held.getItem() instanceof IBindable) {
+            if (args.length > 0) {
+
+                if (args[0].equalsIgnoreCase("help"))
+                    return;
+
+                if (isBoolean(args[0])) {
+                    bind = Boolean.parseBoolean(args[0]);
+
+                    if (args.length > 2)
+                        playerName = args[1];
+                } else {
+                    playerName = args[0];
+                }
+            }
+
+            if (bind) {
+                EnergyItems.setItemOwner(held, playerName);
+                commandSender.addChatMessage(new ChatComponentText("Binding successful"));
+            } else {
+                if (!EnergyItems.getOwnerName(held).isEmpty()) {
+                    held.stackTagCompound.removeTag("ownerName");
+                    commandSender.addChatMessage(new ChatComponentText("Unbinding successful"));
+                }
+            }
+        }
+    }
+
+    private boolean isBoolean(String string) {
+        return string.equalsIgnoreCase("true") || string.equalsIgnoreCase("false");
+    }
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/common/commands/sub/SubCommandHelp.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/commands/sub/SubCommandHelp.java
@@ -1,0 +1,43 @@
+package WayofTime.alchemicalWizardry.common.commands.sub;
+
+import WayofTime.alchemicalWizardry.api.command.ISubCommand;
+import WayofTime.alchemicalWizardry.api.command.SubCommandBase;
+import WayofTime.alchemicalWizardry.common.commands.CommandBloodMagic;
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatStyle;
+import net.minecraft.util.EnumChatFormatting;
+
+public class SubCommandHelp extends SubCommandBase {
+
+    public SubCommandHelp(ICommand parent) {
+        super(parent, "help");
+    }
+
+    @Override
+    public String getArgUsage(ICommandSender commandSender) {
+        return "/bloodmagic help";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Displays the help information for the \"/bloodmagic\" command.";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+    @Override
+    public void processSubCommand(ICommandSender commandSender, String[] args) {
+        super.processSubCommand(commandSender, args);
+
+        if (args.length > 0)
+            return;
+
+        for (ISubCommand subCommand : ((CommandBloodMagic)getParentCommand()).getSubCommands().values())
+            commandSender.addChatMessage(new ChatComponentText(String.format("%s - %s", capitalizeFirstLetter(subCommand.getSubCommandName()), subCommand.getArgUsage(commandSender))).setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GREEN)));
+    }
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/common/commands/sub/SubCommandNetwork.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/commands/sub/SubCommandNetwork.java
@@ -1,0 +1,161 @@
+package WayofTime.alchemicalWizardry.common.commands.sub;
+
+import WayofTime.alchemicalWizardry.api.command.SubCommandBase;
+import WayofTime.alchemicalWizardry.api.soulNetwork.SoulNetworkHandler;
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ChatComponentText;
+
+import java.util.Locale;
+
+public class SubCommandNetwork extends SubCommandBase {
+
+    public SubCommandNetwork(ICommand parent) {
+        super(parent, "network");
+    }
+
+    @Override
+    public String getArgUsage(ICommandSender commandSender) {
+        return "/bloodmagic network [syphon|add|get|fill|cap] player [amount]";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "LP network utilities";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+    @Override
+    public void processSubCommand(ICommandSender commandSender, String[] args) {
+        super.processSubCommand(commandSender, args);
+
+        if (args.length > 0) {
+
+            if (args[0].equalsIgnoreCase("help"))
+                return;
+
+            String givenName = commandSender.getCommandSenderName();
+            EntityPlayer player = getPlayer(commandSender, givenName);
+
+            if (args.length > 1) {
+                givenName = args[1];
+                player = getPlayer(commandSender, givenName);
+            }
+
+            boolean displayHelp = isBounded(0, 2, args.length);
+
+            try {
+                switch (ValidCommands.valueOf(args[0].toUpperCase(Locale.ENGLISH))) {
+                    case SYPHON: {
+                        if (displayHelp) {
+                            displayHelpString(commandSender, ValidCommands.SYPHON.help);
+                            break;
+                        }
+
+                        if (args.length == 3) {
+                            if (isInteger(args[2])) {
+                                int amount = Integer.parseInt(args[2]);
+                                SoulNetworkHandler.syphonAndDamageFromNetwork(givenName, player, amount);
+                            } else {
+                                displayErrorString(commandSender, "Invalid arguments");
+                            }
+                        } else {
+                            displayErrorString(commandSender, "Not enough arguments");
+                        }
+
+                        break;
+                    }
+                    case ADD: {
+                        if (displayHelp) {
+                            displayHelpString(commandSender, ValidCommands.ADD.help);
+                            break;
+                        }
+
+                        if (args.length == 3) {
+                            if (isInteger(args[2])) {
+                                int amount = Integer.parseInt(args[2]);
+                                int maxOrb = SoulNetworkHandler.getMaximumForOrbTier(SoulNetworkHandler.getCurrentMaxOrb(givenName));
+                                SoulNetworkHandler.addCurrentEssenceToMaximum(givenName, amount, maxOrb);
+                            } else {
+                                displayErrorString(commandSender, "Invalid arguments");
+                            }
+                        } else {
+                            displayErrorString(commandSender, "Not enough arguments");
+                        }
+
+                        break;
+                    }
+                    case GET: {
+                        if (displayHelp) {
+                            displayHelpString(commandSender, ValidCommands.GET.help);
+                            break;
+                        }
+
+                        if (args.length > 1)
+                            commandSender.addChatMessage(new ChatComponentText("Current Essence: " + SoulNetworkHandler.getCurrentEssence(givenName)));
+
+                        break;
+                    }
+                    case FILL: {
+                        if (displayHelp) {
+                            displayHelpString(commandSender, ValidCommands.FILL.help);
+                            break;
+                        }
+
+                        if (args.length > 1)
+                            SoulNetworkHandler.setCurrentEssence(givenName, Integer.MAX_VALUE);
+
+                        break;
+                    }
+                    case CAP: {
+                        if (displayHelp) {
+                            displayHelpString(commandSender, ValidCommands.CAP.help);
+                            break;
+                        }
+
+                        if (args.length > 1) {
+                            int maxOrb = SoulNetworkHandler.getMaximumForOrbTier(SoulNetworkHandler.getCurrentMaxOrb(givenName));
+                            SoulNetworkHandler.setCurrentEssence(givenName, maxOrb);
+                        }
+
+                        break;
+                    }
+                }
+            } catch (IllegalArgumentException e) {
+                displayErrorString(commandSender, "Command not found!");
+            }
+        }
+    }
+
+    private enum ValidCommands {
+        SYPHON("Removes the given amount of LP from the given player's LP network."),
+        ADD("Adds the given amount of LP to the given player's LP network."),
+        GET("Returns the amount of LP in the given player's LP network."),
+        FILL(String.format("Fills the given player's LP network to %d", Integer.MAX_VALUE)),
+        CAP("Fills the given player's LP network to the max that their highest Blood Orb can store.");
+
+        public String help;
+
+        ValidCommands(String help) {
+            this.help = help;
+        }
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private static boolean isInteger(String s) {
+        try {
+            Integer.parseInt(s);
+        } catch(NumberFormatException e) {
+            return false;
+        } catch(NullPointerException e) {
+            return false;
+        }
+        // only got here if we didn't return false
+        return true;
+    }
+}

--- a/src/main/java/WayofTime/alchemicalWizardry/common/renderer/block/RenderAlchemicCalcinator.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/renderer/block/RenderAlchemicCalcinator.java
@@ -6,6 +6,7 @@ import WayofTime.alchemicalWizardry.api.alchemy.energy.ReagentStack;
 import WayofTime.alchemicalWizardry.common.renderer.model.ModelAlchemicalCalcinator;
 import WayofTime.alchemicalWizardry.common.tileEntity.TEAlchemicCalcinator;
 import cpw.mods.fml.client.FMLClientHandler;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
@@ -59,6 +60,10 @@ public class RenderAlchemicCalcinator extends TileEntitySpecialRenderer
 
             if (tileAltar.getStackInSlot(1) != null)
             {
+
+                boolean fancySaved = Minecraft.isFancyGraphicsEnabled();
+                Minecraft.getMinecraft().gameSettings.fancyGraphics = true;
+
                 float scaleFactor = getGhostItemScaleFactor(tileAltar.getStackInSlot(1));
                 EntityItem ghostEntityItem = new EntityItem(tileAltar.getWorldObj());
                 ghostEntityItem.hoverStart = 0.0F;
@@ -80,6 +85,7 @@ public class RenderAlchemicCalcinator extends TileEntitySpecialRenderer
                 }
 
                 customRenderItem.doRender(ghostEntityItem, 0, 0, 0, 0, 0);
+                Minecraft.getMinecraft().gameSettings.fancyGraphics = fancySaved;
             }
 
 
@@ -88,6 +94,10 @@ public class RenderAlchemicCalcinator extends TileEntitySpecialRenderer
 
             if (tileAltar.getStackInSlot(0) != null)
             {
+
+                boolean fancySaved = Minecraft.isFancyGraphicsEnabled();
+                Minecraft.getMinecraft().gameSettings.fancyGraphics = true;
+
                 float scaleFactor = getGhostItemScaleFactor(tileAltar.getStackInSlot(0));
                 EntityItem ghostEntityItem = new EntityItem(tileAltar.getWorldObj());
                 ghostEntityItem.hoverStart = 0.0F;
@@ -109,6 +119,7 @@ public class RenderAlchemicCalcinator extends TileEntitySpecialRenderer
                 }
 
                 customRenderItem.doRender(ghostEntityItem, 0, 0, 0, 0, 0);
+                Minecraft.getMinecraft().gameSettings.fancyGraphics = fancySaved;
             }
 
             GL11.glPopMatrix();

--- a/src/main/java/WayofTime/alchemicalWizardry/common/renderer/block/RenderPedestal.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/renderer/block/RenderPedestal.java
@@ -3,6 +3,7 @@ package WayofTime.alchemicalWizardry.common.renderer.block;
 import WayofTime.alchemicalWizardry.common.renderer.model.ModelPedestal;
 import WayofTime.alchemicalWizardry.common.tileEntity.TEPedestal;
 import cpw.mods.fml.client.FMLClientHandler;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
@@ -52,7 +53,8 @@ public class RenderPedestal extends TileEntitySpecialRenderer
             if (tileAltar.getStackInSlot(0) != null)
             {
                 float scaleFactor = getGhostItemScaleFactor(tileAltar.getStackInSlot(0));
-                float rotationAngle = (float) (720.0 * (System.currentTimeMillis() & 0x3FFFL) / 0x3FFFL);
+                float rotationAngle = Minecraft.isFancyGraphicsEnabled() ?  (float) (720.0 * (System.currentTimeMillis() & 0x3FFFL) / 0x3FFFL) : 0;
+
                 EntityItem ghostEntityItem = new EntityItem(tileAltar.getWorldObj());
                 ghostEntityItem.hoverStart = 0.0F;
                 ghostEntityItem.setEntityItemStack(tileAltar.getStackInSlot(0));

--- a/src/main/java/WayofTime/alchemicalWizardry/common/renderer/block/RenderPlinth.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/renderer/block/RenderPlinth.java
@@ -3,6 +3,7 @@ package WayofTime.alchemicalWizardry.common.renderer.block;
 import WayofTime.alchemicalWizardry.common.renderer.model.ModelPlinth;
 import WayofTime.alchemicalWizardry.common.tileEntity.TEPlinth;
 import cpw.mods.fml.client.FMLClientHandler;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
@@ -37,7 +38,7 @@ public class RenderPlinth extends TileEntitySpecialRenderer
     {
         if (tileEntity instanceof TEPlinth)
         {
-            TEPlinth tileAltar = (TEPlinth) tileEntity;
+            TEPlinth tilePlinth = (TEPlinth) tileEntity;
             GL11.glPushMatrix();
             GL11.glTranslatef((float) d0 + 0.5F, (float) d1 + 1.5F, (float) d2 + 0.5F);
             ResourceLocation test = new ResourceLocation("alchemicalwizardry:textures/models/Plinth.png");
@@ -49,12 +50,16 @@ public class RenderPlinth extends TileEntitySpecialRenderer
             GL11.glPopMatrix();
             GL11.glPushMatrix();
 
-            if (tileAltar.getStackInSlot(0) != null)
+            if (tilePlinth.getStackInSlot(0) != null)
             {
-                float scaleFactor = getGhostItemScaleFactor(tileAltar.getStackInSlot(0));
-                EntityItem ghostEntityItem = new EntityItem(tileAltar.getWorldObj());
+
+                boolean fancySaved = Minecraft.isFancyGraphicsEnabled();
+                Minecraft.getMinecraft().gameSettings.fancyGraphics = true;
+
+                float scaleFactor = getGhostItemScaleFactor(tilePlinth.getStackInSlot(0));
+                EntityItem ghostEntityItem = new EntityItem(tilePlinth.getWorldObj());
                 ghostEntityItem.hoverStart = 0.0F;
-                ghostEntityItem.setEntityItemStack(tileAltar.getStackInSlot(0));
+                ghostEntityItem.setEntityItemStack(tilePlinth.getStackInSlot(0));
                 float displacement = 0.2F;
 
                 if (ghostEntityItem.getEntityItem().getItem() instanceof ItemBlock)
@@ -72,6 +77,8 @@ public class RenderPlinth extends TileEntitySpecialRenderer
                 }
 
                 customRenderItem.doRender(ghostEntityItem, 0, 0, 0, 0, 0);
+
+                Minecraft.getMinecraft().gameSettings.fancyGraphics = fancySaved;
             }
 
             GL11.glPopMatrix();

--- a/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectExpulsion.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectExpulsion.java
@@ -16,6 +16,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
@@ -157,6 +158,12 @@ public class RitualEffectExpulsion extends RitualEffect
 
     public boolean teleportRandomly(EntityLivingBase entityLiving, double distance)
     {
+        if (entityLiving instanceof EntityPlayer) {
+            EntityPlayer player = (EntityPlayer) entityLiving;
+            if (player.capabilities.isCreativeMode)
+                return false;
+        }
+
         double x = entityLiving.posX;
         double y = entityLiving.posY;
         double z = entityLiving.posZ;


### PR DESCRIPTION
## Contents

* Command rework to have commands be sub-commands of `/bloodmagic`

 * Makes it a bit cleaner and simpler to add new sub commands.

* Creative players can now bypass the Aura of Expulsion. Fixes #460 

 * Useful for server administration

* All instances of 2D Item model rendering are fixed. Replacement of #465

 * The pedestal always has the item face you (like the altar). The Plinth and Calcinator forces the items to render in 3D.

* Other mods can now add variant blocks to the altar themselves.

 * Very simple to add. Just implement `IAltarComponent` on your Block and return the `ComponentType` in the provided method. [Example](https://gist.github.com/TehNut/8881d741f69eed691d95)