### PR TITLE
Fix for overzealous Mob Sacrifice Array

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/alchemyArray/AlchemyArrayEffectMobSacrifice.java
+++ b/src/main/java/WayofTime/bloodmagic/alchemyArray/AlchemyArrayEffectMobSacrifice.java
@@ -120,7 +120,7 @@ public class AlchemyArrayEffectMobSacrifice extends AlchemyArrayEffect
                         for (EntityLivingBase living : livingEntities)
                         {
                             double health = getEffectiveHealth(living);
-                            if (healthAvailable > 0)
+                            if (healthAvailable > 0 && health > 0)
                             {
                                 healthAvailable -= health;
                                 living.getEntityWorld().playSound(null, living.posX, living.posY, living.posZ, SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.BLOCKS, 0.5F, 2.6F + (living.getEntityWorld().rand.nextFloat() - living.getEntityWorld().rand.nextFloat()) * 0.8F);


### PR DESCRIPTION
This is solving the issue I raised in https://github.com/WayofTime/BloodMagic/issues/1368 where the mob sacrifice array gets a little ahead of itself and kills anyone in its 11x11x11 cube, including creative players and bosses.
Just added a single extra check to an if statement.