### PR TITLE
Several mimic fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,14 +1,4 @@
 ------------------------------------------------------
-Version 2.3.1
-------------------------------------------------------
-
-- Fixed Ritual of Magnetism not being registered
-- Fixed Mob Sacrifice Array so it no longer kills bosses and players
-- Fixed Will type serializer using lowercase names
-- Fixed item rendering for the Sigil of Holding HUD
-- Added mod id to command localization keys to prevent potential conflicts
-
-------------------------------------------------------
 Version 2.3.0
 ------------------------------------------------------
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 mod_name=BloodMagic
 package_group=com.wayoftime.bloodmagic
-mod_version=2.3.1
+mod_version=2.3.0
 mc_version=1.12.2
 forge_version=14.23.2.2611
 curse_id=224791

--- a/src/main/java/WayofTime/bloodmagic/alchemyArray/AlchemyArrayEffectMobSacrifice.java
+++ b/src/main/java/WayofTime/bloodmagic/alchemyArray/AlchemyArrayEffectMobSacrifice.java
@@ -120,7 +120,7 @@ public class AlchemyArrayEffectMobSacrifice extends AlchemyArrayEffect
                         for (EntityLivingBase living : livingEntities)
                         {
                             double health = getEffectiveHealth(living);
-                            if (healthAvailable > 0)
+                            if (healthAvailable > 0 && health > 0)
                             {
                                 healthAvailable -= health;
                                 living.getEntityWorld().playSound(null, living.posX, living.posY, living.posZ, SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.BLOCKS, 0.5F, 2.6F + (living.getEntityWorld().rand.nextFloat() - living.getEntityWorld().rand.nextFloat()) * 0.8F);

--- a/src/main/java/WayofTime/bloodmagic/block/BlockAltar.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockAltar.java
@@ -57,7 +57,7 @@ public class BlockAltar extends Block implements IVariantProvider, IDocumentedBl
 
         TileEntity tile = world.getTileEntity(pos);
 
-        if (tile instanceof TileAltar) {
+        if (tile != null && tile instanceof TileAltar) {
             TileAltar altar = (TileAltar) tile;
             ItemStack orbStack = altar.getStackInSlot(0);
 

--- a/src/main/java/WayofTime/bloodmagic/block/BlockMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockMimic.java
@@ -8,6 +8,7 @@ import WayofTime.bloodmagic.block.enums.EnumMimic;
 import WayofTime.bloodmagic.core.RegistrarBloodMagicBlocks;
 import WayofTime.bloodmagic.tile.TileMimic;
 import WayofTime.bloodmagic.util.Utils;
+import WayofTime.bloodmagic.item.block.ItemBlockMimic;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
@@ -59,7 +60,7 @@ public class BlockMimic extends BlockEnum<EnumMimic> implements IAltarComponent 
                     if (mimicBlock == Blocks.AIR) {
                         return FULL_BLOCK_AABB;
                     }
-                    IBlockState mimicState = mimicBlock.getStateFromMeta(tileMimic.metaOfReplacedBlock);
+                    IBlockState mimicState = tileMimic.getReplacedState();
                     if (mimicBlock != this) {
                         return mimicState.getCollisionBoundingBox(world, pos);
                     }
@@ -82,7 +83,7 @@ public class BlockMimic extends BlockEnum<EnumMimic> implements IAltarComponent 
             if (mimicBlock == Blocks.AIR) {
                 return FULL_BLOCK_AABB;
             }
-            IBlockState mimicState = mimicBlock.getStateFromMeta(tileMimic.getStackInSlot(0).getItemDamage());
+            IBlockState mimicState = tileMimic.getReplacedState();
             if (mimicBlock != this) {
                 return mimicState.getSelectedBoundingBox(world, pos);
             }
@@ -136,7 +137,7 @@ public class BlockMimic extends BlockEnum<EnumMimic> implements IAltarComponent 
             ItemStack stack = mimic.getStackInSlot(0);
             if (stack.getItem() instanceof ItemBlock) {
                 Block block = ((ItemBlock) stack.getItem()).getBlock();
-                IBlockState mimicState = block.getStateFromMeta(stack.getItemDamage());
+                IBlockState mimicState = mimic.getReplacedState();
                 if (block != this) {
                     if (block.getRenderType(mimicState) == EnumBlockRenderType.ENTITYBLOCK_ANIMATED) {
                         return RegistrarBloodMagicBlocks.BLOOD_LIGHT.getDefaultState(); //Small and invisible-ish, basically this is returned in order to not render over the animated block (TESR)
@@ -208,7 +209,7 @@ public class BlockMimic extends BlockEnum<EnumMimic> implements IAltarComponent 
             if (stack.getItem() instanceof ItemBlock) {
                 Block block = ((ItemBlock) stack.getItem()).getBlock();
                 if (block instanceof IAltarComponent) {
-                    return ((IAltarComponent) block).getType(world, block.getStateFromMeta(mimic.metaOfReplacedBlock), pos);
+                    return ((IAltarComponent) block).getType(world, mimic.getReplacedState(), pos);
                 } else {
                     for (ComponentType altarComponent : ComponentType.values())
                         if (block == Utils.getBlockForComponent(altarComponent))
@@ -218,4 +219,10 @@ public class BlockMimic extends BlockEnum<EnumMimic> implements IAltarComponent 
         }
         return null;
     }
+	
+	@Override
+	public ItemBlock getItem() {
+		return new ItemBlockMimic(this);
+	}
+
 }

--- a/src/main/java/WayofTime/bloodmagic/client/hud/element/ElementHolding.java
+++ b/src/main/java/WayofTime/bloodmagic/client/hud/element/ElementHolding.java
@@ -44,7 +44,7 @@ public class ElementHolding extends HUDElement {
         List<ItemStack> inventory = ItemSigilHolding.getInternalInventory(sigilHolding);
         int xOffset = 0;
         for (ItemStack stack : inventory) {
-            renderHotbarItem(drawX + 3 + xOffset, drawY + 3, partialTicks, minecraft.player, stack);
+            renderHotbarItem(drawX + 3 + xOffset, drawY - 4, partialTicks, minecraft.player, stack);
             xOffset += 20;
         }
     }

--- a/src/main/java/WayofTime/bloodmagic/command/sub/SubCommandBind.java
+++ b/src/main/java/WayofTime/bloodmagic/command/sub/SubCommandBind.java
@@ -21,7 +21,7 @@ public class SubCommandBind extends CommandBase {
 
     @Override
     public String getUsage(ICommandSender commandSender) {
-        return TextHelper.localizeEffect("commands.bloodmagic.bind.usage");
+        return TextHelper.localizeEffect("commands.bind.usage");
     }
 
     @Override
@@ -58,17 +58,17 @@ public class SubCommandBind extends CommandBase {
                 if (bind) {
                     Binding binding = new Binding(player.getGameProfile().getId(), player.getGameProfile().getName());
                     BindableHelper.applyBinding(held, binding);
-                    commandSender.sendMessage(new TextComponentTranslation("commands.bloodmagic.bind.success"));
+                    commandSender.sendMessage(new TextComponentTranslation("commands.bind.success"));
                 } else {
                     Binding binding = ((IBindable) held.getItem()).getBinding(held);
                     if (binding != null) {
                         held.getTagCompound().removeTag("binding");
-                        commandSender.sendMessage(new TextComponentTranslation("commands.bloodmagic.bind.remove.success"));
+                        commandSender.sendMessage(new TextComponentTranslation("commands.bind.remove.success"));
                     }
                 }
             }
         } catch (PlayerNotFoundException e) {
-            commandSender.sendMessage(new TextComponentTranslation(TextHelper.localizeEffect("commands.bloodmagic.error.404")));
+            commandSender.sendMessage(new TextComponentTranslation(TextHelper.localizeEffect("commands.error.404")));
         }
     }
 

--- a/src/main/java/WayofTime/bloodmagic/command/sub/SubCommandNetwork.java
+++ b/src/main/java/WayofTime/bloodmagic/command/sub/SubCommandNetwork.java
@@ -23,7 +23,7 @@ public class SubCommandNetwork extends CommandBase {
 
     @Override
     public String getUsage(ICommandSender commandSender) {
-        return TextHelper.localizeEffect("commands.bloodmagic.network.usage");
+        return TextHelper.localizeEffect("commands.network.usage");
     }
 
     @Override
@@ -50,12 +50,12 @@ public class SubCommandNetwork extends CommandBase {
                 CommandBloodMagic.displayErrorString(commandSender, e.getLocalizedMessage());
             }
         } else {
-            CommandBloodMagic.displayErrorString(commandSender, "commands.bloodmagic.error.arg.missing");
+            CommandBloodMagic.displayErrorString(commandSender, "commands.error.arg.missing");
         }
     }
 
     private enum ValidCommands {
-        SYPHON("commands.bloodmagic.network.syphon.help") {
+        SYPHON("commands.network.syphon.help") {
             @Override
             public void run(EntityPlayer player, ICommandSender sender, boolean displayHelp, String... args) {
                 if (displayHelp) {
@@ -67,16 +67,16 @@ public class SubCommandNetwork extends CommandBase {
                     if (Utils.isInteger(args[2])) {
                         int amount = Integer.parseInt(args[2]);
                         NetworkHelper.getSoulNetwork(player).syphonAndDamage(player, amount);
-                        CommandBloodMagic.displaySuccessString(sender, "commands.bloodmagic.network.syphon.success", amount, player.getDisplayName().getFormattedText());
+                        CommandBloodMagic.displaySuccessString(sender, "commands.network.syphon.success", amount, player.getDisplayName().getFormattedText());
                     } else {
-                        CommandBloodMagic.displayErrorString(sender, "commands.bloodmagic.error.arg.invalid");
+                        CommandBloodMagic.displayErrorString(sender, "commands.error.arg.invalid");
                     }
                 } else {
-                    CommandBloodMagic.displayErrorString(sender, "commands.bloodmagic.error.arg.missing");
+                    CommandBloodMagic.displayErrorString(sender, "commands.error.arg.missing");
                 }
             }
         },
-        ADD("commands.bloodmagic.network.add.help") {
+        ADD("commands.network.add.help") {
             @Override
             public void run(EntityPlayer player, ICommandSender sender, boolean displayHelp, String... args) {
                 if (displayHelp) {
@@ -90,16 +90,16 @@ public class SubCommandNetwork extends CommandBase {
                     if (Utils.isInteger(args[2])) {
                         int amount = Integer.parseInt(args[2]);
                         int maxOrb = NetworkHelper.getMaximumForTier(network.getOrbTier());
-                        CommandBloodMagic.displaySuccessString(sender, "commands.bloodmagic.network.add.success", network.add(amount, maxOrb), player.getDisplayName().getFormattedText());
+                        CommandBloodMagic.displaySuccessString(sender, "commands.network.add.success", network.add(amount, maxOrb), player.getDisplayName().getFormattedText());
                     } else {
-                        CommandBloodMagic.displayErrorString(sender, "commands.bloodmagic.error.arg.invalid");
+                        CommandBloodMagic.displayErrorString(sender, "commands.error.arg.invalid");
                     }
                 } else {
-                    CommandBloodMagic.displayErrorString(sender, "commands.bloodmagic.error.arg.missing");
+                    CommandBloodMagic.displayErrorString(sender, "commands.error.arg.missing");
                 }
             }
         },
-        SET("commands.bloodmagic.network.set.help") {
+        SET("commands.network.set.help") {
             @Override
             public void run(EntityPlayer player, ICommandSender sender, boolean displayHelp, String... args) {
                 if (displayHelp) {
@@ -113,16 +113,16 @@ public class SubCommandNetwork extends CommandBase {
                     if (Utils.isInteger(args[2])) {
                         int amount = Integer.parseInt(args[2]);
                         network.setCurrentEssence(amount);
-                        CommandBloodMagic.displaySuccessString(sender, "commands.bloodmagic.network.set.success", player.getDisplayName().getFormattedText(), amount);
+                        CommandBloodMagic.displaySuccessString(sender, "commands.network.set.success", player.getDisplayName().getFormattedText(), amount);
                     } else {
-                        CommandBloodMagic.displayErrorString(sender, "commands.bloodmagic.error.arg.invalid");
+                        CommandBloodMagic.displayErrorString(sender, "commands.error.arg.invalid");
                     }
                 } else {
-                    CommandBloodMagic.displayErrorString(sender, "commands.bloodmagic.error.arg.missing");
+                    CommandBloodMagic.displayErrorString(sender, "commands.error.arg.missing");
                 }
             }
         },
-        GET("commands.bloodmagic.network.get.help") {
+        GET("commands.network.get.help") {
             @Override
             public void run(EntityPlayer player, ICommandSender sender, boolean displayHelp, String... args) {
                 if (displayHelp) {
@@ -137,7 +137,7 @@ public class SubCommandNetwork extends CommandBase {
 
             }
         },
-        FILL("commands.bloodmagic.network.fill.help") {
+        FILL("commands.network.fill.help") {
             @Override
             public void run(EntityPlayer player, ICommandSender sender, boolean displayHelp, String... args) {
                 if (displayHelp) {
@@ -149,11 +149,11 @@ public class SubCommandNetwork extends CommandBase {
 
                 if (args.length > 1) {
                     network.setCurrentEssence(Integer.MAX_VALUE);
-                    CommandBloodMagic.displaySuccessString(sender, "commands.bloodmagic.network.fill.success", player.getDisplayName().getFormattedText());
+                    CommandBloodMagic.displaySuccessString(sender, "commands.network.fill.success", player.getDisplayName().getFormattedText());
                 }
             }
         },
-        CAP("commands.bloodmagic.network.cap.help") {
+        CAP("commands.network.cap.help") {
             @Override
             public void run(EntityPlayer player, ICommandSender sender, boolean displayHelp, String... args) {
                 if (displayHelp) {
@@ -166,7 +166,7 @@ public class SubCommandNetwork extends CommandBase {
                 if (args.length > 1) {
                     int maxOrb = NetworkHelper.getMaximumForTier(network.getOrbTier());
                     network.setCurrentEssence(maxOrb);
-                    CommandBloodMagic.displaySuccessString(sender, "commands.bloodmagic.network.cap.success", player.getDisplayName().getFormattedText());
+                    CommandBloodMagic.displaySuccessString(sender, "commands.network.cap.success", player.getDisplayName().getFormattedText());
                 }
             }
         },;

--- a/src/main/java/WayofTime/bloodmagic/command/sub/SubCommandOrb.java
+++ b/src/main/java/WayofTime/bloodmagic/command/sub/SubCommandOrb.java
@@ -24,7 +24,7 @@ public class SubCommandOrb extends CommandBase {
 
     @Override
     public String getUsage(ICommandSender commandSender) {
-        return TextHelper.localizeEffect("commands.bloodmagic.orb.usage");
+        return TextHelper.localizeEffect("commands.orb.usage");
     }
 
     @Override
@@ -63,12 +63,12 @@ public class SubCommandOrb extends CommandBase {
                                 if (Utils.isInteger(args[2])) {
                                     int amount = Integer.parseInt(args[2]);
                                     network.setOrbTier(amount);
-                                    CommandBloodMagic.displaySuccessString(commandSender, "commands.bloodmagic.success");
+                                    CommandBloodMagic.displaySuccessString(commandSender, "commands.success");
                                 } else {
-                                    CommandBloodMagic.displayErrorString(commandSender, "commands.bloodmagic.error.arg.invalid");
+                                    CommandBloodMagic.displayErrorString(commandSender, "commands.error.arg.invalid");
                                 }
                             } else {
-                                CommandBloodMagic.displayErrorString(commandSender, "commands.bloodmagic.error.arg.missing");
+                                CommandBloodMagic.displayErrorString(commandSender, "commands.error.arg.missing");
                             }
 
                             break;
@@ -86,17 +86,17 @@ public class SubCommandOrb extends CommandBase {
                         }
                     }
                 } catch (IllegalArgumentException e) {
-                    CommandBloodMagic.displayErrorString(commandSender, "commands.bloodmagic.error.404");
+                    CommandBloodMagic.displayErrorString(commandSender, "commands.error.404");
                 }
             } catch (PlayerNotFoundException e) {
-                CommandBloodMagic.displayErrorString(commandSender, "commands.bloodmagic.error.404");
+                CommandBloodMagic.displayErrorString(commandSender, "commands.error.404");
             }
         }
     }
 
     private enum ValidCommands {
-        SET("commands.bloodmagic.orb.set.help"),
-        GET("commands.bloodmagic.orb.get.help");
+        SET("commands.orb.set.help"),
+        GET("commands.orb.get.help");
 
         public String help;
 

--- a/src/main/java/WayofTime/bloodmagic/entity/mob/EntityMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/entity/mob/EntityMimic.java
@@ -4,6 +4,7 @@ import WayofTime.bloodmagic.block.BlockMimic;
 import WayofTime.bloodmagic.core.RegistrarBloodMagicBlocks;
 import WayofTime.bloodmagic.entity.ai.EntityAIMimicReform;
 import WayofTime.bloodmagic.tile.TileMimic;
+import WayofTime.bloodmagic.util.Serializer;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
@@ -12,6 +13,7 @@ import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.*;
 import net.minecraft.entity.monster.EntityIronGolem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.MobEffects;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.EntityEquipmentSlot;
@@ -39,6 +41,7 @@ public class EntityMimic extends EntityDemonBase {
     public boolean dropItemsOnBreak = true;
     public NBTTagCompound tileTag = new NBTTagCompound();
     public int metaOfReplacedBlock = 0;
+	public IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();
     public int playerCheckRadius = 5;
 
     public EntityMimic(World worldIn) {
@@ -67,6 +70,7 @@ public class EntityMimic extends EntityDemonBase {
         tag.setTag("tileTag", tileTag);
         tag.setInteger("metaOfReplacedBlock", metaOfReplacedBlock);
         tag.setInteger("playerCheckRadius", playerCheckRadius);
+		tag.setString("stateOfReplacedBlock", stateOfReplacedBlock.toString());
     }
 
     @Override
@@ -77,6 +81,7 @@ public class EntityMimic extends EntityDemonBase {
         tileTag = tag.getCompoundTag("tileTag");
         metaOfReplacedBlock = tag.getInteger("metaOfReplacedBlock");
         playerCheckRadius = tag.getInteger("playerCheckRadius");
+		stateOfReplacedBlock = Serializer.parseState(tag.getString("stateOfReplacedBlock"));
     }
 
     public ItemStack getMimicItemStack() {
@@ -88,7 +93,7 @@ public class EntityMimic extends EntityDemonBase {
     }
 
     public boolean spawnHeldBlockOnDeath(World world, BlockPos pos) {
-        return world.isAirBlock(pos) && TileMimic.replaceMimicWithBlockActual(world, pos, getMimicItemStack(), tileTag, metaOfReplacedBlock);
+        return world.isAirBlock(pos) && TileMimic.replaceMimicWithBlockActual(world, pos, getMimicItemStack(), tileTag, stateOfReplacedBlock);
     }
 
     public boolean spawnMimicBlockAtPosition(World world, BlockPos pos) {
@@ -98,7 +103,8 @@ public class EntityMimic extends EntityDemonBase {
             TileEntity tile = world.getTileEntity(pos);
             if (tile instanceof TileMimic) {
                 TileMimic mimic = (TileMimic) tile;
-                mimic.metaOfReplacedBlock = metaOfReplacedBlock;
+                //mimic.metaOfReplacedBlock = metaOfReplacedBlock;
+				mimic.setReplacedState(this.stateOfReplacedBlock);
                 mimic.tileTag = tileTag;
                 mimic.setInventorySlotContents(0, getMimicItemStack());
                 mimic.dropItemsOnBreak = dropItemsOnBreak;
@@ -111,11 +117,12 @@ public class EntityMimic extends EntityDemonBase {
         return false;
     }
 
-    public void initializeMimic(ItemStack heldStack, NBTTagCompound tileTag, boolean dropItemsOnBreak, int metaOfReplacedBlock, int playerCheckRadius, BlockPos homePosition) {
+    public void initializeMimic(ItemStack heldStack, NBTTagCompound tileTag, boolean dropItemsOnBreak, IBlockState stateOfReplacedBlock, int playerCheckRadius, BlockPos homePosition) {
         this.setMimicItemStack(heldStack);
         this.tileTag = tileTag;
         this.dropItemsOnBreak = dropItemsOnBreak;
-        this.metaOfReplacedBlock = metaOfReplacedBlock;
+        //this.metaOfReplacedBlock = metaOfReplacedBlock;
+		this.stateOfReplacedBlock = stateOfReplacedBlock;
         this.playerCheckRadius = playerCheckRadius;
         this.setHomePosAndDistance(homePosition, 2); //TODO: Save this.
     }

--- a/src/main/java/WayofTime/bloodmagic/gson/Serializers.java
+++ b/src/main/java/WayofTime/bloodmagic/gson/Serializers.java
@@ -33,7 +33,7 @@ public class Serializers {
 
         @Override
         public EnumDemonWillType copyValue(EnumDemonWillType value) {
-            return EnumDemonWillType.valueOf(value.name());
+            return EnumDemonWillType.valueOf(value.getName());
         }
     };
 

--- a/src/main/java/WayofTime/bloodmagic/item/block/ItemBlockMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/item/block/ItemBlockMimic.java
@@ -49,7 +49,6 @@ public class ItemBlockMimic extends ItemBlockEnum
 			IBlockState replacedBlockstate = world.getBlockState(pos);
 			Block replacedBlock = replacedBlockstate.getBlock();
 			ItemStack replacedStack = replacedBlock.getItem(world, pos, replacedBlockstate);
-			int replacedMeta = replacedBlock.getMetaFromState(replacedBlockstate);
 			
 			//Get the state for the mimic
 			IBlockState mimicBlockstate = this.getBlock().getStateFromMeta(stack.getMetadata());
@@ -95,9 +94,8 @@ public class ItemBlockMimic extends ItemBlockEnum
 			if (tile instanceof TileMimic)
 			{
 				TileMimic mimic = (TileMimic) tile;
-				mimic.metaOfReplacedBlock = replacedMeta;
-				mimic.stateOfReplacedBlock = replacedBlockstate;
 				mimic.tileTag = tileTag;
+				mimic.setReplacedState(replacedBlockstate);
 				mimic.setInventorySlotContents(0, replacedStack);
 				mimic.refreshTileEntity();
 

--- a/src/main/java/WayofTime/bloodmagic/item/block/ItemBlockMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/item/block/ItemBlockMimic.java
@@ -1,0 +1,147 @@
+package WayofTime.bloodmagic.item.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.SoundType;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityChest;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import WayofTime.bloodmagic.block.BlockMimic;
+import WayofTime.bloodmagic.tile.TileMimic;
+import WayofTime.bloodmagic.block.base.BlockEnum;
+import WayofTime.bloodmagic.item.block.base.ItemBlockEnum;
+
+import WayofTime.bloodmagic.util.ChatUtil;
+
+public class ItemBlockMimic extends ItemBlockEnum
+{
+    public ItemBlockMimic(BlockEnum block)
+    {
+        super(block);
+        setHasSubtypes(true);
+    }
+
+    @Override
+    //Old: public EnumActionResult onItemUse(ItemStack stack, EntityPlayer player, EnumHand hand, World world, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ)
+	public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) 
+    {
+		ItemStack stack = player.getHeldItem(hand);
+		
+		//If not sneaking, do normal item use
+        if (!player.isSneaking())
+        {
+            return super.onItemUse(player, world, pos, hand, facing, hitX, hitY, hitZ);
+        }
+		
+		//IF sneaking and player has permission, replace the targeted block
+        if (player.canPlayerEdit(pos, facing, stack))
+        {
+			//Store information about the block being replaced and its appropriate itemstack
+			IBlockState replacedBlockstate = world.getBlockState(pos);
+			Block replacedBlock = replacedBlockstate.getBlock();
+			ItemStack replacedStack = replacedBlock.getItem(world, pos, replacedBlockstate);
+			int replacedMeta = replacedBlock.getMetaFromState(replacedBlockstate);
+			
+			//Get the state for the mimic
+			IBlockState mimicBlockstate = this.getBlock().getStateFromMeta(stack.getMetadata());
+			
+			
+			//Check if the block can be replaced
+			
+            if (!canReplaceBlock(world, pos, replacedBlockstate))
+            {
+                return super.onItemUse(player, world, pos, hand, facing, hitX, hitY, hitZ);
+            }
+
+			//Check if the tile entity, if any, can be replaced
+			TileEntity tileReplaced = world.getTileEntity(pos);
+            if (!canReplaceTile(tileReplaced))
+            {
+                return EnumActionResult.FAIL;
+            }
+			
+			//If tile can be replaced, store info about the tile
+			NBTTagCompound tileTag = getTagFromTileEntity(tileReplaced);
+            if (tileReplaced != null)
+            {
+                NBTTagCompound voidTag = new NBTTagCompound();
+                voidTag.setInteger("x", pos.getX());
+                voidTag.setInteger("y", pos.getY());
+                voidTag.setInteger("z", pos.getZ());
+                tileReplaced.readFromNBT(voidTag);
+            }
+			
+			//Remove one item from stack
+			stack.shrink(1);
+			
+			
+			//Replace the block
+			world.setBlockState(pos, mimicBlockstate, 3);
+			//Make placing sound
+			SoundType soundtype = this.block.getSoundType();
+				world.playSound(player, pos, soundtype.getPlaceSound(), SoundCategory.BLOCKS, (soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F);
+			
+			//Replace the tile entity
+			TileEntity tile = world.getTileEntity(pos);
+			if (tile instanceof TileMimic)
+			{
+				TileMimic mimic = (TileMimic) tile;
+				mimic.metaOfReplacedBlock = replacedMeta;
+				mimic.stateOfReplacedBlock = replacedBlockstate;
+				mimic.tileTag = tileTag;
+				mimic.setInventorySlotContents(0, replacedStack);
+				mimic.refreshTileEntity();
+
+				if (player.capabilities.isCreativeMode)
+				{
+					mimic.dropItemsOnBreak = false;
+				}
+			}
+			return EnumActionResult.SUCCESS;
+		} 
+
+        return EnumActionResult.FAIL;
+
+    }
+	
+    public boolean canReplaceTile(TileEntity tile)
+    {
+        if (tile instanceof TileEntityChest)
+        {
+            return true;
+        }
+
+        return tile == null;
+    }
+
+    public boolean canReplaceBlock(World world, BlockPos pos, IBlockState state) {
+        return state.getBlockHardness(world, pos) != -1.0F;
+    }
+
+    public NBTTagCompound getTagFromTileEntity(TileEntity tile)
+    {
+        NBTTagCompound tag = new NBTTagCompound();
+
+        if (tile != null)
+        {
+            return tile.writeToNBT(tag);
+        }
+
+        return tag;
+    }
+
+    @Override
+    public int getMetadata(int meta)
+    {
+        return meta;
+    }
+}

--- a/src/main/java/WayofTime/bloodmagic/ritual/types/RitualMagnetic.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/types/RitualMagnetic.java
@@ -13,7 +13,6 @@ import net.minecraftforge.oredict.OreDictionary;
 
 import java.util.function.Consumer;
 
-@RitualRegister("magnetism")
 public class RitualMagnetic extends Ritual {
     public static final String PLACEMENT_RANGE = "placementRange";
     //    public static final String SEARCH_RANGE = "searchRange";

--- a/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
@@ -41,8 +41,7 @@ public class TileMimic extends TileInventory implements ITickable {
     public boolean dropItemsOnBreak = true;
     public NBTTagCompound tileTag = new NBTTagCompound();
     public TileEntity mimicedTile = null;
-    public int metaOfReplacedBlock = 0;
-	public IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();
+	IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();
 	
     public int playerCheckRadius = 5;
     public int potionSpawnRadius = 5;
@@ -258,7 +257,6 @@ public class TileMimic extends TileInventory implements ITickable {
 
         dropItemsOnBreak = tag.getBoolean("dropItemsOnBreak");
         tileTag = tag.getCompoundTag("tileTag");
-        //metaOfReplacedBlock = tag.getInteger("metaOfReplacedBlock");
         stateOfReplacedBlock = Serializer.parseState(tag.getString("stateOfReplacedBlock"));
 		mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, stateOfReplacedBlock);
         playerCheckRadius = tag.getInteger("playerCheckRadius");
@@ -272,7 +270,6 @@ public class TileMimic extends TileInventory implements ITickable {
 
         tag.setBoolean("dropItemsOnBreak", dropItemsOnBreak);
         tag.setTag("tileTag", tileTag);
-        //tag.setInteger("metaOfReplacedBlock", metaOfReplacedBlock);
         tag.setInteger("playerCheckRadius", playerCheckRadius);
         tag.setInteger("potionSpawnRadius", potionSpawnRadius);
         tag.setInteger("potionSpawnInterval", potionSpawnInterval);
@@ -314,27 +311,6 @@ public class TileMimic extends TileInventory implements ITickable {
         BlockPos pos = mimic.getPos();
 
         replaceMimicWithBlockActual(world, pos, mimic.getStackInSlot(0), mimic.tileTag, mimic.stateOfReplacedBlock);
-    }
-
-	@Deprecated
-    public static boolean replaceMimicWithBlockActual(World world, BlockPos pos, ItemStack stack, NBTTagCompound tileTag, int replacedMeta) {
-        if (!stack.isEmpty() && stack.getItem() instanceof ItemBlock) {
-            Block block = ((ItemBlock) stack.getItem()).getBlock();
-            IBlockState state = block.getStateFromMeta(replacedMeta);
-            if (world.setBlockState(pos, state, 3)) {
-                TileEntity tile = world.getTileEntity(pos);
-                if (tile != null) {
-                    tileTag.setInteger("x", pos.getX());
-                    tileTag.setInteger("y", pos.getY());
-                    tileTag.setInteger("z", pos.getZ());
-                    tile.readFromNBT(tileTag);
-                }
-
-                return true;
-            }
-        }
-
-        return false;
     }
 	
     public static boolean replaceMimicWithBlockActual(World world, BlockPos pos, ItemStack stack, NBTTagCompound tileTag, IBlockState replacementState) {

--- a/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
@@ -6,10 +6,12 @@ import WayofTime.bloodmagic.core.RegistrarBloodMagicItems;
 import WayofTime.bloodmagic.entity.mob.EntityMimic;
 import WayofTime.bloodmagic.util.ChatUtil;
 import WayofTime.bloodmagic.util.Utils;
+import WayofTime.bloodmagic.util.Serializer;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityPotion;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryHelper;
@@ -40,7 +42,8 @@ public class TileMimic extends TileInventory implements ITickable {
     public NBTTagCompound tileTag = new NBTTagCompound();
     public TileEntity mimicedTile = null;
     public int metaOfReplacedBlock = 0;
-
+	public IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();
+	
     public int playerCheckRadius = 5;
     public int potionSpawnRadius = 5;
     public int potionSpawnInterval = 40;
@@ -134,6 +137,13 @@ public class TileMimic extends TileInventory implements ITickable {
             return false;
 
         Utils.insertItemToTile(this, player, 0);
+		ItemStack stack = getStackInSlot(0);
+		if(stateOfReplacedBlock == Blocks.AIR.getDefaultState()) {
+			if (!stack.isEmpty() && stack.getItem() instanceof ItemBlock) {
+				Block block = ((ItemBlock) stack.getItem()).getBlock();
+				stateOfReplacedBlock = block.getDefaultState();
+			}
+		}
         this.refreshTileEntity();
 
         if (player.capabilities.isCreativeMode) {
@@ -220,7 +230,7 @@ public class TileMimic extends TileInventory implements ITickable {
         EntityMimic mimicEntity = new EntityMimic(getWorld());
         mimicEntity.setPosition(pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5);
 
-        mimicEntity.initializeMimic(getStackInSlot(0), tileTag, dropItemsOnBreak, metaOfReplacedBlock, playerCheckRadius, pos);
+        mimicEntity.initializeMimic(getStackInSlot(0), tileTag, dropItemsOnBreak, stateOfReplacedBlock, playerCheckRadius, pos);
         tileTag = null;
         mimicedTile = null;
         this.setInventorySlotContents(0, ItemStack.EMPTY);
@@ -239,7 +249,7 @@ public class TileMimic extends TileInventory implements ITickable {
         if (mimicedTile != null) {
             dropMimicedTileInventory();
         }
-        mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, metaOfReplacedBlock);
+        mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, stateOfReplacedBlock);
     }
 
     @Override
@@ -248,8 +258,9 @@ public class TileMimic extends TileInventory implements ITickable {
 
         dropItemsOnBreak = tag.getBoolean("dropItemsOnBreak");
         tileTag = tag.getCompoundTag("tileTag");
-        metaOfReplacedBlock = tag.getInteger("metaOfReplacedBlock");
-        mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, metaOfReplacedBlock);
+        //metaOfReplacedBlock = tag.getInteger("metaOfReplacedBlock");
+        stateOfReplacedBlock = Serializer.parseState(tag.getString("stateOfReplacedBlock"));
+		mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, stateOfReplacedBlock);
         playerCheckRadius = tag.getInteger("playerCheckRadius");
         potionSpawnRadius = tag.getInteger("potionSpawnRadius");
         potionSpawnInterval = Math.max(1, tag.getInteger("potionSpawnInterval"));
@@ -261,10 +272,11 @@ public class TileMimic extends TileInventory implements ITickable {
 
         tag.setBoolean("dropItemsOnBreak", dropItemsOnBreak);
         tag.setTag("tileTag", tileTag);
-        tag.setInteger("metaOfReplacedBlock", metaOfReplacedBlock);
+        //tag.setInteger("metaOfReplacedBlock", metaOfReplacedBlock);
         tag.setInteger("playerCheckRadius", playerCheckRadius);
         tag.setInteger("potionSpawnRadius", potionSpawnRadius);
         tag.setInteger("potionSpawnInterval", potionSpawnInterval);
+		tag.setString("stateOfReplacedBlock",stateOfReplacedBlock.toString());
 
         return tag;
     }
@@ -284,6 +296,14 @@ public class TileMimic extends TileInventory implements ITickable {
         }
     }
 
+	public IBlockState getReplacedState() {
+		return stateOfReplacedBlock;
+	}
+	
+	public void setReplacedState(IBlockState state) {
+		stateOfReplacedBlock = state;
+	}
+	
     @Override
     public boolean isItemValidForSlot(int slot, ItemStack itemstack) {
         return slot == 0 && dropItemsOnBreak;
@@ -293,9 +313,10 @@ public class TileMimic extends TileInventory implements ITickable {
         World world = mimic.getWorld();
         BlockPos pos = mimic.getPos();
 
-        replaceMimicWithBlockActual(world, pos, mimic.getStackInSlot(0), mimic.tileTag, mimic.metaOfReplacedBlock);
+        replaceMimicWithBlockActual(world, pos, mimic.getStackInSlot(0), mimic.tileTag, mimic.stateOfReplacedBlock);
     }
 
+	@Deprecated
     public static boolean replaceMimicWithBlockActual(World world, BlockPos pos, ItemStack stack, NBTTagCompound tileTag, int replacedMeta) {
         if (!stack.isEmpty() && stack.getItem() instanceof ItemBlock) {
             Block block = ((ItemBlock) stack.getItem()).getBlock();
@@ -315,12 +336,32 @@ public class TileMimic extends TileInventory implements ITickable {
 
         return false;
     }
-
-    @Nullable
-    public static TileEntity getTileFromStackWithTag(World world, BlockPos pos, ItemStack stack, @Nullable NBTTagCompound tag, int replacementMeta) {
+	
+    public static boolean replaceMimicWithBlockActual(World world, BlockPos pos, ItemStack stack, NBTTagCompound tileTag, IBlockState replacementState) {
         if (!stack.isEmpty() && stack.getItem() instanceof ItemBlock) {
             Block block = ((ItemBlock) stack.getItem()).getBlock();
-            IBlockState state = block.getStateFromMeta(stack.getItemDamage());
+            IBlockState state = replacementState;
+            if (world.setBlockState(pos, state, 3)) {
+                TileEntity tile = world.getTileEntity(pos);
+                if (tile != null) {
+                    tileTag.setInteger("x", pos.getX());
+                    tileTag.setInteger("y", pos.getY());
+                    tileTag.setInteger("z", pos.getZ());
+                    tile.readFromNBT(tileTag);
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Nullable
+    public static TileEntity getTileFromStackWithTag(World world, BlockPos pos, ItemStack stack, @Nullable NBTTagCompound tag, IBlockState replacementState) {
+        if (!stack.isEmpty() && stack.getItem() instanceof ItemBlock) {
+            Block block = ((ItemBlock) stack.getItem()).getBlock();
+            IBlockState state = replacementState;
             if (block.hasTileEntity(state)) {
                 TileEntity tile = block.createTileEntity(world, state);
 
@@ -338,7 +379,7 @@ public class TileMimic extends TileInventory implements ITickable {
                 tile.setWorld(world);
 
                 try {
-                    _blockMetadata.setInt(tile, replacementMeta);
+                    _blockMetadata.setInt(tile, block.getMetaFromState(replacementState));
                 } catch (IllegalArgumentException | IllegalAccessException e) {
                     e.printStackTrace();
                 }

--- a/src/main/java/WayofTime/bloodmagic/util/Serializer.java
+++ b/src/main/java/WayofTime/bloodmagic/util/Serializer.java
@@ -1,0 +1,39 @@
+package WayofTime.bloodmagic.util;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockStateContainer;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+
+public class Serializer
+{
+	//This is a great class name because the one and only function right now deserializes stuff.
+	//TehNut made me do it.
+    public static IBlockState parseState(String blockInfo)
+    {
+        String[] split = blockInfo.split("\\[");
+        split[1] = split[1].substring(0, split[1].lastIndexOf("]")); // Make sure brackets are removed from state
+
+        Block block = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(split[0])); // Find the block
+        if (block == Blocks.AIR)
+            return Blocks.AIR.getDefaultState(); // The block is air, so we're looking at invalid data
+
+        BlockStateContainer blockState = block.getBlockState();
+        IBlockState returnState = blockState.getBaseState();
+
+        // Force our values into the state
+        String[] stateValues = split[1].split(","); // Splits up each value
+        for (String value : stateValues)
+        {
+            String[] valueSplit = value.split("="); // Separates property and value
+            IProperty property = blockState.getProperty(valueSplit[0]);
+            if (property != null)
+                returnState = returnState.withProperty(property, (Comparable) property.parseValue(valueSplit[1]).get()); // Force the property into the state
+        }
+
+        return returnState;
+    }
+}

--- a/src/main/resources/assets/bloodmagic/lang/en_US.lang
+++ b/src/main/resources/assets/bloodmagic/lang/en_US.lang
@@ -794,60 +794,60 @@ entity.bloodmagic.SentientSpecter.name=Sentient Specter
 entity.bloodmagic.Mimic.name=Mimic
 
 # Commands
-commands.bloodmagic.error.arg.invalid=Invalid arguments
-commands.bloodmagic.error.arg.missing=Not enough arguments
-commands.bloodmagic.error.arg.player.missing=You must specify which player you wish to perform this action on.
-commands.bloodmagic.error.404=Command not found!
-commands.bloodmagic.error.unknown=Unknown command!
-commands.bloodmagic.error.perm=You do not have permission to use this command.
+commands.error.arg.invalid=Invalid arguments
+commands.error.arg.missing=Not enough arguments
+commands.error.arg.player.missing=You must specify which player you wish to perform this action on.
+commands.error.404=Command not found!
+commands.error.unknown=Unknown command!
+commands.error.perm=You do not have permission to use this command.
 
-commands.bloodmagic.success=Executed successfully
+commands.success=Executed successfully
 
-commands.bloodmagic.format.help=%s - %s
-commands.bloodmagic.format.error=%s - %s
+commands.format.help=%s - %s
+commands.format.error=%s - %s
 
-commands.bloodmagic.help.usage=/bloodmagic help
-commands.bloodmagic.help.help=Displays the help information for the "/bloodmagic" command.
+commands.help.usage=/bloodmagic help
+commands.help.help=Displays the help information for the "/bloodmagic" command.
 
-commands.bloodmagic.network.usage=/bloodmagic network [syphon|add|get|fill|cap] player [amount]
-commands.bloodmagic.network.help=LP network utilities
-commands.bloodmagic.network.syphon.help=Removes the given amount of LP from the given player's LP network.
-commands.bloodmagic.network.syphon.success=Successfully syphoned %d LP from %s.
-commands.bloodmagic.network.add.help=Adds the given amount of LP to the given player's LP network. Follows standard LP gain rules.
-commands.bloodmagic.network.add.success=Successfully added %d LP to %s's LP network.
-commands.bloodmagic.network.set.help=Sets the given player's LP to the given amount.
-commands.bloodmagic.network.set.success=Successfully set %s's LP network to %d LP.
-commands.bloodmagic.network.get.help=Returns the amount of LP in the given player's LP network.
-commands.bloodmagic.network.fill.help=Fills the given player's LP network to %d.
-commands.bloodmagic.network.fill.success=Successfully filled %s's LP network.
-commands.bloodmagic.network.cap.help=Fills the given player's LP network to the max that their highest Blood Orb can store.
-commands.bloodmagic.network.cap.success=Successfully capped off %s's LP network.
+commands.network.usage=/bloodmagic network [syphon|add|get|fill|cap] player [amount]
+commands.network.help=LP network utilities
+commands.network.syphon.help=Removes the given amount of LP from the given player's LP network.
+commands.network.syphon.success=Successfully syphoned %d LP from %s.
+commands.network.add.help=Adds the given amount of LP to the given player's LP network. Follows standard LP gain rules.
+commands.network.add.success=Successfully added %d LP to %s's LP network.
+commands.network.set.help=Sets the given player's LP to the given amount.
+commands.network.set.success=Successfully set %s's LP network to %d LP.
+commands.network.get.help=Returns the amount of LP in the given player's LP network.
+commands.network.fill.help=Fills the given player's LP network to %d.
+commands.network.fill.success=Successfully filled %s's LP network.
+commands.network.cap.help=Fills the given player's LP network to the max that their highest Blood Orb can store.
+commands.network.cap.success=Successfully capped off %s's LP network.
 
-commands.bloodmagic.bind.usage=/bloodmagic bind [true|false] [player]
-commands.bloodmagic.bind.help=Attempts to (un)bind the currently held item.
-commands.bloodmagic.bind.success=Binding successful
-commands.bloodmagic.bind.remove.success=Unbinding successful
+commands.bind.usage=/bloodmagic bind [true|false] [player]
+commands.bind.help=Attempts to (un)bind the currently held item.
+commands.bind.success=Binding successful
+commands.bind.remove.success=Unbinding successful
 
-commands.bloodmagic.orb.usage=/bloodmagic orb [set|get] player [tier]
-commands.bloodmagic.orb.help=Used to set or get the Player's max Blood Orb tier.
+commands.orb.usage=/bloodmagic orb [set|get] player [tier]
+commands.orb.help=Used to set or get the Player's max Blood Orb tier.
 
-commands.bloodmagic.bind.failed.noPlayer=There is no player specified
-commands.bloodmagic.bind.failed.alreadyBound=Item is already bound; use /unbind to unbind it
-commands.bloodmagic.bind.failed.notBindable=Item cannot be bound
-commands.bloodmagic.unbind.usage=/unbind
-commands.bloodmagic.unbind.success=Item successfully unbound!
-commands.bloodmagic.unbind.failed.notBindable=Item cannot be unbound
-commands.bloodmagic.soulnetwork.usage=/soulnetwork <player> <add|subtract|fill|empty|get> [amount]
-commands.bloodmagic.soulnetwork.add.success=Successfully added %dLP to %s's Soul Network!
-commands.bloodmagic.soulnetwork.subtract.success=Successfully subtracted %dLP from %s's Soul Network!
-commands.bloodmagic.soulnetwork.fill.success=Successfully filled %s's Soul Network!
-commands.bloodmagic.soulnetwork.empty.success=Successfully emptied %s's Soul Network!
-commands.bloodmagic.soulnetwork.get.success=There is %dLP in %s's Soul Network!
-commands.bloodmagic.soulnetwork.noPlayer=There is no player specified
-commands.bloodmagic.soulnetwork.noCommand=There is no command specified
-commands.bloodmagic.soulnetwork.notACommand=That is not a valid command
-commands.bloodmagic.soulnetwork.fillMax.success=Successfully filled %s's Soul Network to their orb max!
-commands.bloodmagic.soulnetwork.create.success=Successfully created %s's Soul Network (Orb tier: %d)
+commands.bind.failed.noPlayer=There is no player specified
+commands.bind.failed.alreadyBound=Item is already bound; use /unbind to unbind it
+commands.bind.failed.notBindable=Item cannot be bound
+commands.unbind.usage=/unbind
+commands.unbind.success=Item successfully unbound!
+commands.unbind.failed.notBindable=Item cannot be unbound
+commands.soulnetwork.usage=/soulnetwork <player> <add|subtract|fill|empty|get> [amount]
+commands.soulnetwork.add.success=Successfully added %dLP to %s's Soul Network!
+commands.soulnetwork.subtract.success=Successfully subtracted %dLP from %s's Soul Network!
+commands.soulnetwork.fill.success=Successfully filled %s's Soul Network!
+commands.soulnetwork.empty.success=Successfully emptied %s's Soul Network!
+commands.soulnetwork.get.success=There is %dLP in %s's Soul Network!
+commands.soulnetwork.noPlayer=There is no player specified
+commands.soulnetwork.noCommand=There is no command specified
+commands.soulnetwork.notACommand=That is not a valid command
+commands.soulnetwork.fillMax.success=Successfully filled %s's Soul Network to their orb max!
+commands.soulnetwork.create.success=Successfully created %s's Soul Network (Orb tier: %d)
 
 # GUI
 tile.bloodmagic.inputNode.name=Input Node

--- a/src/main/resources/assets/bloodmagic/lang/fr_FR.lang
+++ b/src/main/resources/assets/bloodmagic/lang/fr_FR.lang
@@ -552,62 +552,62 @@ secret.bloodmagic.bread.bloody=&r&cBloody Bread
 secret.bloodmagic.bread.bloody.desc=Only for &odire &r&7emergencies.
 
 # Commands
-commands.bloodmagic.error.arg.invalid=Invalid arguments
-commands.bloodmagic.error.arg.missing=Not enough arguments
-commands.bloodmagic.error.arg.player.missing=You must specify which player you wish to perform this action on.
-commands.bloodmagic.error.404=Command not found!
-commands.bloodmagic.error.unknown=Unknown command!
-commands.bloodmagic.error.perm=You do not have permission to use this command.
+commands.error.arg.invalid=Invalid arguments
+commands.error.arg.missing=Not enough arguments
+commands.error.arg.player.missing=You must specify which player you wish to perform this action on.
+commands.error.404=Command not found!
+commands.error.unknown=Unknown command!
+commands.error.perm=You do not have permission to use this command.
 
-commands.bloodmagic.success=Executed successfully
+commands.success=Executed successfully
 
-commands.bloodmagic.format.help=%s - %s
-commands.bloodmagic.format.error=%s - %s
+commands.format.help=%s - %s
+commands.format.error=%s - %s
 
-commands.bloodmagic.help.usage=/bloodmagic help
-commands.bloodmagic.help.help=Displays the help information for the "/bloodmagic" command.
+commands.help.usage=/bloodmagic help
+commands.help.help=Displays the help information for the "/bloodmagic" command.
 
-commands.bloodmagic.network.usage=/bloodmagic network [syphon|add|get|fill|cap] player [amount]
-commands.bloodmagic.network.help=LP network utilities
-commands.bloodmagic.network.syphon.help=Removes the given amount of LP from the given player's LP network.
-commands.bloodmagic.network.syphon.success=Successfully syphoned %d LP from %s.
-commands.bloodmagic.network.add.help=Adds the given amount of LP to the given player's LP network. Follows standard LP gain rules.
-commands.bloodmagic.network.add.success=Successfully added %d LP to %s's LP network.
-commands.bloodmagic.network.set.help=Sets the given player's LP to the given amount.
-commands.bloodmagic.network.set.success=Successfully set %s's LP network to %d LP.
-commands.bloodmagic.network.get.help=Returns the amount of LP in the given player's LP network.
-commands.bloodmagic.network.fill.help=Fills the given player's LP network to %d.
-commands.bloodmagic.network.fill.success=Successfully filled %s's LP network.
-commands.bloodmagic.network.cap.help=Fills the given player's LP network to the max that their highest Blood Orb can store.
-commands.bloodmagic.network.cap.success=Successfully capped off %s's LP network.
+commands.network.usage=/bloodmagic network [syphon|add|get|fill|cap] player [amount]
+commands.network.help=LP network utilities
+commands.network.syphon.help=Removes the given amount of LP from the given player's LP network.
+commands.network.syphon.success=Successfully syphoned %d LP from %s.
+commands.network.add.help=Adds the given amount of LP to the given player's LP network. Follows standard LP gain rules.
+commands.network.add.success=Successfully added %d LP to %s's LP network.
+commands.network.set.help=Sets the given player's LP to the given amount.
+commands.network.set.success=Successfully set %s's LP network to %d LP.
+commands.network.get.help=Returns the amount of LP in the given player's LP network.
+commands.network.fill.help=Fills the given player's LP network to %d.
+commands.network.fill.success=Successfully filled %s's LP network.
+commands.network.cap.help=Fills the given player's LP network to the max that their highest Blood Orb can store.
+commands.network.cap.success=Successfully capped off %s's LP network.
 
-commands.bloodmagic.bind.usage=/bloodmagic bind [true|false] [player]
-commands.bloodmagic.bind.help=Attempts to (un)bind the currently held item.
-commands.bloodmagic.bind.success=Binding successful
-commands.bloodmagic.bind.remove.success=Unbinding successful
+commands.bind.usage=/bloodmagic bind [true|false] [player]
+commands.bind.help=Attempts to (un)bind the currently held item.
+commands.bind.success=Binding successful
+commands.bind.remove.success=Unbinding successful
 
-commands.bloodmagic.orb.usage=/bloodmagic orb [set|get] player [tier]
-commands.bloodmagic.orb.help=Used to set or get the Player's max Blood Orb tier.
+commands.orb.usage=/bloodmagic orb [set|get] player [tier]
+commands.orb.help=Used to set or get the Player's max Blood Orb tier.
 
-commands.bloodmagic.bind.usage=/bind <player>
-commands.bloodmagic.bind.success=Item successfully bound!
-commands.bloodmagic.bind.failed.noPlayer=There is no player specified
-commands.bloodmagic.bind.failed.alreadyBound=Item is already bound; use /unbind to unbind it
-commands.bloodmagic.bind.failed.notBindable=Item cannot be bound
-commands.bloodmagic.unbind.usage=/unbind
-commands.bloodmagic.unbind.success=Item successfully unbound!
-commands.bloodmagic.unbind.failed.notBindable=Item cannot be unbound
-commands.bloodmagic.soulnetwork.usage=/soulnetwork <player> <add|subtract|fill|empty|get> [amount]
-commands.bloodmagic.soulnetwork.add.success=Successfully added %dLP to %s's Soul Network!
-commands.bloodmagic.soulnetwork.subtract.success=Successfully subtracted %dLP from %s's Soul Network!
-commands.bloodmagic.soulnetwork.fill.success=Successfully filled %s's Soul Network!
-commands.bloodmagic.soulnetwork.empty.success=Successfully emptied %s's Soul Network!
-commands.bloodmagic.soulnetwork.get.success=There is %dLP in %s's Soul Network!
-commands.bloodmagic.soulnetwork.noPlayer=There is no player specified
-commands.bloodmagic.soulnetwork.noCommand=There is no command specified
-commands.bloodmagic.soulnetwork.notACommand=That is not a valid command
-commands.bloodmagic.soulnetwork.fillMax.success=Successfully filled %s's Soul Network to their orb max!
-commands.bloodmagic.soulnetwork.create.success=Successfully created %s's Soul Network (Orb tier: %d)
+commands.bind.usage=/bind <player>
+commands.bind.success=Item successfully bound!
+commands.bind.failed.noPlayer=There is no player specified
+commands.bind.failed.alreadyBound=Item is already bound; use /unbind to unbind it
+commands.bind.failed.notBindable=Item cannot be bound
+commands.unbind.usage=/unbind
+commands.unbind.success=Item successfully unbound!
+commands.unbind.failed.notBindable=Item cannot be unbound
+commands.soulnetwork.usage=/soulnetwork <player> <add|subtract|fill|empty|get> [amount]
+commands.soulnetwork.add.success=Successfully added %dLP to %s's Soul Network!
+commands.soulnetwork.subtract.success=Successfully subtracted %dLP from %s's Soul Network!
+commands.soulnetwork.fill.success=Successfully filled %s's Soul Network!
+commands.soulnetwork.empty.success=Successfully emptied %s's Soul Network!
+commands.soulnetwork.get.success=There is %dLP in %s's Soul Network!
+commands.soulnetwork.noPlayer=There is no player specified
+commands.soulnetwork.noCommand=There is no command specified
+commands.soulnetwork.notACommand=That is not a valid command
+commands.soulnetwork.fillMax.success=Successfully filled %s's Soul Network to their orb max!
+commands.soulnetwork.create.success=Successfully created %s's Soul Network (Orb tier: %d)
 
 # Keybinds
 bloodmagic.keybind.openSigilHolding=Open Sigil of Holding

--- a/src/main/resources/assets/bloodmagic/lang/ja_JP.lang
+++ b/src/main/resources/assets/bloodmagic/lang/ja_JP.lang
@@ -785,62 +785,62 @@ entity.bloodmagic.SentientSpecter.name=理力の霊魂
 entity.bloodmagic.Mimic.name=ミミック
 
 # Commands
-commands.bloodmagic.error.arg.invalid=無効な引数です
-commands.bloodmagic.error.arg.missing=引数が足りません
-commands.bloodmagic.error.arg.player.missing=あなたは実行する対象プレイヤーを指定する必要があります。
-commands.bloodmagic.error.404=コマンドが見つかりません！
-commands.bloodmagic.error.unknown=未知のコマンドです！
-commands.bloodmagic.error.perm=このコマンドを実行する権限がありません。
+commands.error.arg.invalid=無効な引数です
+commands.error.arg.missing=引数が足りません
+commands.error.arg.player.missing=あなたは実行する対象プレイヤーを指定する必要があります。
+commands.error.404=コマンドが見つかりません！
+commands.error.unknown=未知のコマンドです！
+commands.error.perm=このコマンドを実行する権限がありません。
 
-commands.bloodmagic.success=正常に実行されました
+commands.success=正常に実行されました
 
-commands.bloodmagic.format.help=%s - %s
-commands.bloodmagic.format.error=%s - %s
+commands.format.help=%s - %s
+commands.format.error=%s - %s
 
-commands.bloodmagic.help.usage=/bloodmagic help
-commands.bloodmagic.help.help="/bloodmagic" コマンドでヘルプ情報が表示されます。
+commands.help.usage=/bloodmagic help
+commands.help.help="/bloodmagic" コマンドでヘルプ情報が表示されます。
 
-commands.bloodmagic.network.usage=/bloodmagic network [syphon|add|get|fill|cap] <プレイヤー> [量]
-commands.bloodmagic.network.help=LP ネットワークユーティリティ
-commands.bloodmagic.network.syphon.help=指定したプレイヤーのLPネットワークからLPを削減します
-commands.bloodmagic.network.syphon.success=%d LPだけ、%sのソウルネットワークを削減することに成功しました。
-commands.bloodmagic.network.add.help=指定されたプレイヤーのLPネットワークのLPを、LP増加ルールの範囲内で増加させます。
-commands.bloodmagic.network.add.success=%d LPだけ、%sのLPネットワークを増加させることに成功しました。
-commands.bloodmagic.network.set.help=指定したプレイヤーのLPを設定します。
-commands.bloodmagic.network.set.success=%sのLPネットワークを%d LPに設定することに成功しました。
-commands.bloodmagic.network.get.help=指定したプレイヤーのLPネットワークのLP量を返します。
-commands.bloodmagic.network.fill.help=指定したプレイヤーのLPネットワークを%d LPまで満たします。
-commands.bloodmagic.network.fill.success=%sのLPネットワークを最大まで付与することに成功しました。
-commands.bloodmagic.network.cap.help=プレイヤーが入手できる最高位のブラッドオーブで貯蔵可能な最大値のLPを付与します。
-commands.bloodmagic.network.cap.success=%sのLPネットワークの限界値までLPを付与することに成功しました。
+commands.network.usage=/bloodmagic network [syphon|add|get|fill|cap] <プレイヤー> [量]
+commands.network.help=LP ネットワークユーティリティ
+commands.network.syphon.help=指定したプレイヤーのLPネットワークからLPを削減します
+commands.network.syphon.success=%d LPだけ、%sのソウルネットワークを削減することに成功しました。
+commands.network.add.help=指定されたプレイヤーのLPネットワークのLPを、LP増加ルールの範囲内で増加させます。
+commands.network.add.success=%d LPだけ、%sのLPネットワークを増加させることに成功しました。
+commands.network.set.help=指定したプレイヤーのLPを設定します。
+commands.network.set.success=%sのLPネットワークを%d LPに設定することに成功しました。
+commands.network.get.help=指定したプレイヤーのLPネットワークのLP量を返します。
+commands.network.fill.help=指定したプレイヤーのLPネットワークを%d LPまで満たします。
+commands.network.fill.success=%sのLPネットワークを最大まで付与することに成功しました。
+commands.network.cap.help=プレイヤーが入手できる最高位のブラッドオーブで貯蔵可能な最大値のLPを付与します。
+commands.network.cap.success=%sのLPネットワークの限界値までLPを付与することに成功しました。
 
-commands.bloodmagic.bind.usage=/bloodmagic bind [true|false] [プレイヤー]
-commands.bloodmagic.bind.help=手に所持したアイテムを結合／分離します。
-commands.bloodmagic.bind.success=結合に成功しました
-commands.bloodmagic.bind.remove.success=分離に成功しました
+commands.bind.usage=/bloodmagic bind [true|false] [プレイヤー]
+commands.bind.help=手に所持したアイテムを結合／分離します。
+commands.bind.success=結合に成功しました
+commands.bind.remove.success=分離に成功しました
 
-commands.bloodmagic.orb.usage=/bloodmagic orb [set|get] <プレイヤー> [グレード]
-commands.bloodmagic.orb.help=対象プレイヤーのブラッドオーブのグレードの最大値を設定、取得するために使います。
+commands.orb.usage=/bloodmagic orb [set|get] <プレイヤー> [グレード]
+commands.orb.help=対象プレイヤーのブラッドオーブのグレードの最大値を設定、取得するために使います。
 
-commands.bloodmagic.bind.usage=/bind <プレイヤー>
-commands.bloodmagic.bind.success=アイテムの登録が成功しました！
-commands.bloodmagic.bind.failed.noPlayer=指定されたプレイヤーは存在しません
-commands.bloodmagic.bind.failed.alreadyBound=アイテムは既に登録済みです； /unbind コマンドで登録解除してください
-commands.bloodmagic.bind.failed.notBindable=アイテムの登録が出来ませんでした
-commands.bloodmagic.unbind.usage=/unbind
-commands.bloodmagic.unbind.success=アイテムの登録解除が成功しました！
-commands.bloodmagic.unbind.failed.notBindable=アイテムの登録解除が出来ませんでした
-commands.bloodmagic.soulnetwork.usage=/soulnetwork <プレイヤー> <add|subtract|fill|empty|get> [量]
-commands.bloodmagic.soulnetwork.add.success=%d LPだけ、%sのソウルネットワークを増加させることに成功しました！
-commands.bloodmagic.soulnetwork.subtract.success=%d LPだけ、%sのソウルネットワークを減少させることに成功しました！
-commands.bloodmagic.soulnetwork.fill.success=正常に%sのソウルネットワークを満たしました！
-commands.bloodmagic.soulnetwork.empty.success=正常に%sのソウルネットワークを空にしました！
-commands.bloodmagic.soulnetwork.get.success=%dだけ%sのソウルネットワークにはLPがあります！
-commands.bloodmagic.soulnetwork.noPlayer=指定されたプレイヤーは存在しません
-commands.bloodmagic.soulnetwork.noCommand=指定されたコマンドはありません
-commands.bloodmagic.soulnetwork.notACommand=有効なコマンドではありません
-commands.bloodmagic.soulnetwork.fillMax.success=正常に%sのソウルネットワークにオーブの最大値までLPを供給しました！
-commands.bloodmagic.soulnetwork.create.success=正常に%sのソウルネットワークを構築しました(オーブのグレード： %d)
+commands.bind.usage=/bind <プレイヤー>
+commands.bind.success=アイテムの登録が成功しました！
+commands.bind.failed.noPlayer=指定されたプレイヤーは存在しません
+commands.bind.failed.alreadyBound=アイテムは既に登録済みです； /unbind コマンドで登録解除してください
+commands.bind.failed.notBindable=アイテムの登録が出来ませんでした
+commands.unbind.usage=/unbind
+commands.unbind.success=アイテムの登録解除が成功しました！
+commands.unbind.failed.notBindable=アイテムの登録解除が出来ませんでした
+commands.soulnetwork.usage=/soulnetwork <プレイヤー> <add|subtract|fill|empty|get> [量]
+commands.soulnetwork.add.success=%d LPだけ、%sのソウルネットワークを増加させることに成功しました！
+commands.soulnetwork.subtract.success=%d LPだけ、%sのソウルネットワークを減少させることに成功しました！
+commands.soulnetwork.fill.success=正常に%sのソウルネットワークを満たしました！
+commands.soulnetwork.empty.success=正常に%sのソウルネットワークを空にしました！
+commands.soulnetwork.get.success=%dだけ%sのソウルネットワークにはLPがあります！
+commands.soulnetwork.noPlayer=指定されたプレイヤーは存在しません
+commands.soulnetwork.noCommand=指定されたコマンドはありません
+commands.soulnetwork.notACommand=有効なコマンドではありません
+commands.soulnetwork.fillMax.success=正常に%sのソウルネットワークにオーブの最大値までLPを供給しました！
+commands.soulnetwork.create.success=正常に%sのソウルネットワークを構築しました(オーブのグレード： %d)
 
 # GUI
 tile.bloodmagic.inputNode.name=入力ノード

--- a/src/main/resources/assets/bloodmagic/lang/zh_CN.lang
+++ b/src/main/resources/assets/bloodmagic/lang/zh_CN.lang
@@ -783,62 +783,62 @@ entity.bloodmagic.SentientSpecter.name=感知之灵
 entity.bloodmagic.Mimic.name=拟态
 
 # Commands
-commands.bloodmagic.error.arg.invalid=无效参数
-commands.bloodmagic.error.arg.missing=参数不足
-commands.bloodmagic.error.arg.player.missing=你必须指定一个玩家来执行该命令。
-commands.bloodmagic.error.404=命令未找到！
-commands.bloodmagic.error.unknown=未知的命令！
-commands.bloodmagic.error.perm=你没有使用该命令的权限。
+commands.error.arg.invalid=无效参数
+commands.error.arg.missing=参数不足
+commands.error.arg.player.missing=你必须指定一个玩家来执行该命令。
+commands.error.404=命令未找到！
+commands.error.unknown=未知的命令！
+commands.error.perm=你没有使用该命令的权限。
 
-commands.bloodmagic.success=成功执行
+commands.success=成功执行
 
-commands.bloodmagic.format.help=%s - %s
-commands.bloodmagic.format.error=%s - %s
+commands.format.help=%s - %s
+commands.format.error=%s - %s
 
-commands.bloodmagic.help.usage=/bloodmagic help
-commands.bloodmagic.help.help=使用"/bloodmagic help"命令显示指令列表。
+commands.help.usage=/bloodmagic help
+commands.help.help=使用"/bloodmagic help"命令显示指令列表。
 
-commands.bloodmagic.network.usage=/bloodmagic network [吸取(syphon)|添加(add)|查看(get)|填充(fill)|填满(cap)] <玩家> [数量]
-commands.bloodmagic.network.help=灵魂网络实用工具
-commands.bloodmagic.network.syphon.help=从指定玩家的灵魂网络中移出指定的LP值。
-commands.bloodmagic.network.syphon.success=成功从 %s 吸取出 %dLP。
-commands.bloodmagic.network.add.help=添加指定的LP值到指定玩家的灵魂网络中。服从标准的LP增加规则。
-commands.bloodmagic.network.add.success=成功添加 %dLP 到 %s 的灵魂网络。
-commands.bloodmagic.network.set.help=将指定玩家的LP设置为所给数值。
-commands.bloodmagic.network.set.success=成功将 %s 灵魂网络中的LP设置为 %d。
-commands.bloodmagic.network.get.help=返还指定玩家灵魂网络中的LP值。
-commands.bloodmagic.network.fill.help=将指定玩家的LP填充为 %d。
-commands.bloodmagic.network.fill.success=成功填充 %s 的灵魂网络。
-commands.bloodmagic.network.cap.help=填充指定玩家的灵魂网络至其所持有的最高阶气血宝珠容量的最大值。
-commands.bloodmagic.network.cap.success=成功填满 %s 的灵魂网络。
+commands.network.usage=/bloodmagic network [吸取(syphon)|添加(add)|查看(get)|填充(fill)|填满(cap)] <玩家> [数量]
+commands.network.help=灵魂网络实用工具
+commands.network.syphon.help=从指定玩家的灵魂网络中移出指定的LP值。
+commands.network.syphon.success=成功从 %s 吸取出 %dLP。
+commands.network.add.help=添加指定的LP值到指定玩家的灵魂网络中。服从标准的LP增加规则。
+commands.network.add.success=成功添加 %dLP 到 %s 的灵魂网络。
+commands.network.set.help=将指定玩家的LP设置为所给数值。
+commands.network.set.success=成功将 %s 灵魂网络中的LP设置为 %d。
+commands.network.get.help=返还指定玩家灵魂网络中的LP值。
+commands.network.fill.help=将指定玩家的LP填充为 %d。
+commands.network.fill.success=成功填充 %s 的灵魂网络。
+commands.network.cap.help=填充指定玩家的灵魂网络至其所持有的最高阶气血宝珠容量的最大值。
+commands.network.cap.success=成功填满 %s 的灵魂网络。
 
-commands.bloodmagic.bind.usage=/bind <玩家>
-commands.bloodmagic.bind.help=用于设置/解除对手持物品的绑定情况。
-commands.bloodmagic.bind.success=物品成功绑定！
-commands.bloodmagic.bind.remove.success=解除绑定成功
+commands.bind.usage=/bind <玩家>
+commands.bind.help=用于设置/解除对手持物品的绑定情况。
+commands.bind.success=物品成功绑定！
+commands.bind.remove.success=解除绑定成功
 
-commands.bloodmagic.orb.usage=/bloodmagic orb [设置(set)|查看(get)] <玩家> [等级]
-commands.bloodmagic.orb.help=用于设置或查看玩家的最高血宝珠等级.
+commands.orb.usage=/bloodmagic orb [设置(set)|查看(get)] <玩家> [等级]
+commands.orb.help=用于设置或查看玩家的最高血宝珠等级.
 
-commands.bloodmagic.bind.usage=/bind <玩家>
-commands.bloodmagic.bind.success=物品成功绑定！
-commands.bloodmagic.bind.failed.noPlayer=没有指定玩家
-commands.bloodmagic.bind.failed.alreadyBound=物品已经被绑定；使用 /unbind 来解除绑定
-commands.bloodmagic.bind.failed.notBindable=物品无法被绑定
-commands.bloodmagic.unbind.usage=/unbind
-commands.bloodmagic.unbind.success=物品成功解除绑定！
-commands.bloodmagic.unbind.failed.notBindable=物品无法解除绑定
-commands.bloodmagic.soulnetwork.usage=/soulnetwork <玩家> <添加(add)|减去(subtract)|填满(fill)|清空(empty)|查看(get)> [数量]
-commands.bloodmagic.soulnetwork.add.success=成功添加 %dLP 到 %s 的灵魂网络！
-commands.bloodmagic.soulnetwork.subtract.success=成功从 %s 的灵魂网络中减去 %dLP！
-commands.bloodmagic.soulnetwork.fill.success=成功填满 %s 的灵魂网络！
-commands.bloodmagic.soulnetwork.empty.success=成功清空 %s 的灵魂网络！
-commands.bloodmagic.soulnetwork.get.success=%s 的灵魂网络中有 %dLP！
-commands.bloodmagic.soulnetwork.noPlayer=没有指定玩家
-commands.bloodmagic.soulnetwork.noCommand=这不符命令规定
-commands.bloodmagic.soulnetwork.notACommand=这不是有效的命令
-commands.bloodmagic.soulnetwork.fillMax.success=成功将 %s 的灵魂网络填满至其宝珠的最大值！
-commands.bloodmagic.soulnetwork.create.success=创建 %s 的灵魂网络成功（宝珠等级：%d）
+commands.bind.usage=/bind <玩家>
+commands.bind.success=物品成功绑定！
+commands.bind.failed.noPlayer=没有指定玩家
+commands.bind.failed.alreadyBound=物品已经被绑定；使用 /unbind 来解除绑定
+commands.bind.failed.notBindable=物品无法被绑定
+commands.unbind.usage=/unbind
+commands.unbind.success=物品成功解除绑定！
+commands.unbind.failed.notBindable=物品无法解除绑定
+commands.soulnetwork.usage=/soulnetwork <玩家> <添加(add)|减去(subtract)|填满(fill)|清空(empty)|查看(get)> [数量]
+commands.soulnetwork.add.success=成功添加 %dLP 到 %s 的灵魂网络！
+commands.soulnetwork.subtract.success=成功从 %s 的灵魂网络中减去 %dLP！
+commands.soulnetwork.fill.success=成功填满 %s 的灵魂网络！
+commands.soulnetwork.empty.success=成功清空 %s 的灵魂网络！
+commands.soulnetwork.get.success=%s 的灵魂网络中有 %dLP！
+commands.soulnetwork.noPlayer=没有指定玩家
+commands.soulnetwork.noCommand=这不符命令规定
+commands.soulnetwork.notACommand=这不是有效的命令
+commands.soulnetwork.fillMax.success=成功将 %s 的灵魂网络填满至其宝珠的最大值！
+commands.soulnetwork.create.success=创建 %s 的灵魂网络成功（宝珠等级：%d）
 
 # GUI
 tile.bloodmagic.inputNode.name=输入节点


### PR DESCRIPTION
In response to https://github.com/WayofTime/BloodMagic/issues/1376
A few fixes to mimics have been made to restore the long-missing shift+right click behavior of mimic blocks when placed. Now they'll replace blocks when shift-clicked onto them, and will inherit the BlockState of blocks replaced in this way.
- Reimplemented the shift+right click behavior of mimics and implemented an explicit mimic ItemBlock
- Changed the mimic tile from using metadata to using blockstates when storing the replaced block's information. This includes edits to the block, tile, and entity files. 
- Copied parseState() from WayofTime.bloodmagic.api.impl.BloodMagicCorePlugin to a public function in a new class WayofTime.bloodmagic.util.Serializer, because TehNut told me to not put it in Utils.java
- Completely removed the TileMimic#metaOfReplacedBlock variable and all calls to it. Mimics no longer use metadata directly for their replaced blocks, any metadata values are derived from blockstate.