### PR TITLE
Entity Registration Fix

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/registry/ModEntities.java
+++ b/src/main/java/WayofTime/bloodmagic/registry/ModEntities.java
@@ -1,6 +1,8 @@
 package WayofTime.bloodmagic.registry;
 
-import net.minecraftforge.fml.common.registry.EntityEntry;
+import WayofTime.bloodmagic.BloodMagic;
+import WayofTime.bloodmagic.api.Constants;
+import net.minecraft.util.ResourceLocation;
 import WayofTime.bloodmagic.entity.mob.EntityCorruptedChicken;
 import WayofTime.bloodmagic.entity.mob.EntityCorruptedSheep;
 import WayofTime.bloodmagic.entity.mob.EntityCorruptedSpider;
@@ -11,21 +13,22 @@ import WayofTime.bloodmagic.entity.projectile.EntityBloodLight;
 import WayofTime.bloodmagic.entity.projectile.EntityMeteor;
 import WayofTime.bloodmagic.entity.projectile.EntitySentientArrow;
 import WayofTime.bloodmagic.entity.projectile.EntitySoulSnare;
-import net.minecraftforge.fml.common.registry.GameRegistry;
+import net.minecraftforge.fml.common.registry.EntityRegistry;
 
 public class ModEntities
 {
     public static void init()
     {
-        GameRegistry.register(new EntityEntry(EntityBloodLight.class, "BloodLight").setRegistryName("BloodLight"));
-        GameRegistry.register(new EntityEntry(EntitySoulSnare.class, "SoulSnare").setRegistryName("SoulSnare"));
-        GameRegistry.register(new EntityEntry(EntitySentientArrow.class, "SoulArrow").setRegistryName("SoulArrow"));
-        GameRegistry.register(new EntityEntry(EntityMeteor.class, "Meteor").setRegistryName("Meteor"));
-        GameRegistry.register(new EntityEntry(EntitySentientSpecter.class, "SentientSpecter").setRegistryName("SentientSpecter"));
-        GameRegistry.register(new EntityEntry(EntityMimic.class, "Mimic").setRegistryName("Mimic"));
-        GameRegistry.register(new EntityEntry(EntityCorruptedZombie.class, "CorruptedZombie").setRegistryName("CorruptedZombie"));
-        GameRegistry.register(new EntityEntry(EntityCorruptedSheep.class, "CorruptedSheep").setRegistryName("CorruptedSheep"));
-        GameRegistry.register(new EntityEntry(EntityCorruptedChicken.class, "CorruptedChicken").setRegistryName("CorruptedChicken"));
-        GameRegistry.register(new EntityEntry(EntityCorruptedSpider.class, "CorruptedSpider").setRegistryName("CorruptedSpider"));
+        int entities = 0;
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":BloodLight"),EntityBloodLight.class, "BloodLight",++entities, BloodMagic.instance,16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":SoulSnare"),EntitySoulSnare.class, "SoulSnare",++entities, BloodMagic.instance,16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":SoulArrow"),EntitySentientArrow.class, "SoulArrow",++entities, BloodMagic.instance,16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":Meteor"),EntityMeteor.class, "Meteor",++entities, BloodMagic.instance,16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":SentientSpecter"),EntitySentientSpecter.class, "SentientSpecter",++entities, BloodMagic.instance,16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":Mimic"),EntityMimic.class, "Mimic",++entities, BloodMagic.instance,16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":CorruptedZombie"),EntityCorruptedZombie.class, "CorruptedZombie",++entities, BloodMagic.instance,16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":CorruptedSheep"),EntityCorruptedSheep.class, "CorruptedSheep",++entities, BloodMagic.instance,16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":CorruptedChicken"),EntityCorruptedChicken.class, "CorruptedChicken",++entities, BloodMagic.instance,16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":CorruptedSpider"),EntityCorruptedSpider.class, "CorruptedSpider",++entities, BloodMagic.instance,16*4, 3, true);
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/registry/ModEntities.java
+++ b/src/main/java/WayofTime/bloodmagic/registry/ModEntities.java
@@ -20,15 +20,15 @@ public class ModEntities
     public static void init()
     {
         int entities = 0;
-        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":BloodLight"),EntityBloodLight.class, "BloodLight",++entities, BloodMagic.instance,16*4, 3, true);
-        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":SoulSnare"),EntitySoulSnare.class, "SoulSnare",++entities, BloodMagic.instance,16*4, 3, true);
-        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":SoulArrow"),EntitySentientArrow.class, "SoulArrow",++entities, BloodMagic.instance,16*4, 3, true);
-        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":Meteor"),EntityMeteor.class, "Meteor",++entities, BloodMagic.instance,16*4, 3, true);
-        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":SentientSpecter"),EntitySentientSpecter.class, "SentientSpecter",++entities, BloodMagic.instance,16*4, 3, true);
-        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":Mimic"),EntityMimic.class, "Mimic",++entities, BloodMagic.instance,16*4, 3, true);
-        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":CorruptedZombie"),EntityCorruptedZombie.class, "CorruptedZombie",++entities, BloodMagic.instance,16*4, 3, true);
-        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":CorruptedSheep"),EntityCorruptedSheep.class, "CorruptedSheep",++entities, BloodMagic.instance,16*4, 3, true);
-        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":CorruptedChicken"),EntityCorruptedChicken.class, "CorruptedChicken",++entities, BloodMagic.instance,16*4, 3, true);
-        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID+":CorruptedSpider"),EntityCorruptedSpider.class, "CorruptedSpider",++entities, BloodMagic.instance,16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID, "BloodLight"), EntityBloodLight.class, "BloodLight", ++entities, BloodMagic.instance, 16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID, "SoulSnare"), EntitySoulSnare.class, "SoulSnare", ++entities, BloodMagic.instance, 16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID, "SoulArrow"), EntitySentientArrow.class, "SoulArrow", ++entities, BloodMagic.instance, 16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID, "Meteor"), EntityMeteor.class, "Meteor", ++entities, BloodMagic.instance, 16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID, "SentientSpecter"), EntitySentientSpecter.class, "SentientSpecter", ++entities, BloodMagic.instance, 16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID, "Mimic"), EntityMimic.class, "Mimic", ++entities, BloodMagic.instance, 16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID, "CorruptedZombie"), EntityCorruptedZombie.class, "CorruptedZombie", ++entities, BloodMagic.instance, 16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID, "CorruptedSheep"), EntityCorruptedSheep.class, "CorruptedSheep", ++entities, BloodMagic.instance, 16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID, "CorruptedChicken"), EntityCorruptedChicken.class, "CorruptedChicken", ++entities, BloodMagic.instance, 16*4, 3, true);
+        EntityRegistry.registerModEntity(new ResourceLocation(Constants.Mod.MODID, "CorruptedSpider"), EntityCorruptedSpider.class, "CorruptedSpider", ++entities, BloodMagic.instance, 16*4, 3, true);
     }
 }


### PR DESCRIPTION
Replaced the Entity registration code. 

Before, the code was manually adding entities to the GameRegistry. Doing this prevents the engine from fully registering the added entities in all the proper places. The result was that the Client was never informed of when these entities were created or what they were doing, as all of that behavior is managed by the EntityRegistry.

Changing to the proper EntityRegistry calls fixes issue #1065.

It should be noted that I wasn't super sure what to enter as the values for the  tracking components for the entities, so I set all of them to send tracking updates to the player as long as they are within  4 chunks, send those tracking updates every 3 ticks, and to include velocity with the tracking data. If this should be changed later, it can be done in another pull request.
![2017-03-07_18 28 07](https://cloud.githubusercontent.com/assets/7277096/23682870/d8c26456-0363-11e7-8cf8-35bef5ffaaa1.png)
