### PR TITLE
Several mimic fixes, with actually cleaned up commit history.

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/api/impl/BloodMagicCorePlugin.java
+++ b/src/main/java/WayofTime/bloodmagic/api/impl/BloodMagicCorePlugin.java
@@ -15,6 +15,7 @@ import WayofTime.bloodmagic.core.RegistrarBloodMagicBlocks;
 import WayofTime.bloodmagic.core.RegistrarBloodMagicRecipes;
 import WayofTime.bloodmagic.incense.EnumTranquilityType;
 import WayofTime.bloodmagic.incense.TranquilityStack;
+import WayofTime.bloodmagic.util.StateUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.BlockStateContainer;
@@ -116,7 +117,7 @@ public class BloodMagicCorePlugin implements IBloodMagicPlugin
 
                 if (blockData.length > 1)
                 { // We have properties listed, so let's build a state.
-                    api.getBlacklist().addTeleposer(parseState(value));
+                    api.getBlacklist().addTeleposer(StateUtil.parseState(value));
                     continue;
                 }
 
@@ -136,7 +137,7 @@ public class BloodMagicCorePlugin implements IBloodMagicPlugin
 
             if (blockData.length > 1)
             { // We have properties listed, so let's build a state.
-                api.getBlacklist().addTeleposer(parseState(value));
+                api.getBlacklist().addTeleposer(StateUtil.parseState(value));
                 continue;
             }
 
@@ -151,30 +152,5 @@ public class BloodMagicCorePlugin implements IBloodMagicPlugin
 
             api.getBlacklist().addWellOfSuffering(entityEntry.getRegistryName());
         }
-    }
-
-    private static IBlockState parseState(String blockInfo)
-    {
-        String[] split = blockInfo.split("\\[");
-        split[1] = split[1].substring(0, split[1].lastIndexOf("]")); // Make sure brackets are removed from state
-
-        Block block = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(split[0])); // Find the block
-        if (block == Blocks.AIR)
-            return Blocks.AIR.getDefaultState(); // The block is air, so we're looking at invalid data
-
-        BlockStateContainer blockState = block.getBlockState();
-        IBlockState returnState = blockState.getBaseState();
-
-        // Force our values into the state
-        String[] stateValues = split[1].split(","); // Splits up each value
-        for (String value : stateValues)
-        {
-            String[] valueSplit = value.split("="); // Separates property and value
-            IProperty property = blockState.getProperty(valueSplit[0]);
-            if (property != null)
-                returnState = returnState.withProperty(property, (Comparable) property.parseValue(valueSplit[1]).get()); // Force the property into the state
-        }
-
-        return returnState;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/block/BlockMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockMimic.java
@@ -8,6 +8,7 @@ import WayofTime.bloodmagic.block.enums.EnumMimic;
 import WayofTime.bloodmagic.core.RegistrarBloodMagicBlocks;
 import WayofTime.bloodmagic.tile.TileMimic;
 import WayofTime.bloodmagic.util.Utils;
+import WayofTime.bloodmagic.item.block.ItemBlockMimic;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
@@ -59,7 +60,7 @@ public class BlockMimic extends BlockEnum<EnumMimic> implements IAltarComponent 
                     if (mimicBlock == Blocks.AIR) {
                         return FULL_BLOCK_AABB;
                     }
-                    IBlockState mimicState = mimicBlock.getStateFromMeta(tileMimic.metaOfReplacedBlock);
+                    IBlockState mimicState = tileMimic.getReplacedState();
                     if (mimicBlock != this) {
                         return mimicState.getCollisionBoundingBox(world, pos);
                     }
@@ -82,7 +83,7 @@ public class BlockMimic extends BlockEnum<EnumMimic> implements IAltarComponent 
             if (mimicBlock == Blocks.AIR) {
                 return FULL_BLOCK_AABB;
             }
-            IBlockState mimicState = mimicBlock.getStateFromMeta(tileMimic.getStackInSlot(0).getItemDamage());
+            IBlockState mimicState = tileMimic.getReplacedState();
             if (mimicBlock != this) {
                 return mimicState.getSelectedBoundingBox(world, pos);
             }
@@ -136,7 +137,7 @@ public class BlockMimic extends BlockEnum<EnumMimic> implements IAltarComponent 
             ItemStack stack = mimic.getStackInSlot(0);
             if (stack.getItem() instanceof ItemBlock) {
                 Block block = ((ItemBlock) stack.getItem()).getBlock();
-                IBlockState mimicState = block.getStateFromMeta(stack.getItemDamage());
+                IBlockState mimicState = mimic.getReplacedState();
                 if (block != this) {
                     if (block.getRenderType(mimicState) == EnumBlockRenderType.ENTITYBLOCK_ANIMATED) {
                         return RegistrarBloodMagicBlocks.BLOOD_LIGHT.getDefaultState(); //Small and invisible-ish, basically this is returned in order to not render over the animated block (TESR)
@@ -208,7 +209,7 @@ public class BlockMimic extends BlockEnum<EnumMimic> implements IAltarComponent 
             if (stack.getItem() instanceof ItemBlock) {
                 Block block = ((ItemBlock) stack.getItem()).getBlock();
                 if (block instanceof IAltarComponent) {
-                    return ((IAltarComponent) block).getType(world, block.getStateFromMeta(mimic.metaOfReplacedBlock), pos);
+                    return ((IAltarComponent) block).getType(world, mimic.getReplacedState(), pos);
                 } else {
                     for (ComponentType altarComponent : ComponentType.values())
                         if (block == Utils.getBlockForComponent(altarComponent))
@@ -218,4 +219,10 @@ public class BlockMimic extends BlockEnum<EnumMimic> implements IAltarComponent 
         }
         return null;
     }
+	
+	@Override
+	public ItemBlock getItem() {
+		return new ItemBlockMimic(this);
+	}
+
 }

--- a/src/main/java/WayofTime/bloodmagic/block/BlockMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockMimic.java
@@ -219,10 +219,10 @@ public class BlockMimic extends BlockEnum<EnumMimic> implements IAltarComponent 
         }
         return null;
     }
-	
-	@Override
-	public ItemBlock getItem() {
-		return new ItemBlockMimic(this);
-	}
+    
+    @Override
+    public ItemBlock getItem() {
+        return new ItemBlockMimic(this);
+    }
 
 }

--- a/src/main/java/WayofTime/bloodmagic/entity/mob/EntityMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/entity/mob/EntityMimic.java
@@ -38,7 +38,7 @@ public class EntityMimic extends EntityDemonBase {
      */
     private static final DataParameter<Byte> CLIMBING = EntityDataManager.createKey(EntityMimic.class, DataSerializers.BYTE);
 
-    public boolean dropItemsOnBreak = true;
+    public boolean dropItemsOnBreak = true/
     public NBTTagCompound tileTag = new NBTTagCompound();
     public int metaOfReplacedBlock = 0;
 	public IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();
@@ -103,8 +103,7 @@ public class EntityMimic extends EntityDemonBase {
             TileEntity tile = world.getTileEntity(pos);
             if (tile instanceof TileMimic) {
                 TileMimic mimic = (TileMimic) tile;
-                //mimic.metaOfReplacedBlock = metaOfReplacedBlock;
-				mimic.setReplacedState(this.stateOfReplacedBlock);
+		mimic.setReplacedState(this.stateOfReplacedBlock);
                 mimic.tileTag = tileTag;
                 mimic.setInventorySlotContents(0, getMimicItemStack());
                 mimic.dropItemsOnBreak = dropItemsOnBreak;
@@ -121,8 +120,7 @@ public class EntityMimic extends EntityDemonBase {
         this.setMimicItemStack(heldStack);
         this.tileTag = tileTag;
         this.dropItemsOnBreak = dropItemsOnBreak;
-        //this.metaOfReplacedBlock = metaOfReplacedBlock;
-		this.stateOfReplacedBlock = stateOfReplacedBlock;
+	this.stateOfReplacedBlock = stateOfReplacedBlock;
         this.playerCheckRadius = playerCheckRadius;
         this.setHomePosAndDistance(homePosition, 2); //TODO: Save this.
     }

--- a/src/main/java/WayofTime/bloodmagic/entity/mob/EntityMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/entity/mob/EntityMimic.java
@@ -103,7 +103,7 @@ public class EntityMimic extends EntityDemonBase {
             TileEntity tile = world.getTileEntity(pos);
             if (tile instanceof TileMimic) {
                 TileMimic mimic = (TileMimic) tile;
-        mimic.setReplacedState(this.stateOfReplacedBlock);
+                mimic.setReplacedState(this.stateOfReplacedBlock);
                 mimic.tileTag = tileTag;
                 mimic.setInventorySlotContents(0, getMimicItemStack());
                 mimic.dropItemsOnBreak = dropItemsOnBreak;
@@ -120,7 +120,7 @@ public class EntityMimic extends EntityDemonBase {
         this.setMimicItemStack(heldStack);
         this.tileTag = tileTag;
         this.dropItemsOnBreak = dropItemsOnBreak;
-    this.stateOfReplacedBlock = stateOfReplacedBlock;
+        this.stateOfReplacedBlock = stateOfReplacedBlock;
         this.playerCheckRadius = playerCheckRadius;
         this.setHomePosAndDistance(homePosition, 2); //TODO: Save this.
     }

--- a/src/main/java/WayofTime/bloodmagic/entity/mob/EntityMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/entity/mob/EntityMimic.java
@@ -4,7 +4,7 @@ import WayofTime.bloodmagic.block.BlockMimic;
 import WayofTime.bloodmagic.core.RegistrarBloodMagicBlocks;
 import WayofTime.bloodmagic.entity.ai.EntityAIMimicReform;
 import WayofTime.bloodmagic.tile.TileMimic;
-import WayofTime.bloodmagic.util.Serializer;
+import WayofTime.bloodmagic.util.StateUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
@@ -41,7 +41,7 @@ public class EntityMimic extends EntityDemonBase {
     public boolean dropItemsOnBreak = true;
     public NBTTagCompound tileTag = new NBTTagCompound();
     public int metaOfReplacedBlock = 0;
-	public IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();
+    public IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();
     public int playerCheckRadius = 5;
 
     public EntityMimic(World worldIn) {
@@ -70,7 +70,7 @@ public class EntityMimic extends EntityDemonBase {
         tag.setTag("tileTag", tileTag);
         tag.setInteger("metaOfReplacedBlock", metaOfReplacedBlock);
         tag.setInteger("playerCheckRadius", playerCheckRadius);
-		tag.setString("stateOfReplacedBlock", stateOfReplacedBlock.toString());
+        tag.setString("stateOfReplacedBlock", stateOfReplacedBlock.toString());
     }
 
     @Override
@@ -81,7 +81,7 @@ public class EntityMimic extends EntityDemonBase {
         tileTag = tag.getCompoundTag("tileTag");
         metaOfReplacedBlock = tag.getInteger("metaOfReplacedBlock");
         playerCheckRadius = tag.getInteger("playerCheckRadius");
-		stateOfReplacedBlock = Serializer.parseState(tag.getString("stateOfReplacedBlock"));
+        stateOfReplacedBlock = StateUtil.parseState(tag.getString("stateOfReplacedBlock"));
     }
 
     public ItemStack getMimicItemStack() {
@@ -103,7 +103,7 @@ public class EntityMimic extends EntityDemonBase {
             TileEntity tile = world.getTileEntity(pos);
             if (tile instanceof TileMimic) {
                 TileMimic mimic = (TileMimic) tile;
-		mimic.setReplacedState(this.stateOfReplacedBlock);
+        mimic.setReplacedState(this.stateOfReplacedBlock);
                 mimic.tileTag = tileTag;
                 mimic.setInventorySlotContents(0, getMimicItemStack());
                 mimic.dropItemsOnBreak = dropItemsOnBreak;
@@ -120,7 +120,7 @@ public class EntityMimic extends EntityDemonBase {
         this.setMimicItemStack(heldStack);
         this.tileTag = tileTag;
         this.dropItemsOnBreak = dropItemsOnBreak;
-	this.stateOfReplacedBlock = stateOfReplacedBlock;
+    this.stateOfReplacedBlock = stateOfReplacedBlock;
         this.playerCheckRadius = playerCheckRadius;
         this.setHomePosAndDistance(homePosition, 2); //TODO: Save this.
     }

--- a/src/main/java/WayofTime/bloodmagic/entity/mob/EntityMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/entity/mob/EntityMimic.java
@@ -38,7 +38,7 @@ public class EntityMimic extends EntityDemonBase {
      */
     private static final DataParameter<Byte> CLIMBING = EntityDataManager.createKey(EntityMimic.class, DataSerializers.BYTE);
 
-    public boolean dropItemsOnBreak = true/
+    public boolean dropItemsOnBreak = true;
     public NBTTagCompound tileTag = new NBTTagCompound();
     public int metaOfReplacedBlock = 0;
 	public IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();

--- a/src/main/java/WayofTime/bloodmagic/entity/mob/EntityMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/entity/mob/EntityMimic.java
@@ -4,6 +4,7 @@ import WayofTime.bloodmagic.block.BlockMimic;
 import WayofTime.bloodmagic.core.RegistrarBloodMagicBlocks;
 import WayofTime.bloodmagic.entity.ai.EntityAIMimicReform;
 import WayofTime.bloodmagic.tile.TileMimic;
+import WayofTime.bloodmagic.util.Serializer;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
@@ -12,6 +13,7 @@ import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.*;
 import net.minecraft.entity.monster.EntityIronGolem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.MobEffects;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.EntityEquipmentSlot;
@@ -39,6 +41,7 @@ public class EntityMimic extends EntityDemonBase {
     public boolean dropItemsOnBreak = true;
     public NBTTagCompound tileTag = new NBTTagCompound();
     public int metaOfReplacedBlock = 0;
+	public IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();
     public int playerCheckRadius = 5;
 
     public EntityMimic(World worldIn) {
@@ -67,6 +70,7 @@ public class EntityMimic extends EntityDemonBase {
         tag.setTag("tileTag", tileTag);
         tag.setInteger("metaOfReplacedBlock", metaOfReplacedBlock);
         tag.setInteger("playerCheckRadius", playerCheckRadius);
+		tag.setString("stateOfReplacedBlock", stateOfReplacedBlock.toString());
     }
 
     @Override
@@ -77,6 +81,7 @@ public class EntityMimic extends EntityDemonBase {
         tileTag = tag.getCompoundTag("tileTag");
         metaOfReplacedBlock = tag.getInteger("metaOfReplacedBlock");
         playerCheckRadius = tag.getInteger("playerCheckRadius");
+		stateOfReplacedBlock = Serializer.parseState(tag.getString("stateOfReplacedBlock"));
     }
 
     public ItemStack getMimicItemStack() {
@@ -88,7 +93,7 @@ public class EntityMimic extends EntityDemonBase {
     }
 
     public boolean spawnHeldBlockOnDeath(World world, BlockPos pos) {
-        return world.isAirBlock(pos) && TileMimic.replaceMimicWithBlockActual(world, pos, getMimicItemStack(), tileTag, metaOfReplacedBlock);
+        return world.isAirBlock(pos) && TileMimic.replaceMimicWithBlockActual(world, pos, getMimicItemStack(), tileTag, stateOfReplacedBlock);
     }
 
     public boolean spawnMimicBlockAtPosition(World world, BlockPos pos) {
@@ -98,7 +103,8 @@ public class EntityMimic extends EntityDemonBase {
             TileEntity tile = world.getTileEntity(pos);
             if (tile instanceof TileMimic) {
                 TileMimic mimic = (TileMimic) tile;
-                mimic.metaOfReplacedBlock = metaOfReplacedBlock;
+                //mimic.metaOfReplacedBlock = metaOfReplacedBlock;
+				mimic.setReplacedState(this.stateOfReplacedBlock);
                 mimic.tileTag = tileTag;
                 mimic.setInventorySlotContents(0, getMimicItemStack());
                 mimic.dropItemsOnBreak = dropItemsOnBreak;
@@ -111,11 +117,12 @@ public class EntityMimic extends EntityDemonBase {
         return false;
     }
 
-    public void initializeMimic(ItemStack heldStack, NBTTagCompound tileTag, boolean dropItemsOnBreak, int metaOfReplacedBlock, int playerCheckRadius, BlockPos homePosition) {
+    public void initializeMimic(ItemStack heldStack, NBTTagCompound tileTag, boolean dropItemsOnBreak, IBlockState stateOfReplacedBlock, int playerCheckRadius, BlockPos homePosition) {
         this.setMimicItemStack(heldStack);
         this.tileTag = tileTag;
         this.dropItemsOnBreak = dropItemsOnBreak;
-        this.metaOfReplacedBlock = metaOfReplacedBlock;
+        //this.metaOfReplacedBlock = metaOfReplacedBlock;
+		this.stateOfReplacedBlock = stateOfReplacedBlock;
         this.playerCheckRadius = playerCheckRadius;
         this.setHomePosAndDistance(homePosition, 2); //TODO: Save this.
     }

--- a/src/main/java/WayofTime/bloodmagic/item/block/ItemBlockMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/item/block/ItemBlockMimic.java
@@ -31,8 +31,7 @@ public class ItemBlockMimic extends ItemBlockEnum
     }
 
     @Override
-    //Old: public EnumActionResult onItemUse(ItemStack stack, EntityPlayer player, EnumHand hand, World world, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ)
-	public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) 
+    public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) 
     {
 		ItemStack stack = player.getHeldItem(hand);
 		

--- a/src/main/java/WayofTime/bloodmagic/item/block/ItemBlockMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/item/block/ItemBlockMimic.java
@@ -49,7 +49,6 @@ public class ItemBlockMimic extends ItemBlockEnum
 			IBlockState replacedBlockstate = world.getBlockState(pos);
 			Block replacedBlock = replacedBlockstate.getBlock();
 			ItemStack replacedStack = replacedBlock.getItem(world, pos, replacedBlockstate);
-			int replacedMeta = replacedBlock.getMetaFromState(replacedBlockstate);
 			
 			//Get the state for the mimic
 			IBlockState mimicBlockstate = this.getBlock().getStateFromMeta(stack.getMetadata());
@@ -95,9 +94,8 @@ public class ItemBlockMimic extends ItemBlockEnum
 			if (tile instanceof TileMimic)
 			{
 				TileMimic mimic = (TileMimic) tile;
-				mimic.metaOfReplacedBlock = replacedMeta;
-				mimic.stateOfReplacedBlock = replacedBlockstate;
 				mimic.tileTag = tileTag;
+				mimic.setReplacedState(replacedBlockstate);
 				mimic.setInventorySlotContents(0, replacedStack);
 				mimic.refreshTileEntity();
 

--- a/src/main/java/WayofTime/bloodmagic/item/block/ItemBlockMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/item/block/ItemBlockMimic.java
@@ -33,42 +33,42 @@ public class ItemBlockMimic extends ItemBlockEnum
     @Override
     public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) 
     {
-		ItemStack stack = player.getHeldItem(hand);
-		
-		//If not sneaking, do normal item use
+        ItemStack stack = player.getHeldItem(hand);
+        
+        //If not sneaking, do normal item use
         if (!player.isSneaking())
         {
             return super.onItemUse(player, world, pos, hand, facing, hitX, hitY, hitZ);
         }
-		
-		//IF sneaking and player has permission, replace the targeted block
+        
+        //IF sneaking and player has permission, replace the targeted block
         if (player.canPlayerEdit(pos, facing, stack))
         {
-			//Store information about the block being replaced and its appropriate itemstack
-			IBlockState replacedBlockstate = world.getBlockState(pos);
-			Block replacedBlock = replacedBlockstate.getBlock();
-			ItemStack replacedStack = replacedBlock.getItem(world, pos, replacedBlockstate);
-			
-			//Get the state for the mimic
-			IBlockState mimicBlockstate = this.getBlock().getStateFromMeta(stack.getMetadata());
-			
-			
-			//Check if the block can be replaced
-			
+            //Store information about the block being replaced and its appropriate itemstack
+            IBlockState replacedBlockstate = world.getBlockState(pos);
+            Block replacedBlock = replacedBlockstate.getBlock();
+            ItemStack replacedStack = replacedBlock.getItem(world, pos, replacedBlockstate);
+            
+            //Get the state for the mimic
+            IBlockState mimicBlockstate = this.getBlock().getStateFromMeta(stack.getMetadata());
+            
+            
+            //Check if the block can be replaced
+            
             if (!canReplaceBlock(world, pos, replacedBlockstate))
             {
                 return super.onItemUse(player, world, pos, hand, facing, hitX, hitY, hitZ);
             }
 
-			//Check if the tile entity, if any, can be replaced
-			TileEntity tileReplaced = world.getTileEntity(pos);
+            //Check if the tile entity, if any, can be replaced
+            TileEntity tileReplaced = world.getTileEntity(pos);
             if (!canReplaceTile(tileReplaced))
             {
                 return EnumActionResult.FAIL;
             }
-			
-			//If tile can be replaced, store info about the tile
-			NBTTagCompound tileTag = getTagFromTileEntity(tileReplaced);
+            
+            //If tile can be replaced, store info about the tile
+            NBTTagCompound tileTag = getTagFromTileEntity(tileReplaced);
             if (tileReplaced != null)
             {
                 NBTTagCompound voidTag = new NBTTagCompound();
@@ -77,39 +77,39 @@ public class ItemBlockMimic extends ItemBlockEnum
                 voidTag.setInteger("z", pos.getZ());
                 tileReplaced.readFromNBT(voidTag);
             }
-			
-			//Remove one item from stack
-			stack.shrink(1);
-			
-			
-			//Replace the block
-			world.setBlockState(pos, mimicBlockstate, 3);
-			//Make placing sound
-			SoundType soundtype = this.block.getSoundType();
-				world.playSound(player, pos, soundtype.getPlaceSound(), SoundCategory.BLOCKS, (soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F);
-			
-			//Replace the tile entity
-			TileEntity tile = world.getTileEntity(pos);
-			if (tile instanceof TileMimic)
-			{
-				TileMimic mimic = (TileMimic) tile;
-				mimic.tileTag = tileTag;
-				mimic.setReplacedState(replacedBlockstate);
-				mimic.setInventorySlotContents(0, replacedStack);
-				mimic.refreshTileEntity();
+            
+            //Remove one item from stack
+            stack.shrink(1);
+            
+            
+            //Replace the block
+            world.setBlockState(pos, mimicBlockstate, 3);
+            //Make placing sound
+            SoundType soundtype = this.block.getSoundType();
+                world.playSound(player, pos, soundtype.getPlaceSound(), SoundCategory.BLOCKS, (soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F);
+            
+            //Replace the tile entity
+            TileEntity tile = world.getTileEntity(pos);
+            if (tile instanceof TileMimic)
+            {
+                TileMimic mimic = (TileMimic) tile;
+                mimic.tileTag = tileTag;
+                mimic.setReplacedState(replacedBlockstate);
+                mimic.setInventorySlotContents(0, replacedStack);
+                mimic.refreshTileEntity();
 
-				if (player.capabilities.isCreativeMode)
-				{
-					mimic.dropItemsOnBreak = false;
-				}
-			}
-			return EnumActionResult.SUCCESS;
-		} 
+                if (player.capabilities.isCreativeMode)
+                {
+                    mimic.dropItemsOnBreak = false;
+                }
+            }
+            return EnumActionResult.SUCCESS;
+        } 
 
         return EnumActionResult.FAIL;
 
     }
-	
+    
     public boolean canReplaceTile(TileEntity tile)
     {
         if (tile instanceof TileEntityChest)

--- a/src/main/java/WayofTime/bloodmagic/item/block/ItemBlockMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/item/block/ItemBlockMimic.java
@@ -1,0 +1,147 @@
+package WayofTime.bloodmagic.item.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.SoundType;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityChest;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import WayofTime.bloodmagic.block.BlockMimic;
+import WayofTime.bloodmagic.tile.TileMimic;
+import WayofTime.bloodmagic.block.base.BlockEnum;
+import WayofTime.bloodmagic.item.block.base.ItemBlockEnum;
+
+import WayofTime.bloodmagic.util.ChatUtil;
+
+public class ItemBlockMimic extends ItemBlockEnum
+{
+    public ItemBlockMimic(BlockEnum block)
+    {
+        super(block);
+        setHasSubtypes(true);
+    }
+
+    @Override
+    //Old: public EnumActionResult onItemUse(ItemStack stack, EntityPlayer player, EnumHand hand, World world, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ)
+	public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) 
+    {
+		ItemStack stack = player.getHeldItem(hand);
+		
+		//If not sneaking, do normal item use
+        if (!player.isSneaking())
+        {
+            return super.onItemUse(player, world, pos, hand, facing, hitX, hitY, hitZ);
+        }
+		
+		//IF sneaking and player has permission, replace the targeted block
+        if (player.canPlayerEdit(pos, facing, stack))
+        {
+			//Store information about the block being replaced and its appropriate itemstack
+			IBlockState replacedBlockstate = world.getBlockState(pos);
+			Block replacedBlock = replacedBlockstate.getBlock();
+			ItemStack replacedStack = replacedBlock.getItem(world, pos, replacedBlockstate);
+			int replacedMeta = replacedBlock.getMetaFromState(replacedBlockstate);
+			
+			//Get the state for the mimic
+			IBlockState mimicBlockstate = this.getBlock().getStateFromMeta(stack.getMetadata());
+			
+			
+			//Check if the block can be replaced
+			
+            if (!canReplaceBlock(world, pos, replacedBlockstate))
+            {
+                return super.onItemUse(player, world, pos, hand, facing, hitX, hitY, hitZ);
+            }
+
+			//Check if the tile entity, if any, can be replaced
+			TileEntity tileReplaced = world.getTileEntity(pos);
+            if (!canReplaceTile(tileReplaced))
+            {
+                return EnumActionResult.FAIL;
+            }
+			
+			//If tile can be replaced, store info about the tile
+			NBTTagCompound tileTag = getTagFromTileEntity(tileReplaced);
+            if (tileReplaced != null)
+            {
+                NBTTagCompound voidTag = new NBTTagCompound();
+                voidTag.setInteger("x", pos.getX());
+                voidTag.setInteger("y", pos.getY());
+                voidTag.setInteger("z", pos.getZ());
+                tileReplaced.readFromNBT(voidTag);
+            }
+			
+			//Remove one item from stack
+			stack.shrink(1);
+			
+			
+			//Replace the block
+			world.setBlockState(pos, mimicBlockstate, 3);
+			//Make placing sound
+			SoundType soundtype = this.block.getSoundType();
+				world.playSound(player, pos, soundtype.getPlaceSound(), SoundCategory.BLOCKS, (soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F);
+			
+			//Replace the tile entity
+			TileEntity tile = world.getTileEntity(pos);
+			if (tile instanceof TileMimic)
+			{
+				TileMimic mimic = (TileMimic) tile;
+				mimic.metaOfReplacedBlock = replacedMeta;
+				mimic.stateOfReplacedBlock = replacedBlockstate;
+				mimic.tileTag = tileTag;
+				mimic.setInventorySlotContents(0, replacedStack);
+				mimic.refreshTileEntity();
+
+				if (player.capabilities.isCreativeMode)
+				{
+					mimic.dropItemsOnBreak = false;
+				}
+			}
+			return EnumActionResult.SUCCESS;
+		} 
+
+        return EnumActionResult.FAIL;
+
+    }
+	
+    public boolean canReplaceTile(TileEntity tile)
+    {
+        if (tile instanceof TileEntityChest)
+        {
+            return true;
+        }
+
+        return tile == null;
+    }
+
+    public boolean canReplaceBlock(World world, BlockPos pos, IBlockState state) {
+        return state.getBlockHardness(world, pos) != -1.0F;
+    }
+
+    public NBTTagCompound getTagFromTileEntity(TileEntity tile)
+    {
+        NBTTagCompound tag = new NBTTagCompound();
+
+        if (tile != null)
+        {
+            return tile.writeToNBT(tag);
+        }
+
+        return tag;
+    }
+
+    @Override
+    public int getMetadata(int meta)
+    {
+        return meta;
+    }
+}

--- a/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
@@ -258,7 +258,7 @@ public class TileMimic extends TileInventory implements ITickable {
         dropItemsOnBreak = tag.getBoolean("dropItemsOnBreak");
         tileTag = tag.getCompoundTag("tileTag");
         stateOfReplacedBlock = Serializer.parseState(tag.getString("stateOfReplacedBlock"));
-		mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, stateOfReplacedBlock);
+	mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, stateOfReplacedBlock);
         playerCheckRadius = tag.getInteger("playerCheckRadius");
         potionSpawnRadius = tag.getInteger("potionSpawnRadius");
         potionSpawnInterval = Math.max(1, tag.getInteger("potionSpawnInterval"));
@@ -273,7 +273,7 @@ public class TileMimic extends TileInventory implements ITickable {
         tag.setInteger("playerCheckRadius", playerCheckRadius);
         tag.setInteger("potionSpawnRadius", potionSpawnRadius);
         tag.setInteger("potionSpawnInterval", potionSpawnInterval);
-		tag.setString("stateOfReplacedBlock",stateOfReplacedBlock.toString());
+	tag.setString("stateOfReplacedBlock",stateOfReplacedBlock.toString());
 
         return tag;
     }

--- a/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
@@ -258,7 +258,7 @@ public class TileMimic extends TileInventory implements ITickable {
         dropItemsOnBreak = tag.getBoolean("dropItemsOnBreak");
         tileTag = tag.getCompoundTag("tileTag");
         stateOfReplacedBlock = StateUtil.parseState(tag.getString("stateOfReplacedBlock"));
-    mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, stateOfReplacedBlock);
+        mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, stateOfReplacedBlock);
         playerCheckRadius = tag.getInteger("playerCheckRadius");
         potionSpawnRadius = tag.getInteger("potionSpawnRadius");
         potionSpawnInterval = Math.max(1, tag.getInteger("potionSpawnInterval"));
@@ -273,7 +273,7 @@ public class TileMimic extends TileInventory implements ITickable {
         tag.setInteger("playerCheckRadius", playerCheckRadius);
         tag.setInteger("potionSpawnRadius", potionSpawnRadius);
         tag.setInteger("potionSpawnInterval", potionSpawnInterval);
-    tag.setString("stateOfReplacedBlock",stateOfReplacedBlock.toString());
+        tag.setString("stateOfReplacedBlock",stateOfReplacedBlock.toString());
 
         return tag;
     }

--- a/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
@@ -41,8 +41,7 @@ public class TileMimic extends TileInventory implements ITickable {
     public boolean dropItemsOnBreak = true;
     public NBTTagCompound tileTag = new NBTTagCompound();
     public TileEntity mimicedTile = null;
-    public int metaOfReplacedBlock = 0;
-	public IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();
+	IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();
 	
     public int playerCheckRadius = 5;
     public int potionSpawnRadius = 5;
@@ -258,7 +257,6 @@ public class TileMimic extends TileInventory implements ITickable {
 
         dropItemsOnBreak = tag.getBoolean("dropItemsOnBreak");
         tileTag = tag.getCompoundTag("tileTag");
-        //metaOfReplacedBlock = tag.getInteger("metaOfReplacedBlock");
         stateOfReplacedBlock = Serializer.parseState(tag.getString("stateOfReplacedBlock"));
 		mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, stateOfReplacedBlock);
         playerCheckRadius = tag.getInteger("playerCheckRadius");
@@ -272,7 +270,6 @@ public class TileMimic extends TileInventory implements ITickable {
 
         tag.setBoolean("dropItemsOnBreak", dropItemsOnBreak);
         tag.setTag("tileTag", tileTag);
-        //tag.setInteger("metaOfReplacedBlock", metaOfReplacedBlock);
         tag.setInteger("playerCheckRadius", playerCheckRadius);
         tag.setInteger("potionSpawnRadius", potionSpawnRadius);
         tag.setInteger("potionSpawnInterval", potionSpawnInterval);
@@ -314,27 +311,6 @@ public class TileMimic extends TileInventory implements ITickable {
         BlockPos pos = mimic.getPos();
 
         replaceMimicWithBlockActual(world, pos, mimic.getStackInSlot(0), mimic.tileTag, mimic.stateOfReplacedBlock);
-    }
-
-	@Deprecated
-    public static boolean replaceMimicWithBlockActual(World world, BlockPos pos, ItemStack stack, NBTTagCompound tileTag, int replacedMeta) {
-        if (!stack.isEmpty() && stack.getItem() instanceof ItemBlock) {
-            Block block = ((ItemBlock) stack.getItem()).getBlock();
-            IBlockState state = block.getStateFromMeta(replacedMeta);
-            if (world.setBlockState(pos, state, 3)) {
-                TileEntity tile = world.getTileEntity(pos);
-                if (tile != null) {
-                    tileTag.setInteger("x", pos.getX());
-                    tileTag.setInteger("y", pos.getY());
-                    tileTag.setInteger("z", pos.getZ());
-                    tile.readFromNBT(tileTag);
-                }
-
-                return true;
-            }
-        }
-
-        return false;
     }
 	
     public static boolean replaceMimicWithBlockActual(World world, BlockPos pos, ItemStack stack, NBTTagCompound tileTag, IBlockState replacementState) {

--- a/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
@@ -6,10 +6,12 @@ import WayofTime.bloodmagic.core.RegistrarBloodMagicItems;
 import WayofTime.bloodmagic.entity.mob.EntityMimic;
 import WayofTime.bloodmagic.util.ChatUtil;
 import WayofTime.bloodmagic.util.Utils;
+import WayofTime.bloodmagic.util.Serializer;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityPotion;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryHelper;
@@ -40,7 +42,8 @@ public class TileMimic extends TileInventory implements ITickable {
     public NBTTagCompound tileTag = new NBTTagCompound();
     public TileEntity mimicedTile = null;
     public int metaOfReplacedBlock = 0;
-
+	public IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();
+	
     public int playerCheckRadius = 5;
     public int potionSpawnRadius = 5;
     public int potionSpawnInterval = 40;
@@ -134,6 +137,13 @@ public class TileMimic extends TileInventory implements ITickable {
             return false;
 
         Utils.insertItemToTile(this, player, 0);
+		ItemStack stack = getStackInSlot(0);
+		if(stateOfReplacedBlock == Blocks.AIR.getDefaultState()) {
+			if (!stack.isEmpty() && stack.getItem() instanceof ItemBlock) {
+				Block block = ((ItemBlock) stack.getItem()).getBlock();
+				stateOfReplacedBlock = block.getDefaultState();
+			}
+		}
         this.refreshTileEntity();
 
         if (player.capabilities.isCreativeMode) {
@@ -220,7 +230,7 @@ public class TileMimic extends TileInventory implements ITickable {
         EntityMimic mimicEntity = new EntityMimic(getWorld());
         mimicEntity.setPosition(pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5);
 
-        mimicEntity.initializeMimic(getStackInSlot(0), tileTag, dropItemsOnBreak, metaOfReplacedBlock, playerCheckRadius, pos);
+        mimicEntity.initializeMimic(getStackInSlot(0), tileTag, dropItemsOnBreak, stateOfReplacedBlock, playerCheckRadius, pos);
         tileTag = null;
         mimicedTile = null;
         this.setInventorySlotContents(0, ItemStack.EMPTY);
@@ -239,7 +249,7 @@ public class TileMimic extends TileInventory implements ITickable {
         if (mimicedTile != null) {
             dropMimicedTileInventory();
         }
-        mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, metaOfReplacedBlock);
+        mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, stateOfReplacedBlock);
     }
 
     @Override
@@ -248,8 +258,9 @@ public class TileMimic extends TileInventory implements ITickable {
 
         dropItemsOnBreak = tag.getBoolean("dropItemsOnBreak");
         tileTag = tag.getCompoundTag("tileTag");
-        metaOfReplacedBlock = tag.getInteger("metaOfReplacedBlock");
-        mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, metaOfReplacedBlock);
+        //metaOfReplacedBlock = tag.getInteger("metaOfReplacedBlock");
+        stateOfReplacedBlock = Serializer.parseState(tag.getString("stateOfReplacedBlock"));
+		mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, stateOfReplacedBlock);
         playerCheckRadius = tag.getInteger("playerCheckRadius");
         potionSpawnRadius = tag.getInteger("potionSpawnRadius");
         potionSpawnInterval = Math.max(1, tag.getInteger("potionSpawnInterval"));
@@ -261,10 +272,11 @@ public class TileMimic extends TileInventory implements ITickable {
 
         tag.setBoolean("dropItemsOnBreak", dropItemsOnBreak);
         tag.setTag("tileTag", tileTag);
-        tag.setInteger("metaOfReplacedBlock", metaOfReplacedBlock);
+        //tag.setInteger("metaOfReplacedBlock", metaOfReplacedBlock);
         tag.setInteger("playerCheckRadius", playerCheckRadius);
         tag.setInteger("potionSpawnRadius", potionSpawnRadius);
         tag.setInteger("potionSpawnInterval", potionSpawnInterval);
+		tag.setString("stateOfReplacedBlock",stateOfReplacedBlock.toString());
 
         return tag;
     }
@@ -284,6 +296,14 @@ public class TileMimic extends TileInventory implements ITickable {
         }
     }
 
+	public IBlockState getReplacedState() {
+		return stateOfReplacedBlock;
+	}
+	
+	public void setReplacedState(IBlockState state) {
+		stateOfReplacedBlock = state;
+	}
+	
     @Override
     public boolean isItemValidForSlot(int slot, ItemStack itemstack) {
         return slot == 0 && dropItemsOnBreak;
@@ -293,9 +313,10 @@ public class TileMimic extends TileInventory implements ITickable {
         World world = mimic.getWorld();
         BlockPos pos = mimic.getPos();
 
-        replaceMimicWithBlockActual(world, pos, mimic.getStackInSlot(0), mimic.tileTag, mimic.metaOfReplacedBlock);
+        replaceMimicWithBlockActual(world, pos, mimic.getStackInSlot(0), mimic.tileTag, mimic.stateOfReplacedBlock);
     }
 
+	@Deprecated
     public static boolean replaceMimicWithBlockActual(World world, BlockPos pos, ItemStack stack, NBTTagCompound tileTag, int replacedMeta) {
         if (!stack.isEmpty() && stack.getItem() instanceof ItemBlock) {
             Block block = ((ItemBlock) stack.getItem()).getBlock();
@@ -315,12 +336,32 @@ public class TileMimic extends TileInventory implements ITickable {
 
         return false;
     }
-
-    @Nullable
-    public static TileEntity getTileFromStackWithTag(World world, BlockPos pos, ItemStack stack, @Nullable NBTTagCompound tag, int replacementMeta) {
+	
+    public static boolean replaceMimicWithBlockActual(World world, BlockPos pos, ItemStack stack, NBTTagCompound tileTag, IBlockState replacementState) {
         if (!stack.isEmpty() && stack.getItem() instanceof ItemBlock) {
             Block block = ((ItemBlock) stack.getItem()).getBlock();
-            IBlockState state = block.getStateFromMeta(stack.getItemDamage());
+            IBlockState state = replacementState;
+            if (world.setBlockState(pos, state, 3)) {
+                TileEntity tile = world.getTileEntity(pos);
+                if (tile != null) {
+                    tileTag.setInteger("x", pos.getX());
+                    tileTag.setInteger("y", pos.getY());
+                    tileTag.setInteger("z", pos.getZ());
+                    tile.readFromNBT(tileTag);
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Nullable
+    public static TileEntity getTileFromStackWithTag(World world, BlockPos pos, ItemStack stack, @Nullable NBTTagCompound tag, IBlockState replacementState) {
+        if (!stack.isEmpty() && stack.getItem() instanceof ItemBlock) {
+            Block block = ((ItemBlock) stack.getItem()).getBlock();
+            IBlockState state = replacementState;
             if (block.hasTileEntity(state)) {
                 TileEntity tile = block.createTileEntity(world, state);
 
@@ -338,7 +379,7 @@ public class TileMimic extends TileInventory implements ITickable {
                 tile.setWorld(world);
 
                 try {
-                    _blockMetadata.setInt(tile, replacementMeta);
+                    _blockMetadata.setInt(tile, block.getMetaFromState(replacementState));
                 } catch (IllegalArgumentException | IllegalAccessException e) {
                     e.printStackTrace();
                 }

--- a/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
+++ b/src/main/java/WayofTime/bloodmagic/tile/TileMimic.java
@@ -6,7 +6,7 @@ import WayofTime.bloodmagic.core.RegistrarBloodMagicItems;
 import WayofTime.bloodmagic.entity.mob.EntityMimic;
 import WayofTime.bloodmagic.util.ChatUtil;
 import WayofTime.bloodmagic.util.Utils;
-import WayofTime.bloodmagic.util.Serializer;
+import WayofTime.bloodmagic.util.StateUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
@@ -41,8 +41,8 @@ public class TileMimic extends TileInventory implements ITickable {
     public boolean dropItemsOnBreak = true;
     public NBTTagCompound tileTag = new NBTTagCompound();
     public TileEntity mimicedTile = null;
-	IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();
-	
+    IBlockState stateOfReplacedBlock = Blocks.AIR.getDefaultState();
+    
     public int playerCheckRadius = 5;
     public int potionSpawnRadius = 5;
     public int potionSpawnInterval = 40;
@@ -136,13 +136,13 @@ public class TileMimic extends TileInventory implements ITickable {
             return false;
 
         Utils.insertItemToTile(this, player, 0);
-		ItemStack stack = getStackInSlot(0);
-		if(stateOfReplacedBlock == Blocks.AIR.getDefaultState()) {
-			if (!stack.isEmpty() && stack.getItem() instanceof ItemBlock) {
-				Block block = ((ItemBlock) stack.getItem()).getBlock();
-				stateOfReplacedBlock = block.getDefaultState();
-			}
-		}
+        ItemStack stack = getStackInSlot(0);
+        if(stateOfReplacedBlock == Blocks.AIR.getDefaultState()) {
+            if (!stack.isEmpty() && stack.getItem() instanceof ItemBlock) {
+                Block block = ((ItemBlock) stack.getItem()).getBlock();
+                stateOfReplacedBlock = block.getDefaultState();
+            }
+        }
         this.refreshTileEntity();
 
         if (player.capabilities.isCreativeMode) {
@@ -257,8 +257,8 @@ public class TileMimic extends TileInventory implements ITickable {
 
         dropItemsOnBreak = tag.getBoolean("dropItemsOnBreak");
         tileTag = tag.getCompoundTag("tileTag");
-        stateOfReplacedBlock = Serializer.parseState(tag.getString("stateOfReplacedBlock"));
-	mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, stateOfReplacedBlock);
+        stateOfReplacedBlock = StateUtil.parseState(tag.getString("stateOfReplacedBlock"));
+    mimicedTile = getTileFromStackWithTag(getWorld(), pos, getStackInSlot(0), tileTag, stateOfReplacedBlock);
         playerCheckRadius = tag.getInteger("playerCheckRadius");
         potionSpawnRadius = tag.getInteger("potionSpawnRadius");
         potionSpawnInterval = Math.max(1, tag.getInteger("potionSpawnInterval"));
@@ -273,7 +273,7 @@ public class TileMimic extends TileInventory implements ITickable {
         tag.setInteger("playerCheckRadius", playerCheckRadius);
         tag.setInteger("potionSpawnRadius", potionSpawnRadius);
         tag.setInteger("potionSpawnInterval", potionSpawnInterval);
-	tag.setString("stateOfReplacedBlock",stateOfReplacedBlock.toString());
+    tag.setString("stateOfReplacedBlock",stateOfReplacedBlock.toString());
 
         return tag;
     }
@@ -293,14 +293,14 @@ public class TileMimic extends TileInventory implements ITickable {
         }
     }
 
-	public IBlockState getReplacedState() {
-		return stateOfReplacedBlock;
-	}
-	
-	public void setReplacedState(IBlockState state) {
-		stateOfReplacedBlock = state;
-	}
-	
+    public IBlockState getReplacedState() {
+        return stateOfReplacedBlock;
+    }
+    
+    public void setReplacedState(IBlockState state) {
+        stateOfReplacedBlock = state;
+    }
+    
     @Override
     public boolean isItemValidForSlot(int slot, ItemStack itemstack) {
         return slot == 0 && dropItemsOnBreak;
@@ -312,7 +312,7 @@ public class TileMimic extends TileInventory implements ITickable {
 
         replaceMimicWithBlockActual(world, pos, mimic.getStackInSlot(0), mimic.tileTag, mimic.stateOfReplacedBlock);
     }
-	
+    
     public static boolean replaceMimicWithBlockActual(World world, BlockPos pos, ItemStack stack, NBTTagCompound tileTag, IBlockState replacementState) {
         if (!stack.isEmpty() && stack.getItem() instanceof ItemBlock) {
             Block block = ((ItemBlock) stack.getItem()).getBlock();

--- a/src/main/java/WayofTime/bloodmagic/util/Serializer.java
+++ b/src/main/java/WayofTime/bloodmagic/util/Serializer.java
@@ -1,0 +1,39 @@
+package WayofTime.bloodmagic.util;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockStateContainer;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+
+public class Serializer
+{
+	//This is a great class name because the one and only function right now deserializes stuff.
+	//TehNut made me do it.
+    public static IBlockState parseState(String blockInfo)
+    {
+        String[] split = blockInfo.split("\\[");
+        split[1] = split[1].substring(0, split[1].lastIndexOf("]")); // Make sure brackets are removed from state
+
+        Block block = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(split[0])); // Find the block
+        if (block == Blocks.AIR)
+            return Blocks.AIR.getDefaultState(); // The block is air, so we're looking at invalid data
+
+        BlockStateContainer blockState = block.getBlockState();
+        IBlockState returnState = blockState.getBaseState();
+
+        // Force our values into the state
+        String[] stateValues = split[1].split(","); // Splits up each value
+        for (String value : stateValues)
+        {
+            String[] valueSplit = value.split("="); // Separates property and value
+            IProperty property = blockState.getProperty(valueSplit[0]);
+            if (property != null)
+                returnState = returnState.withProperty(property, (Comparable) property.parseValue(valueSplit[1]).get()); // Force the property into the state
+        }
+
+        return returnState;
+    }
+}

--- a/src/main/java/WayofTime/bloodmagic/util/StateUtil.java
+++ b/src/main/java/WayofTime/bloodmagic/util/StateUtil.java
@@ -8,10 +8,8 @@ import net.minecraft.init.Blocks;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
-public class Serializer
+public class StateUtil
 {
-	//This is a great class name because the one and only function right now deserializes stuff.
-	//TehNut made me do it.
     public static IBlockState parseState(String blockInfo)
     {
         String[] split = blockInfo.split("\\[");


### PR DESCRIPTION
In response to #1376
A few fixes to mimics have been made to restore the long-missing shift+right click behavior of mimic blocks when placed. Now they'll replace blocks when shift-clicked onto them, and will inherit the BlockState of blocks replaced in this way.

 - Reimplemented the shift+right click behavior of mimics and implemented an explicit mimic ItemBlock
 - Changed the mimic tile from using metadata to using blockstates when storing the replaced block's information. This includes edits to the block, tile, and entity files.
 - Copied parseState() from WayofTime.bloodmagic.api.impl.BloodMagicCorePlugin to a public function in a new class WayofTime.bloodmagic.util.Serializer, because TehNut told me to not put it in Utils.java
 - Completely removed the TileMimic#metaOfReplacedBlock variable and all calls to it. Mimics no longer use metadata directly for their replaced blocks, any metadata values are derived from blockstate.

Also this time I checked to make sure I didn't have a bunch of random extraneous commits and repeats of commits from this repo.