### PR TITLE
Add crop support for Pam's Harvestcraft and Roots herbs

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/ritual/harvest/HarvestHandlerPlantable.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/harvest/HarvestHandlerPlantable.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
 
+import WayofTime.bloodmagic.BloodMagic;
 import WayofTime.bloodmagic.api.BlockStack;
 import WayofTime.bloodmagic.api.iface.IHarvestHandler;
 import WayofTime.bloodmagic.api.registry.HarvestRegistry;
@@ -16,7 +17,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.fml.common.Loader;
-import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
@@ -130,19 +130,19 @@ public class HarvestHandlerPlantable implements IHarvestHandler
                 HarvestRegistry.registerStandardCrop(crop, 3);
             }
         } catch (NoSuchMethodException e) {
-            FMLLog.warning("HarvestCraft integration cancelled; unable to find crop name mapper");
+            BloodMagic.instance.getLogger().error("HarvestCraft integration cancelled; unable to find crop name mapper");
             return;
         } catch (IllegalAccessException e) {
-            FMLLog.warning("HarvestCraft integration cancelled; crop name lookup broke");
+            BloodMagic.instance.getLogger().error("HarvestCraft integration cancelled; crop name lookup broke");
             return;
         } catch (InvocationTargetException e) {
-            FMLLog.warning("HarvestCraft integration cancelled; crop name lookup broke");
+            BloodMagic.instance.getLogger().error("HarvestCraft integration cancelled; crop name lookup broke");
             return;
         } catch (ReflectionHelper.UnableToFindClassException e) {
-            FMLLog.warning("HarvestCraft integration cancelled; unable to find crop registry");
+            BloodMagic.instance.getLogger().error("HarvestCraft integration cancelled; unable to find crop registry");
             return;
         } catch (ReflectionHelper.UnableToFindFieldException e) {
-            FMLLog.warning("HarvestCraft integration cancelled; unable to find crop names in registry");
+            BloodMagic.instance.getLogger().error("HarvestCraft integration cancelled; unable to find crop names in registry");
             return;
         }
     }

--- a/src/main/java/WayofTime/bloodmagic/ritual/harvest/HarvestHandlerPlantable.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/harvest/HarvestHandlerPlantable.java
@@ -45,6 +45,13 @@ public class HarvestHandlerPlantable implements IHarvestHandler
         addThirdPartyCrop("extrautils2", "redorchid", 6);
         addThirdPartyCrop("extrautils2", "enderlily", 7);
 
+        addThirdPartyCrop("roots", "moonglow", 7);
+        addThirdPartyCrop("roots", "terra_moss", 7);
+        addThirdPartyCrop("roots", "pereskia", 7);
+        addThirdPartyCrop("roots", "wildroot", 7);
+        addThirdPartyCrop("roots", "aubergine", 7);
+        addThirdPartyCrop("roots", "spirit_herb", 7);
+
         addPamCrops();
     }
 

--- a/src/main/java/WayofTime/bloodmagic/ritual/harvest/HarvestHandlerPlantable.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/harvest/HarvestHandlerPlantable.java
@@ -9,6 +9,7 @@ import WayofTime.bloodmagic.api.BlockStack;
 import WayofTime.bloodmagic.api.iface.IHarvestHandler;
 import WayofTime.bloodmagic.api.registry.HarvestRegistry;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockCrops;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -126,8 +127,8 @@ public class HarvestHandlerPlantable implements IHarvestHandler
             Field names = ReflectionHelper.findField(registry, "cropNames");
             Method getCrop = registry.getMethod("getCrop", String.class);
             for (String name : (String[])names.get(null)) {
-                Block crop = (Block) getCrop.invoke(null, name);
-                HarvestRegistry.registerStandardCrop(crop, 3);
+                BlockCrops crop = (BlockCrops) getCrop.invoke(null, name);
+                HarvestRegistry.registerStandardCrop(crop, crop.getMaxAge());
             }
         } catch (NoSuchMethodException e) {
             BloodMagic.instance.getLogger().error("HarvestCraft integration cancelled; unable to find crop name mapper");


### PR DESCRIPTION
This adds support for Pam's many crops and Roots herbs to the Harvest Moon ritual.  Rather than enumerate all the Pam's crops, it uses reflection to get a list from Harvestcraft itself.