### PR TITLE
Third stage of "Dagger of Sacrifice"-glow

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/item/ItemSacrificialDagger.java
+++ b/src/main/java/WayofTime/bloodmagic/item/ItemSacrificialDagger.java
@@ -34,8 +34,6 @@ import java.util.function.Consumer;
 
 public class ItemSacrificialDagger extends ItemEnum<ItemSacrificialDagger.DaggerType> implements IMeshProvider {
 
-    private boolean hasMaxIncense;
-
     public ItemSacrificialDagger() {
         super(DaggerType.class, "sacrificial_dagger");
 
@@ -56,7 +54,7 @@ public class ItemSacrificialDagger extends ItemEnum<ItemSacrificialDagger.Dagger
     public void onPlayerStoppedUsing(ItemStack stack, World worldIn, EntityLivingBase entityLiving, int timeLeft) {
         if (entityLiving instanceof EntityPlayer && !entityLiving.getEntityWorld().isRemote)
             if(PlayerSacrificeHelper.sacrificePlayerHealth((EntityPlayer) entityLiving))
-                this.hasMaxIncense = (IncenseHelper.getMaxIncense((EntityPlayer) entityLiving) == IncenseHelper.getCurrentIncense((EntityPlayer) entityLiving));
+                IncenseHelper.setHasMaxIncense(stack, (EntityPlayer) entityLiving, false);
     }
 
     @Override
@@ -134,8 +132,12 @@ public class ItemSacrificialDagger extends ItemEnum<ItemSacrificialDagger.Dagger
         if (!world.isRemote && entity instanceof EntityPlayer) {
             boolean prepared = this.isPlayerPreparedForSacrifice(world, (EntityPlayer) entity);
             this.setUseForSacrifice(stack, prepared);
-            if(prepared && !this.hasMaxIncense)
-                this.hasMaxIncense = (IncenseHelper.getMaxIncense((EntityPlayer) entity) == IncenseHelper.getCurrentIncense((EntityPlayer) entity));
+            if(IncenseHelper.getHasMaxIncense(stack) && !prepared)
+                IncenseHelper.setHasMaxIncense(stack, (EntityPlayer) entity, false);
+            if(prepared) {
+                boolean isMax = IncenseHelper.getMaxIncense((EntityPlayer) entity) == IncenseHelper.getCurrentIncense((EntityPlayer) entity);
+                IncenseHelper.setHasMaxIncense(stack, (EntityPlayer) entity, isMax);
+            }
         }
     }
 
@@ -176,10 +178,9 @@ public class ItemSacrificialDagger extends ItemEnum<ItemSacrificialDagger.Dagger
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
     public boolean hasEffect(ItemStack stack)
     {
-        return this.hasMaxIncense || super.hasEffect(stack);
+        return IncenseHelper.getHasMaxIncense(stack) || super.hasEffect(stack);
     }
 
     public enum DaggerType implements ISubItem {

--- a/src/main/java/WayofTime/bloodmagic/util/Constants.java
+++ b/src/main/java/WayofTime/bloodmagic/util/Constants.java
@@ -131,7 +131,6 @@ public class Constants
         public static final String TANK = "tank";
 
         public static final String BREATH = "breath";
-        public static final String MAXINCENSE = "BM:";
     }
 
     public static class Mod

--- a/src/main/java/WayofTime/bloodmagic/util/Constants.java
+++ b/src/main/java/WayofTime/bloodmagic/util/Constants.java
@@ -33,6 +33,7 @@ public class Constants
         public static final String REAGENT_TANKS = "reagentTanks";
         public static final String CURRENT_INCENSE = "BM:CurrentIncense";
         public static final String MAX_INCENSE = "BM:MaxIncenseFromLastAltar";
+        public static final String HAS_MAX_INCENSE = "BM:CurrentIsMaxIncense";
         public static final String CURRENT_PURITY = "BM:CurrentPurity";
         public static final String EMPTY = "Empty";
         public static final String OUTPUT_AMOUNT = "outputAmount";
@@ -130,6 +131,7 @@ public class Constants
         public static final String TANK = "tank";
 
         public static final String BREATH = "breath";
+        public static final String MAXINCENSE = "BM:";
     }
 
     public static class Mod

--- a/src/main/java/WayofTime/bloodmagic/util/Constants.java
+++ b/src/main/java/WayofTime/bloodmagic/util/Constants.java
@@ -32,6 +32,7 @@ public class Constants
         public static final String DIRECTION = "direction";
         public static final String REAGENT_TANKS = "reagentTanks";
         public static final String CURRENT_INCENSE = "BM:CurrentIncense";
+        public static final String MAX_INCENSE = "BM:MaxIncenseFromLastAltar";
         public static final String CURRENT_PURITY = "BM:CurrentPurity";
         public static final String EMPTY = "Empty";
         public static final String OUTPUT_AMOUNT = "outputAmount";

--- a/src/main/java/WayofTime/bloodmagic/util/helper/IncenseHelper.java
+++ b/src/main/java/WayofTime/bloodmagic/util/helper/IncenseHelper.java
@@ -18,4 +18,17 @@ public class IncenseHelper {
         NBTTagCompound data = player.getEntityData();
         data.setDouble(Constants.NBT.CURRENT_INCENSE, amount);
     }
+
+    public static void setMaxIncense(EntityPlayer player, double amount){
+        NBTTagCompound data = player.getEntityData();
+        data.setDouble(Constants.NBT.MAX_INCENSE, amount);
+    }
+
+    public static double getMaxIncense(EntityPlayer player) {
+        NBTTagCompound data = player.getEntityData();
+        if (data.hasKey(Constants.NBT.MAX_INCENSE)) {
+            return data.getDouble(Constants.NBT.MAX_INCENSE);
+        }
+        return 0;
+    }
 }

--- a/src/main/java/WayofTime/bloodmagic/util/helper/IncenseHelper.java
+++ b/src/main/java/WayofTime/bloodmagic/util/helper/IncenseHelper.java
@@ -2,9 +2,11 @@ package WayofTime.bloodmagic.util.helper;
 
 import WayofTime.bloodmagic.util.Constants;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
 public class IncenseHelper {
+
     public static double getCurrentIncense(EntityPlayer player) {
         NBTTagCompound data = player.getEntityData();
         if (data.hasKey(Constants.NBT.CURRENT_INCENSE)) {
@@ -30,5 +32,14 @@ public class IncenseHelper {
             return data.getDouble(Constants.NBT.MAX_INCENSE);
         }
         return 0;
+    }
+
+    public static void setHasMaxIncense(ItemStack stack, EntityPlayer player, boolean isMax) {
+        stack = NBTHelper.checkNBT(stack);
+        stack.getTagCompound().setBoolean(Constants.NBT.MAXINCENSE, isMax);
+    }
+    public static boolean getHasMaxIncense(ItemStack stack) {
+        stack = NBTHelper.checkNBT(stack);
+        return stack.getTagCompound().getBoolean(Constants.NBT.MAXINCENSE);
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/util/helper/IncenseHelper.java
+++ b/src/main/java/WayofTime/bloodmagic/util/helper/IncenseHelper.java
@@ -36,10 +36,10 @@ public class IncenseHelper {
 
     public static void setHasMaxIncense(ItemStack stack, EntityPlayer player, boolean isMax) {
         stack = NBTHelper.checkNBT(stack);
-        stack.getTagCompound().setBoolean(Constants.NBT.MAXINCENSE, isMax);
+        stack.getTagCompound().setBoolean(Constants.NBT.HAS_MAX_INCENSE, isMax);
     }
     public static boolean getHasMaxIncense(ItemStack stack) {
         stack = NBTHelper.checkNBT(stack);
-        return stack.getTagCompound().getBoolean(Constants.NBT.MAXINCENSE);
+        return stack.getTagCompound().getBoolean(Constants.NBT.HAS_MAX_INCENSE);
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/util/helper/PlayerSacrificeHelper.java
+++ b/src/main/java/WayofTime/bloodmagic/util/helper/PlayerSacrificeHelper.java
@@ -35,6 +35,9 @@ public class PlayerSacrificeHelper {
         amount = amount + Math.min(increment, incenseAddition - amount);
         setPlayerIncense(player, amount);
 
+        if(amount == incenseAddition) {
+            IncenseHelper.setMaxIncense(player, incenseAddition);
+        }
         // System.out.println("Amount of incense: " + amount + ", Increment: " +
         // increment);
 

--- a/src/main/java/WayofTime/bloodmagic/util/helper/PlayerSacrificeHelper.java
+++ b/src/main/java/WayofTime/bloodmagic/util/helper/PlayerSacrificeHelper.java
@@ -2,8 +2,8 @@ package WayofTime.bloodmagic.util.helper;
 
 import WayofTime.bloodmagic.ConfigHandler;
 import WayofTime.bloodmagic.altar.IBloodAltar;
-import WayofTime.bloodmagic.event.SacrificeKnifeUsedEvent;
 import WayofTime.bloodmagic.core.RegistrarBloodMagic;
+import WayofTime.bloodmagic.event.SacrificeKnifeUsedEvent;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.potion.Potion;


### PR DESCRIPTION
Added Soul Fray check.
Sacrificial dagger now glows even more if you're fully prepared!
Added NBT field for maximum incense altar bonus from the last incense altar the player has encountered.
(There is a case in which the dagger glows even if the player is not at maximum incense bonus:
 The player must have been at maximum incense bonus and then gone into the vincinity of a stronger incense altar.
 The maximum incense bonus data field only updates once the maximum bonus has been reached for efficiency.)

closes #1034