### PR TITLE
Fix ItemBoundSword damage

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/item/ItemBoundSword.java
+++ b/src/main/java/WayofTime/bloodmagic/item/ItemBoundSword.java
@@ -42,8 +42,6 @@ public class ItemBoundSword extends ItemSword implements IBindable, IActivatable
         setUnlocalizedName(Constants.Mod.MODID + ".bound.sword");
         setRegistryName(Constants.BloodMagicItem.BOUND_SWORD.getRegName());
         setCreativeTab(BloodMagic.tabBloodMagic);
-
-        this.attackDamage = 1.0F + ModItems.boundToolMaterial.getDamageVsEntity();
     }
 
     @Override


### PR DESCRIPTION
ItemSword has this line:

"this.attackDamage = 3.0F + material.getDamageVsEntity();"

Currently, BloodMagic has this line:

"this.attackDamage = 1.0F + ModItems.boundToolMaterial.getDamageVsEntity();"

This is makes the sword do less damage than it should. (making the pickaxe, axe, and shovel all better in terms of damage.)

Simple change that allows the SuperClass ItemSword handle the attackDamage variable.
