### PR TITLE
Fixed Crystal Cluster behavior.

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrystal.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrystal.java
@@ -55,7 +55,7 @@ public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvid
                 boolean isCreative = player.capabilities.isCreativeMode;
                 boolean holdsCrystal = player.getHeldItem(hand).getItem() instanceof ItemDemonCrystal;
 
-                if (PlayerDemonWillHandler.getTotalDemonWill(EnumDemonWillType.DEFAULT, player) > 1024 && ((!holdsCrystal || !isCreative))) {
+                if (PlayerDemonWillHandler.getTotalDemonWill(EnumDemonWillType.DEFAULT, player) > 1024 && !(holdsCrystal && isCreative)) {
                     crystal.dropSingleCrystal();
 
                 }

--- a/src/main/java/WayofTime/bloodmagic/tile/TileDemonCrystal.java
+++ b/src/main/java/WayofTime/bloodmagic/tile/TileDemonCrystal.java
@@ -1,17 +1,16 @@
 package WayofTime.bloodmagic.tile;
 
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.inventory.InventoryHelper;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
 import WayofTime.bloodmagic.block.BlockDemonCrystal;
 import WayofTime.bloodmagic.demonAura.WorldDemonWillHandler;
 import WayofTime.bloodmagic.soul.DemonWillHolder;
 import WayofTime.bloodmagic.soul.EnumDemonWillType;
 import WayofTime.bloodmagic.tile.base.TileTicking;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.inventory.InventoryHelper;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.MathHelper;
 
 public class TileDemonCrystal extends TileTicking
 {
@@ -36,6 +35,8 @@ public class TileDemonCrystal extends TileTicking
     {
         if (getWorld().isRemote)
         {
+            if(internalCounter % 20 == 0)
+                getWorld().markBlockRangeForRenderUpdate(pos, pos);
             return;
         }
 


### PR DESCRIPTION
Players in creative mode can now add crystals to crystal blocks by right clicking them with an item demon crystal.

Crystal block texture now updates on the next tick. The render update is only called when a new crystal has been added (by natural or unnatural means).
Adding a crystal imitates a positive result of checkAndGrowCrystal()

Tested successfully in both SSP and SMP

closes #1151