### PR TITLE
Fix light calculation to use actual visible level. Also tweak duration slightly.

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/livingArmour/upgrade/LivingArmourUpgradeNightSight.java
+++ b/src/main/java/WayofTime/bloodmagic/livingArmour/upgrade/LivingArmourUpgradeNightSight.java
@@ -29,7 +29,7 @@ public class LivingArmourUpgradeNightSight extends LivingArmourUpgrade {
 
     @Override
     public void onTick(World world, EntityPlayer player, ILivingArmour livingArmour) {
-        if (world.getLight(player.getPosition()) <= 9) {
+        if (world.getLight(player.getPosition(), false) <= 9) {
             isActive = true;
             if (player.isPotionActive(MobEffects.NIGHT_VISION)) {
                 int dur = player.getActivePotionEffect(MobEffects.NIGHT_VISION).getDuration();

--- a/src/main/java/WayofTime/bloodmagic/util/Constants.java
+++ b/src/main/java/WayofTime/bloodmagic/util/Constants.java
@@ -168,7 +168,7 @@ public class Constants
     {
         public static final int POTION_ARRAY_SIZE = 256;
         public static final float ALTERED_STEP_HEIGHT = 1.00314159f;
-        public static final int NIGHT_VISION_CONSTANT_BEGIN = 30002;
+        public static final int NIGHT_VISION_CONSTANT_BEGIN = 30020;
         public static final int NIGHT_VISION_CONSTANT_END = 30000;
     }
 }


### PR DESCRIPTION
The night vision effect wouldn't work at, well, night. It would work underground fine, where you couldn't see the sky.
The light calculation was relying on a zero skylight. This is fixed now.
I also tweaked the duration by a few ticks - the mechanism was removing the effect too frequently and causing obnoxious flicker on the client. I imagine it'd only be worse on a server.