### PR TITLE
Fix operator precedence causing wrong items to be crafted in Rhythm of the Beating Anvil

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectCrafting.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/rituals/RitualEffectCrafting.java
@@ -419,7 +419,7 @@ public class RitualEffectCrafting extends RitualEffect
 //            return false;
 //        }
 
-        return stack1.getItem() == stack2.getItem() && !stack1.getItem().getHasSubtypes() || stack1.getItemDamage() == stack2.getItemDamage();
+        return stack1.getItem() == stack2.getItem() && (!stack1.getItem().getHasSubtypes() || stack1.getItemDamage() == stack2.getItemDamage());
     }
 
     public boolean areItemStacksEqualWithWildcard(ItemStack recipeStack, ItemStack comparedStack)


### PR DESCRIPTION
Missing parentheses cause incorrect items to be crafted when multiple recipes are used in the ritual, since the check that items are equivalent will return true for all undamaged items. If there is a valid crafting recipe for the same shape and the block chosen, it will be crafted, otherwise, the inputs will simply disappear. This basically means that crafting more than one recipe in the same recipe is unlikely to ever work reliably. This should not apply to crafting only a single recipe.

I understand that 1.7.10 is EOL so this will never be fixed, but I wanted to document this problem so that it doesn't come along when/if this ritual is ported to newer versions, and to create a record for others googling the Rhythm of the Beating Anvil for crafting the wrong items, losing items, etc in 1.7.10.