### PR TITLE
Fix: Interaction Sigil of Holding + Seer/Divination Sigil (no render)

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/client/hud/element/ElementDivinedInformation.java
+++ b/src/main/java/WayofTime/bloodmagic/client/hud/element/ElementDivinedInformation.java
@@ -25,24 +25,28 @@ public abstract class ElementDivinedInformation<T extends TileEntity> extends El
         ItemStack sigilStack = player.getHeldItem(EnumHand.MAIN_HAND);
         boolean flag = false;
         if (simple) {
-            if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_DIVINATION) {
+            if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_DIVINATION)
                 flag = true;
-            }
+
+            if(!flag)
+                flag = isFlagSigilHolding(sigilStack, true);
+
             if (!flag) {
                 sigilStack = player.getHeldItem(EnumHand.OFF_HAND);
                 if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_DIVINATION)
                     flag = true;
             }
-            if(!flag){
-                flag = isFlagSigilHolding(sigilStack, true);
-            }
+
             if(!flag) {
-                sigilStack = player.getHeldItem(EnumHand.MAIN_HAND);
                 flag = isFlagSigilHolding(sigilStack, true);
             }
+
         } else {
             if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_SEER)
                 flag = true;
+
+            if(!flag)
+                flag = isFlagSigilHolding(sigilStack, false);
 
             if (!flag) {
                 sigilStack = player.getHeldItem(EnumHand.OFF_HAND);
@@ -50,13 +54,9 @@ public abstract class ElementDivinedInformation<T extends TileEntity> extends El
                     flag = true;
             }
 
-            if(!flag){
+            if(!flag)
                 flag = isFlagSigilHolding(sigilStack, false);
-            }
-            if(!flag) {
-                sigilStack = player.getHeldItem(EnumHand.MAIN_HAND);
-                flag = isFlagSigilHolding(sigilStack, false);
-            }
+
         }
         return super.shouldRender(minecraft) && flag;
     }

--- a/src/main/java/WayofTime/bloodmagic/client/hud/element/ElementDivinedInformation.java
+++ b/src/main/java/WayofTime/bloodmagic/client/hud/element/ElementDivinedInformation.java
@@ -27,36 +27,26 @@ public abstract class ElementDivinedInformation<T extends TileEntity> extends El
         if (simple) {
             if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_DIVINATION)
                 flag = true;
-
-            if(!flag)
-                flag = isFlagSigilHolding(sigilStack, true);
+            else flag = isFlagSigilHolding(sigilStack, true);
 
             if (!flag) {
                 sigilStack = player.getHeldItem(EnumHand.OFF_HAND);
                 if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_DIVINATION)
                     flag = true;
-            }
-
-            if(!flag) {
-                flag = isFlagSigilHolding(sigilStack, true);
+                else flag = isFlagSigilHolding(sigilStack, true);
             }
 
         } else {
             if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_SEER)
                 flag = true;
-
-            if(!flag)
-                flag = isFlagSigilHolding(sigilStack, false);
+            else flag = isFlagSigilHolding(sigilStack, false);
 
             if (!flag) {
                 sigilStack = player.getHeldItem(EnumHand.OFF_HAND);
                 if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_SEER)
                     flag = true;
+                else flag = isFlagSigilHolding(sigilStack, false);
             }
-
-            if(!flag)
-                flag = isFlagSigilHolding(sigilStack, false);
-
         }
         return super.shouldRender(minecraft) && flag;
     }

--- a/src/main/java/WayofTime/bloodmagic/client/hud/element/ElementDivinedInformation.java
+++ b/src/main/java/WayofTime/bloodmagic/client/hud/element/ElementDivinedInformation.java
@@ -1,11 +1,14 @@
 package WayofTime.bloodmagic.client.hud.element;
 
 import WayofTime.bloodmagic.core.RegistrarBloodMagicItems;
+import WayofTime.bloodmagic.item.sigil.ItemSigilHolding;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumHand;
+
+import java.util.List;
 
 public abstract class ElementDivinedInformation<T extends TileEntity> extends ElementTileInformation<T> {
 
@@ -22,13 +25,20 @@ public abstract class ElementDivinedInformation<T extends TileEntity> extends El
         ItemStack sigilStack = player.getHeldItem(EnumHand.MAIN_HAND);
         boolean flag = false;
         if (simple) {
-            if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_DIVINATION)
+            if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_DIVINATION) {
                 flag = true;
-
+            }
             if (!flag) {
                 sigilStack = player.getHeldItem(EnumHand.OFF_HAND);
                 if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_DIVINATION)
                     flag = true;
+            }
+            if(!flag){
+                flag = isFlagSigilHolding(sigilStack, true);
+            }
+            if(!flag) {
+                sigilStack = player.getHeldItem(EnumHand.MAIN_HAND);
+                flag = isFlagSigilHolding(sigilStack, true);
             }
         } else {
             if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_SEER)
@@ -39,8 +49,26 @@ public abstract class ElementDivinedInformation<T extends TileEntity> extends El
                 if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_SEER)
                     flag = true;
             }
-        }
 
+            if(!flag){
+                flag = isFlagSigilHolding(sigilStack, false);
+            }
+            if(!flag) {
+                sigilStack = player.getHeldItem(EnumHand.MAIN_HAND);
+                flag = isFlagSigilHolding(sigilStack, false);
+            }
+        }
         return super.shouldRender(minecraft) && flag;
+    }
+
+    private boolean isFlagSigilHolding(ItemStack sigilStack, boolean simple) {
+        if (sigilStack.getItem() instanceof ItemSigilHolding) {
+            List<ItemStack> internalInv = ItemSigilHolding.getInternalInventory(sigilStack);
+            int currentSlot = ItemSigilHolding.getCurrentItemOrdinal(sigilStack);
+            if(internalInv != null && !internalInv.get(currentSlot).isEmpty()) {
+                return (internalInv.get(currentSlot).getItem() == RegistrarBloodMagicItems.SIGIL_SEER && !simple) || (internalInv.get(currentSlot).getItem() == RegistrarBloodMagicItems.SIGIL_DIVINATION && simple);
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Seer Sigil and Sigil of Divination now work properly when placed inside the Sigil of Holding
(rendering not included)

closes #1285