### PR TITLE
Fix biomeID selection for the ritual of gaias transformation.

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectBiomeChanger.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectBiomeChanger.java
@@ -263,7 +263,7 @@ public class RitualEffectBiomeChanger extends RitualEffect
 
                 if (Math.abs(rainfall - humidity) < acceptableRange && Math.abs(temperature - temp) < acceptableRange)
                 {
-                    biomeID = iteration;
+                    biomeID = biome.biomeID;
                     if (biomeSkip == 0)
                     {
                         break;


### PR DESCRIPTION
The biome id is wrongly assigned an arbitary iteration variable. This works until the loop starts skipping null biomes, where the iteration variable goes out of sync.

This PR changes the selection to the biomeID property of the selected biome object, thus making sure it is always the correct id.
