### PR TITLE
Fix compatibility with mods using item.getAttributeModifiers

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/item/armour/ItemLivingArmour.java
+++ b/src/main/java/WayofTime/bloodmagic/item/armour/ItemLivingArmour.java
@@ -410,7 +410,7 @@ public class ItemLivingArmour extends ItemArmor implements ISpecialArmor, IMeshP
             return armour.getAttributeModifiers();
         }
 
-        return HashMultimap.<String, AttributeModifier>create();
+        return super.getAttributeModifiers(slot, stack);
     }
 
     @Override

--- a/src/main/java/WayofTime/bloodmagic/item/armour/ItemSentientArmour.java
+++ b/src/main/java/WayofTime/bloodmagic/item/armour/ItemSentientArmour.java
@@ -368,16 +368,18 @@ public class ItemSentientArmour extends ItemArmor implements ISpecialArmor, IMes
     @Override
     public Multimap<String, AttributeModifier> getAttributeModifiers(EntityEquipmentSlot slot, ItemStack stack)
     {
-        Multimap<String, AttributeModifier> multimap = HashMultimap.<String, AttributeModifier>create();
         if (slot == EntityEquipmentSlot.CHEST)
         {
+            Multimap<String, AttributeModifier> multimap = HashMultimap.<String, AttributeModifier>create();
             multimap.put(SharedMonsterAttributes.MAX_HEALTH.getName(), new AttributeModifier(new UUID(0, 318145), "Armor modifier", this.getHealthBonus(stack), 0));
             multimap.put(SharedMonsterAttributes.KNOCKBACK_RESISTANCE.getName(), new AttributeModifier(new UUID(0, 8145), "Armor modifier", this.getKnockbackResistance(stack), 0));
             multimap.put(SharedMonsterAttributes.MOVEMENT_SPEED.getName(), new AttributeModifier(new UUID(0, 94021), "Armor modifier", this.getSpeedBoost(stack), 2));
             multimap.put(SharedMonsterAttributes.ATTACK_DAMAGE.getName(), new AttributeModifier(new UUID(0, 96721), "Armor modifier", this.getDamageBoost(stack), 2));
             multimap.put(SharedMonsterAttributes.ATTACK_SPEED.getName(), new AttributeModifier(new UUID(0, 73245), "Armor modifier", this.getAttackSpeedBoost(stack), 2));
+            multimap.putAll(super.getAttributeModifiers(slot, stack));
+            return multimap;
         }
-        return multimap;
+        return super.getAttributeModifiers(slot, stack);
     }
 
     public static void revertAllArmour(EntityPlayer player)


### PR DESCRIPTION
Any mod that uses ARMOR and ARMOR_TOUGHNESS from `item.getAttributeModifiers` will crash because it's providing an empty Map.