### PR TITLE
Fix #347 again...

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectMagnetic.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectMagnetic.java
@@ -33,11 +33,12 @@ public class RitualEffectMagnetic extends RitualEffect
     
     public static boolean isBlockOre(Block block, int meta)
     {
-        if (block == null || Item.getItemFromBlock(block) == null)
-            return false;
-        
+        //Special case for lit redstone ore
         if (block instanceof BlockOre || block instanceof BlockRedstoneOre)
             return true;
+        
+        if (block == null || Item.getItemFromBlock(block) == null)
+            return false;
         
         ItemType type = new ItemType(block, meta);
         Boolean result = oreBlockCache.get(type);


### PR DESCRIPTION
When I made pull request #359 I inadvertently broke this method again for the case of lit redstone ore, since it has no item attached to it. This should work better now ^^