### PR TITLE
Fix JEI Altar recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ crash-reports/
 /logs/
 /mods/
 /screenshots/
+/classes/
 
 # File Extensions
 *.psd

--- a/src/main/java/WayofTime/bloodmagic/compat/jei/altar/AltarRecipeCategory.java
+++ b/src/main/java/WayofTime/bloodmagic/compat/jei/altar/AltarRecipeCategory.java
@@ -2,11 +2,14 @@ package WayofTime.bloodmagic.compat.jei.altar;
 
 import javax.annotation.Nonnull;
 
+import java.util.List;
+
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.recipe.IRecipeCategory;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import WayofTime.bloodmagic.api.Constants;
 import WayofTime.bloodmagic.compat.jei.BloodMagicPlugin;
@@ -56,7 +59,6 @@ public class AltarRecipeCategory implements IRecipeCategory
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull IRecipeWrapper recipeWrapper)
     {
         recipeLayout.getItemStacks().init(INPUT_SLOT, true, 31, 0);
@@ -65,7 +67,8 @@ public class AltarRecipeCategory implements IRecipeCategory
         if (recipeWrapper instanceof AltarRecipeJEI)
         {
             AltarRecipeJEI altarRecipeWrapper = (AltarRecipeJEI) recipeWrapper;
-            recipeLayout.getItemStacks().set(INPUT_SLOT, altarRecipeWrapper.getInputs());
+            List<List<ItemStack>> inputs = altarRecipeWrapper.getInputs();
+            recipeLayout.getItemStacks().set(INPUT_SLOT, inputs.get(0));
             recipeLayout.getItemStacks().set(OUTPUT_SLOT, altarRecipeWrapper.getOutputs());
         }
     }

--- a/src/main/java/WayofTime/bloodmagic/compat/jei/altar/AltarRecipeJEI.java
+++ b/src/main/java/WayofTime/bloodmagic/compat/jei/altar/AltarRecipeJEI.java
@@ -17,7 +17,7 @@ import WayofTime.bloodmagic.util.helper.TextHelper;
 public class AltarRecipeJEI extends BlankRecipeWrapper
 {
     @Nonnull
-    private final Object input;
+    private final List<ItemStack> input;
 
     @Nonnull
     private final ItemStack output;
@@ -37,13 +37,13 @@ public class AltarRecipeJEI extends BlankRecipeWrapper
     }
 
     @Override
-    public List getInputs()
+    public List<List<ItemStack>> getInputs()
     {
         return Collections.singletonList(input);
     }
 
     @Override
-    public List getOutputs()
+    public List<ItemStack> getOutputs()
     {
         return Collections.singletonList(output);
     }


### PR DESCRIPTION
There is a minor error in the Blood Altar JEI integration. It sends JEI a `List<List<ItemStack>>` where JEI requires `Collection<ItemStack>`.
Old versions of JEI were tolerant to this error (by luck heh), but the new versions breaks. This PR fixes the issue.
