### PR TITLE
Fixed a null pointer exception with certain modded blocks with the Ritual of Magnetism

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/ritual/types/RitualMagnetic.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/types/RitualMagnetic.java
@@ -12,6 +12,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.common.util.FakePlayer;
+import net.minecraftforge.common.util.FakePlayerFactory;
 
 
 import java.util.function.Consumer;
@@ -21,6 +23,7 @@ public class RitualMagnetic extends Ritual {
     public static final String PLACEMENT_RANGE = "placementRange";
     //    public static final String SEARCH_RANGE = "searchRange";
     public BlockPos lastPos; // An offset
+    private FakePlayer fakePlayer;
 
     public RitualMagnetic() {
         super("ritualMagnetic", 0, 5000, "ritual." + BloodMagic.MODID + ".magneticRitual");
@@ -75,7 +78,7 @@ public class RitualMagnetic extends Ritual {
                         Vec3d newPosVector = new Vec3d(newPos);
                         IBlockState state = world.getBlockState(newPos);
                         RayTraceResult fakeRayTrace = world.rayTraceBlocks(MRSpos, newPosVector, false);
-                        ItemStack checkStack = state.getBlock().getPickBlock(state, fakeRayTrace, world, newPos, null);
+                        ItemStack checkStack = state.getBlock().getPickBlock(state, fakeRayTrace, world, newPos, getFakePlayer((WorldServer) world));
                         if (isBlockOre(checkStack)) {
                             Utils.swapLocations(world, newPos, world, replacement);
                             masterRitualStone.getOwnerNetwork().syphon(getRefreshCost());
@@ -138,6 +141,10 @@ public class RitualMagnetic extends Ritual {
     @Override
     public Ritual getNewCopy() {
         return new RitualMagnetic();
+    }
+
+    private FakePlayer getFakePlayer(WorldServer world) {
+        return fakePlayer == null ? fakePlayer = FakePlayerFactory.get(world, new GameProfile(null, BloodMagic.MODID + "_ritual_magnetic")) : fakePlayer;
     }
 
     public static boolean isBlockOre(ItemStack stack) {

--- a/src/main/java/WayofTime/bloodmagic/ritual/types/RitualMagnetic.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/types/RitualMagnetic.java
@@ -7,9 +7,12 @@ import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.oredict.OreDictionary;
+
 
 import java.util.function.Consumer;
 
@@ -28,6 +31,7 @@ public class RitualMagnetic extends Ritual {
     @Override
     public void performRitual(IMasterRitualStone masterRitualStone) {
         World world = masterRitualStone.getWorldObj();
+        Vec3d MRSpos = new Vec3d(masterRitualStone.getBlockPos());
         int currentEssence = masterRitualStone.getOwnerNetwork().getCurrentEssence();
 
         if (currentEssence < getRefreshCost()) {
@@ -68,8 +72,10 @@ public class RitualMagnetic extends Ritual {
                 while (i <= radius) {
                     while (k <= radius) {
                         BlockPos newPos = pos.add(i, j, k);
+                        Vec3d newPosVector = new Vec3d(newPos);
                         IBlockState state = world.getBlockState(newPos);
-                        ItemStack checkStack = state.getBlock().getPickBlock(state, null, world, newPos, null);
+                        RayTraceResult fakeRayTrace = world.rayTraceBlocks(MRSpos, newPosVector, false);
+                        ItemStack checkStack = state.getBlock().getPickBlock(state, fakeRayTrace, world, newPos, null);
                         if (isBlockOre(checkStack)) {
                             Utils.swapLocations(world, newPos, world, replacement);
                             masterRitualStone.getOwnerNetwork().syphon(getRefreshCost());


### PR DESCRIPTION
After looking through some of the choices I could make with rewriting this little bit of code, I decided to keep it simple and keep the use of the getPickBlock() method.
I made it so the Ritual of Magnetism passes a RayTraceResult from the MRS to the target block when calling the getPickBlock() method. This stops it from throwing NPEs for any kind of multipart block that bothers to override getPickBlock() to let you select the actual multipart being looked at.
It's rather unlikely that an ore would ever be a multipart block, so the fact that the RayTraceResult is just made up largely out of thin air isn't really relevant to its job. And in the case that an ore is a multipart that cares about the exact RayTraceResult, the previous code would have just crashed the server, so it wouldn't have found it anyway.

When the mod updates to Minecraft 1.13 all of this can be tossed out in favor of the new vanilla interface for getting item information from blocks, but for now, this fixes the crash.

The Ritual still passes a null value for the EntityPlayer argument of getPickBlock(), but I didn't quite feel confident in setting up a FakePlayer just for the ritual.
Especially since I have no idea how to do that in anything resembling the correct way.