### PR TITLE
Fixed Issue #703; Blocks with MetaData being reset to 0

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilTransposition.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilTransposition.java
@@ -77,7 +77,7 @@ public class ItemSigilTransposition extends ItemSigilBase
 
                     NBTTagCompound tileNBTTag = new NBTTagCompound();
                     String blockName = rightClickedBlock.getBlock().getRegistryName().toString();
-                    byte metadata = (byte) stack.getMetadata();
+                    byte metadata =  (byte) rightClickedBlock.getMeta();
 
                     if (world.getTileEntity(blockPos) != null)
                     {


### PR DESCRIPTION
Issue fixed and tested. No longer is changing block metadata.
