### PR TITLE
Changed the lava, water, and void sigils to work with fluid tanks better

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilFluidBase.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilFluidBase.java
@@ -1,0 +1,120 @@
+package WayofTime.bloodmagic.item.sigil;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockLiquid;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.IFluidBlock;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.wrappers.BlockLiquidWrapper;
+import net.minecraftforge.fluids.capability.wrappers.BlockWrapper;
+import net.minecraftforge.fluids.capability.wrappers.FluidBlockWrapper;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+
+public abstract class ItemSigilFluidBase extends ItemSigilBase {
+    //Class for sigils that interact with fluids, either creating or deleting them.
+    //Sigils still have to define their own onRightClick behavior, but the actual fluid-interacting code is largely limited to here.
+    public final FluidStack sigilFluid;
+    
+    public ItemSigilFluidBase(String name, int lpUsed, FluidStack fluid){
+        super(name, lpUsed);
+        sigilFluid = fluid;
+    }
+    public ItemSigilFluidBase(String name){
+        super(name);
+        sigilFluid = null;
+    }
+    
+    //The following are handler functions for fluids, all genericized.
+    //They're all based off of the Forge FluidUtil methods, but directly taking the sigilFluid constant instead of getting an argument.
+    
+    /* Gets a fluid handler for the targeted block and siding.
+     * Works for both tile entity liquid containers and fluid blocks.
+     * This one is literally identical to the FluidUtil method of the same signature.
+     */
+    protected IFluidHandler getFluidHandler(World world, BlockPos blockPos, EnumFacing side) {
+        IBlockState state = world.getBlockState(blockPos);
+        Block block = state.getBlock();
+        
+        if (block.hasTileEntity(state)) {
+            TileEntity tile = world.getTileEntity(blockPos);
+            if(tile != null && tile.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side))
+                return tile.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
+        }
+        if (block instanceof IFluidBlock)
+            return new FluidBlockWrapper((IFluidBlock) block, world, blockPos);
+        else if (block instanceof BlockLiquid)
+            return new BlockLiquidWrapper((BlockLiquid) block, world, blockPos);
+        return null;
+    }
+    
+    /* Tries to insert fluid into a fluid handler.
+     * If doTransfer is false, only simulate the transfer. If true, actually do so.
+     * Returns true if the transfer is successful, false otherwise.
+     */
+    protected boolean tryInsertSigilFluid(IFluidHandler destination, boolean doTransfer) {
+        if(destination == null)
+            return false;
+        return destination.fill(sigilFluid, doTransfer) > 0;
+    }
+    
+    /* Tries basically the oppostive of the above, removing fluids instead of adding them
+     */
+    protected boolean tryRemoveFluid(IFluidHandler source, int amount, boolean doTransfer) {
+        if (source == null)
+            return false;
+        return source.drain(amount, doTransfer) != null;
+    }
+    
+    /* Tries to place a fluid block in the world.
+     * Returns true if successful, otherwise false.
+     * This is the big troublesome one, oddly enough.
+     * It's genericized in case anyone wants to create variant sigils with weird fluids.
+     */
+    protected boolean tryPlaceSigilFluid(EntityPlayer player, World world, BlockPos blockPos) {
+        
+        //Make sure world coordinants are valid
+        if (world == null || blockPos == null) {
+            return false;
+        }
+        //Make sure fluid is placeable
+        Fluid fluid = sigilFluid.getFluid();
+        if (!fluid.canBePlacedInWorld()){
+            return false;
+        }
+        
+        //Check if the block is an air block or otherwise replaceable
+        IBlockState state = world.getBlockState(blockPos);
+        Material mat = state.getMaterial();
+        boolean isDestSolid = mat.isSolid();
+        boolean isDestReplaceable = state.getBlock().isReplaceable(world, blockPos);
+        if(!world.isAirBlock(blockPos) && isDestSolid && !isDestReplaceable){
+            return false;
+        }
+        
+        //If the fluid vaporizes, this exists here in the lava sigil solely so the code is usable for other fluids
+        if(world.provider.doesWaterVaporize() && fluid.doesVaporize(sigilFluid)) {
+            fluid.vaporize(player, world, blockPos, sigilFluid);
+            return true;
+        }
+        
+        //Finally we've done enough checking to make sure everything at the end is safe, let's place some fluid.
+        IFluidHandler handler;
+        Block block = fluid.getBlock();
+        if (block instanceof IFluidBlock)
+            handler = new FluidBlockWrapper((IFluidBlock) block, world, blockPos);
+        else if(block instanceof BlockLiquid)
+            handler = new BlockLiquidWrapper((BlockLiquid) block, world, blockPos);
+        else
+            handler = new BlockWrapper(block, world, blockPos);
+        System.out.print(handler);
+        return tryInsertSigilFluid(handler, true);
+    }
+}

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilFluidBase.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilFluidBase.java
@@ -9,44 +9,53 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.fluids.IFluidBlock;
-import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidBlock;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.wrappers.BlockLiquidWrapper;
 import net.minecraftforge.fluids.capability.wrappers.BlockWrapper;
 import net.minecraftforge.fluids.capability.wrappers.FluidBlockWrapper;
-import net.minecraftforge.fluids.capability.IFluidHandler;
+
+import javax.annotation.Nullable;
 
 public abstract class ItemSigilFluidBase extends ItemSigilBase {
     //Class for sigils that interact with fluids, either creating or deleting them.
     //Sigils still have to define their own onRightClick behavior, but the actual fluid-interacting code is largely limited to here.
     public final FluidStack sigilFluid;
-    
-    public ItemSigilFluidBase(String name, int lpUsed, FluidStack fluid){
+
+    public ItemSigilFluidBase(String name, int lpUsed, FluidStack fluid) {
         super(name, lpUsed);
         sigilFluid = fluid;
     }
-    public ItemSigilFluidBase(String name){
+
+    public ItemSigilFluidBase(String name, FluidStack fluid) {
+        super(name);
+        sigilFluid = fluid;
+    }
+
+    public ItemSigilFluidBase(String name) {
         super(name);
         sigilFluid = null;
     }
-    
+
     //The following are handler functions for fluids, all genericized.
     //They're all based off of the Forge FluidUtil methods, but directly taking the sigilFluid constant instead of getting an argument.
-    
+
     /* Gets a fluid handler for the targeted block and siding.
      * Works for both tile entity liquid containers and fluid blocks.
      * This one is literally identical to the FluidUtil method of the same signature.
      */
-    protected IFluidHandler getFluidHandler(World world, BlockPos blockPos, EnumFacing side) {
+    @Nullable
+    protected IFluidHandler getFluidHandler(World world, BlockPos blockPos, @Nullable EnumFacing side) {
         IBlockState state = world.getBlockState(blockPos);
         Block block = state.getBlock();
-        
-        if (block.hasTileEntity(state)) {
-            TileEntity tile = world.getTileEntity(blockPos);
-            if(tile != null && tile.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side))
-                return tile.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
+        TileEntity tile = world.getTileEntity(blockPos);
+        if (tile != null) {
+            IFluidHandler handler = tile.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
+            if (handler != null)
+                return handler;
         }
         if (block instanceof IFluidBlock)
             return new FluidBlockWrapper((IFluidBlock) block, world, blockPos);
@@ -54,17 +63,17 @@ public abstract class ItemSigilFluidBase extends ItemSigilBase {
             return new BlockLiquidWrapper((BlockLiquid) block, world, blockPos);
         return null;
     }
-    
+
     /* Tries to insert fluid into a fluid handler.
      * If doTransfer is false, only simulate the transfer. If true, actually do so.
      * Returns true if the transfer is successful, false otherwise.
      */
     protected boolean tryInsertSigilFluid(IFluidHandler destination, boolean doTransfer) {
-        if(destination == null)
+        if (destination == null)
             return false;
         return destination.fill(sigilFluid, doTransfer) > 0;
     }
-    
+
     /* Tries basically the oppostive of the above, removing fluids instead of adding them
      */
     protected boolean tryRemoveFluid(IFluidHandler source, int amount, boolean doTransfer) {
@@ -72,49 +81,48 @@ public abstract class ItemSigilFluidBase extends ItemSigilBase {
             return false;
         return source.drain(amount, doTransfer) != null;
     }
-    
+
     /* Tries to place a fluid block in the world.
      * Returns true if successful, otherwise false.
      * This is the big troublesome one, oddly enough.
      * It's genericized in case anyone wants to create variant sigils with weird fluids.
      */
     protected boolean tryPlaceSigilFluid(EntityPlayer player, World world, BlockPos blockPos) {
-        
+
         //Make sure world coordinants are valid
         if (world == null || blockPos == null) {
             return false;
         }
         //Make sure fluid is placeable
         Fluid fluid = sigilFluid.getFluid();
-        if (!fluid.canBePlacedInWorld()){
+        if (!fluid.canBePlacedInWorld()) {
             return false;
         }
-        
+
         //Check if the block is an air block or otherwise replaceable
         IBlockState state = world.getBlockState(blockPos);
         Material mat = state.getMaterial();
         boolean isDestSolid = mat.isSolid();
         boolean isDestReplaceable = state.getBlock().isReplaceable(world, blockPos);
-        if(!world.isAirBlock(blockPos) && isDestSolid && !isDestReplaceable){
+        if (!world.isAirBlock(blockPos) && isDestSolid && !isDestReplaceable) {
             return false;
         }
-        
+
         //If the fluid vaporizes, this exists here in the lava sigil solely so the code is usable for other fluids
-        if(world.provider.doesWaterVaporize() && fluid.doesVaporize(sigilFluid)) {
+        if (world.provider.doesWaterVaporize() && fluid.doesVaporize(sigilFluid)) {
             fluid.vaporize(player, world, blockPos, sigilFluid);
             return true;
         }
-        
+
         //Finally we've done enough checking to make sure everything at the end is safe, let's place some fluid.
         IFluidHandler handler;
         Block block = fluid.getBlock();
         if (block instanceof IFluidBlock)
             handler = new FluidBlockWrapper((IFluidBlock) block, world, blockPos);
-        else if(block instanceof BlockLiquid)
+        else if (block instanceof BlockLiquid)
             handler = new BlockLiquidWrapper((BlockLiquid) block, world, blockPos);
         else
             handler = new BlockWrapper(block, world, blockPos);
-        System.out.print(handler);
         return tryInsertSigilFluid(handler, true);
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
@@ -30,7 +30,7 @@ public class ItemSigilLava extends ItemSigilBase implements IFluidHandlerItem {
     public ItemSigilLava() {
         super("lava", 1000);
     }
-	
+    
     @Override
     public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
         ItemStack stack = player.getHeldItem(hand);
@@ -41,61 +41,61 @@ public class ItemSigilLava extends ItemSigilBase implements IFluidHandlerItem {
 
         if (!world.isRemote && !isUnusable(stack)) {
             RayTraceResult rayTrace = this.rayTrace(world, player, false);
-			
+            
             ActionResult<ItemStack> ret = ForgeEventFactory.onBucketUse(player, world, stack, rayTrace);
             if (ret != null) return ret;
-			
-			if (rayTrace == null || rayTrace.typeOfHit != RayTraceResult.Type.BLOCK) {
-				return ActionResult.newResult(EnumActionResult.PASS, stack);
-			}
-			
-			BlockPos blockPos = rayTrace.getBlockPos();
-			
-			if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
-				//Case for if block at blockPos is a fluid handler like a tank
-  				//Try to put fluid into tank
-				IFluidHandler destination = FluidUtil.getFluidHandler(world, blockPos, null);
-				if(destination != null && FluidUtil.tryFluidTransfer(destination, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-					FluidStack result = FluidUtil.tryFluidTransfer(destination, this, this.getFluid(), true);
-					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
-				}
-				//Do the same as above, but use sidedness to interact with the fluid handler.
-				IFluidHandler destinationSide = FluidUtil.getFluidHandler(world, blockPos, rayTrace.sideHit);
-				if(destinationSide != null && FluidUtil.tryFluidTransfer(destinationSide, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-					FluidStack result = FluidUtil.tryFluidTransfer(destinationSide, this, this.getFluid(), true);
-					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
-				}
-				//Case for if block at blockPos is not a tank
-				//Place fluid in world
-				if (destination == null && destinationSide == null){
-					BlockPos targetPos = blockPos.offset(rayTrace.sideHit);
-					if (FluidUtil.tryPlaceFluid(player, world, targetPos, this, this.getFluid()) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()){
-						return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
-					}
-				}
-			}
+            
+            if (rayTrace == null || rayTrace.typeOfHit != RayTraceResult.Type.BLOCK) {
+                return ActionResult.newResult(EnumActionResult.PASS, stack);
+            }
+            
+            BlockPos blockPos = rayTrace.getBlockPos();
+            
+            if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
+                //Case for if block at blockPos is a fluid handler like a tank
+                  //Try to put fluid into tank
+                IFluidHandler destination = FluidUtil.getFluidHandler(world, blockPos, null);
+                if(destination != null && FluidUtil.tryFluidTransfer(destination, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                    FluidStack result = FluidUtil.tryFluidTransfer(destination, this, this.getFluid(), true);
+                    if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                }
+                //Do the same as above, but use sidedness to interact with the fluid handler.
+                IFluidHandler destinationSide = FluidUtil.getFluidHandler(world, blockPos, rayTrace.sideHit);
+                if(destinationSide != null && FluidUtil.tryFluidTransfer(destinationSide, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                    FluidStack result = FluidUtil.tryFluidTransfer(destinationSide, this, this.getFluid(), true);
+                    if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                }
+                //Case for if block at blockPos is not a tank
+                //Place fluid in world
+                if (destination == null && destinationSide == null){
+                    BlockPos targetPos = blockPos.offset(rayTrace.sideHit);
+                    if (FluidUtil.tryPlaceFluid(player, world, targetPos, this, this.getFluid()) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()){
+                        return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                    }
+                }
+            }
         }
 
         return super.onItemRightClick(world, player, hand);
     }
-	
-	//Required interface functions for IFluidHandlerItem
-	public ItemStack getContainer() {
-		return this.getDefaultInstance();
-	}
-	public FluidStack getFluid() {
-		return new FluidStack(FluidRegistry.LAVA, 1000);
-	}
-	public IFluidTankProperties[] getTankProperties() {
-		return new FluidTankProperties[] { new FluidTankProperties(this.getFluid(),1000) };
-	}
-	public int fill(FluidStack resource, boolean doFill) {
-		return 0;
-	}
-	public FluidStack drain(FluidStack resource, boolean doDrain) {
-		return this.getFluid();
-	}
-	public FluidStack drain(int maxDrain, boolean doDrain) {
-		return this.getFluid();
-	}
+    
+    //Required interface functions for IFluidHandlerItem
+    public ItemStack getContainer() {
+        return this.getDefaultInstance();
+    }
+    public FluidStack getFluid() {
+        return new FluidStack(FluidRegistry.LAVA, 1000);
+    }
+    public IFluidTankProperties[] getTankProperties() {
+        return new FluidTankProperties[] { new FluidTankProperties(this.getFluid(),1000) };
+    }
+    public int fill(FluidStack resource, boolean doFill) {
+        return 0;
+    }
+    public FluidStack drain(FluidStack resource, boolean doDrain) {
+        return this.getFluid();
+    }
+    public FluidStack drain(int maxDrain, boolean doDrain) {
+        return this.getFluid();
+    }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
@@ -9,21 +9,28 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.*;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.capability.IFluidTankProperties;
+import net.minecraftforge.fluids.capability.FluidTankProperties;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
-public class ItemSigilLava extends ItemSigilBase {
+
+public class ItemSigilLava extends ItemSigilBase implements IFluidHandlerItem {
     public ItemSigilLava() {
         super("lava", 1000);
     }
-
+	
     @Override
     public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
         ItemStack stack = player.getHeldItem(hand);
@@ -34,80 +41,69 @@ public class ItemSigilLava extends ItemSigilBase {
 
         if (!world.isRemote && !isUnusable(stack)) {
             RayTraceResult rayTrace = this.rayTrace(world, player, false);
-
-            if (rayTrace != null) {
-                ActionResult<ItemStack> ret = ForgeEventFactory.onBucketUse(player, world, stack, rayTrace);
-                if (ret != null)
-                    return ret;
-
-                if (rayTrace.typeOfHit == RayTraceResult.Type.BLOCK) {
-                    BlockPos blockpos = rayTrace.getBlockPos();
-
-                    if (!world.isBlockModifiable(player, blockpos)) {
-                        return super.onItemRightClick(world, player, hand);
-                    }
-
-                    if (!player.canPlayerEdit(blockpos.offset(rayTrace.sideHit), rayTrace.sideHit, stack)) {
-                        return super.onItemRightClick(world, player, hand);
-                    }
-
-                    BlockPos blockpos1 = blockpos.offset(rayTrace.sideHit);
-
-                    if (!player.canPlayerEdit(blockpos1, rayTrace.sideHit, stack)) {
-                        return super.onItemRightClick(world, player, hand);
-                    }
-
-                    if (canPlaceLava(world, blockpos1) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess() && tryPlaceLava(world, blockpos1)) {
-                        return super.onItemRightClick(world, player, hand);
-                    }
-                }
-            }
+			
+            ActionResult<ItemStack> ret = ForgeEventFactory.onBucketUse(player, world, stack, rayTrace);
+            if (ret != null) return ret;
+			
+			if (rayTrace == null || rayTrace.typeOfHit != RayTraceResult.Type.BLOCK) {
+				return ActionResult.newResult(EnumActionResult.PASS, stack);
+			}
+			
+			BlockPos blockPos = rayTrace.getBlockPos();
+			
+			if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
+				/* Case for if block at blockPos is a fluid handler like a tank
+  				 * Put fluid into tank
+				 */
+				IFluidHandler destination = FluidUtil.getFluidHandler(world, blockPos, null);
+				if(destination != null && FluidUtil.tryFluidTransfer(destination, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+					//Attempt to put fluid in sidelessly first
+					FluidStack result = FluidUtil.tryFluidTransfer(destination, this, this.getFluid(), true);
+					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+				}
+				//Do the same as above, but use sidedness to interact with the fluid handler.
+				IFluidHandler destinationSide = FluidUtil.getFluidHandler(world, blockPos, rayTrace.sideHit);
+				if(destinationSide != null && FluidUtil.tryFluidTransfer(destinationSide, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+					//Attempt to put fluid in sidelessly first
+					FluidStack result = FluidUtil.tryFluidTransfer(destinationSide, this, this.getFluid(), true);
+					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+				}
+				//Case for if block at blockPos is not a tank
+				//Place fluid in world
+				if (destination == null && destinationSide == null){
+					BlockPos targetPos = blockPos.offset(rayTrace.sideHit);
+					if (FluidUtil.tryPlaceFluid(player, world, targetPos, this, this.getFluid()) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()){
+						return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+					}
+				}
+			}
         }
 
         return super.onItemRightClick(world, player, hand);
     }
-
-    @Override
-    public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos blockPos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
-        ItemStack stack = player.getHeldItem(hand);
-        if (world.isRemote || player.isSneaking() || isUnusable(stack)) {
-            return EnumActionResult.FAIL;
-        }
-        if (!world.canMineBlockBody(player, blockPos)) {
-            return EnumActionResult.FAIL;
-        }
-
-        TileEntity tile = world.getTileEntity(blockPos);
-        if (tile != null && tile.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side)) {
-            IFluidHandler handler = tile.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
-            FluidStack fluid = new FluidStack(FluidRegistry.LAVA, 1000);
-            int amount = handler.fill(fluid, false);
-
-            if (amount > 0 && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-                handler.fill(fluid, true);
-                return EnumActionResult.SUCCESS;
-            }
-
-            return EnumActionResult.FAIL;
-        }
-
-        return EnumActionResult.FAIL;
-    }
-
-    public boolean canPlaceLava(World world, BlockPos blockPos) {
-        if (!world.isAirBlock(blockPos) && world.getBlockState(blockPos).getBlock().getMaterial(world.getBlockState(blockPos)).isSolid()) {
-            return false;
-        } else if ((world.getBlockState(blockPos).getBlock() == Blocks.LAVA || world.getBlockState(blockPos).getBlock() == Blocks.FLOWING_LAVA) && world.getBlockState(blockPos).getBlock().getMetaFromState(world.getBlockState(blockPos)) == 0) {
-            return false;
-        } else {
-            world.setBlockState(blockPos, Blocks.FLOWING_LAVA.getBlockState().getBaseState(), 3);
-            return true;
-        }
-    }
-
-    public boolean tryPlaceLava(World world, BlockPos pos) {
-        Material material = world.getBlockState(pos).getBlock().getMaterial(world.getBlockState(pos));
-
-        return world.isAirBlock(pos) && !material.isSolid();
-    }
+	
+	//Required interface functions for IFluidHandlerItem
+	public ItemStack getContainer() {
+		return this.getDefaultInstance();
+	}
+	public FluidStack getFluid() {
+		return new FluidStack(FluidRegistry.LAVA, 1000);
+	}
+	public IFluidTankProperties[] getTankProperties() {
+		return new FluidTankProperties[] { new FluidTankProperties(this.getFluid(),1000) };
+	}
+	public int fill(FluidStack resource, boolean doFill) {
+		return 0;
+	}
+	public FluidStack drain(FluidStack resource, boolean doDrain) {
+		return this.getFluid();
+	}
+	public FluidStack drain(int maxDrain, boolean doDrain) {
+		return this.getFluid();
+	}
+	/*
+	public ICapabilityProvider initCapabilities(ItemStack stack, NBTTagCompound nbt) {
+        return new FluidSigilHandler(stack, (IFluidHandlerItem) this, false, true);
+	}
+	*/
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
@@ -52,19 +52,16 @@ public class ItemSigilLava extends ItemSigilBase implements IFluidHandlerItem {
 			BlockPos blockPos = rayTrace.getBlockPos();
 			
 			if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
-				/* Case for if block at blockPos is a fluid handler like a tank
-  				 * Put fluid into tank
-				 */
+				//Case for if block at blockPos is a fluid handler like a tank
+  				//Try to put fluid into tank
 				IFluidHandler destination = FluidUtil.getFluidHandler(world, blockPos, null);
 				if(destination != null && FluidUtil.tryFluidTransfer(destination, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-					//Attempt to put fluid in sidelessly first
 					FluidStack result = FluidUtil.tryFluidTransfer(destination, this, this.getFluid(), true);
 					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
 				}
 				//Do the same as above, but use sidedness to interact with the fluid handler.
 				IFluidHandler destinationSide = FluidUtil.getFluidHandler(world, blockPos, rayTrace.sideHit);
 				if(destinationSide != null && FluidUtil.tryFluidTransfer(destinationSide, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-					//Attempt to put fluid in sidelessly first
 					FluidStack result = FluidUtil.tryFluidTransfer(destinationSide, this, this.getFluid(), true);
 					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
 				}
@@ -101,9 +98,4 @@ public class ItemSigilLava extends ItemSigilBase implements IFluidHandlerItem {
 	public FluidStack drain(int maxDrain, boolean doDrain) {
 		return this.getFluid();
 	}
-	/*
-	public ICapabilityProvider initCapabilities(ItemStack stack, NBTTagCompound nbt) {
-        return new FluidSigilHandler(stack, (IFluidHandlerItem) this, false, true);
-	}
-	*/
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
@@ -4,7 +4,6 @@ import WayofTime.bloodmagic.core.data.SoulTicket;
 import WayofTime.bloodmagic.iface.ISigil;
 import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
-import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -16,19 +15,18 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
-import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.FluidUtil;
-import net.minecraftforge.fluids.capability.IFluidTankProperties;
-import net.minecraftforge.fluids.capability.FluidTankProperties;
-import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+
+import net.minecraftforge.fluids.capability.IFluidHandler;
+
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
 
-public class ItemSigilLava extends ItemSigilBase implements IFluidHandlerItem {
+public class ItemSigilLava extends ItemSigilFluidBase {
+
     public ItemSigilLava() {
-        super("lava", 1000);
+        super("lava", 1000, new FluidStack(FluidRegistry.LAVA, 1000));
     }
     
     @Override
@@ -42,9 +40,6 @@ public class ItemSigilLava extends ItemSigilBase implements IFluidHandlerItem {
         if (!world.isRemote && !isUnusable(stack)) {
             RayTraceResult rayTrace = this.rayTrace(world, player, false);
             
-            ActionResult<ItemStack> ret = ForgeEventFactory.onBucketUse(player, world, stack, rayTrace);
-            if (ret != null) return ret;
-            
             if (rayTrace == null || rayTrace.typeOfHit != RayTraceResult.Type.BLOCK) {
                 return ActionResult.newResult(EnumActionResult.PASS, stack);
             }
@@ -54,48 +49,27 @@ public class ItemSigilLava extends ItemSigilBase implements IFluidHandlerItem {
             if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
                 //Case for if block at blockPos is a fluid handler like a tank
                   //Try to put fluid into tank
-                IFluidHandler destination = FluidUtil.getFluidHandler(world, blockPos, null);
-                if(destination != null && FluidUtil.tryFluidTransfer(destination, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-                    FluidStack result = FluidUtil.tryFluidTransfer(destination, this, this.getFluid(), true);
-                    if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                IFluidHandler destination = getFluidHandler(world, blockPos, null);
+                if(destination != null && tryInsertSigilFluid(destination, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                    boolean result = tryInsertSigilFluid(destination, true);
+                    if (result) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
                 }
                 //Do the same as above, but use sidedness to interact with the fluid handler.
-                IFluidHandler destinationSide = FluidUtil.getFluidHandler(world, blockPos, rayTrace.sideHit);
-                if(destinationSide != null && FluidUtil.tryFluidTransfer(destinationSide, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-                    FluidStack result = FluidUtil.tryFluidTransfer(destinationSide, this, this.getFluid(), true);
-                    if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                IFluidHandler destinationSide = getFluidHandler(world, blockPos, rayTrace.sideHit);
+                if(destinationSide != null && tryInsertSigilFluid(destinationSide, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                    boolean result = tryInsertSigilFluid(destinationSide, true);
+                    if (result) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
                 }
                 //Case for if block at blockPos is not a tank
                 //Place fluid in world
                 if (destination == null && destinationSide == null){
                     BlockPos targetPos = blockPos.offset(rayTrace.sideHit);
-                    if (FluidUtil.tryPlaceFluid(player, world, targetPos, this, this.getFluid()) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()){
+                    if (tryPlaceSigilFluid(player, world, targetPos) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()){
                         return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
                     }
                 }
             }
         }
-
         return super.onItemRightClick(world, player, hand);
-    }
-    
-    //Required interface functions for IFluidHandlerItem
-    public ItemStack getContainer() {
-        return this.getDefaultInstance();
-    }
-    public FluidStack getFluid() {
-        return new FluidStack(FluidRegistry.LAVA, 1000);
-    }
-    public IFluidTankProperties[] getTankProperties() {
-        return new FluidTankProperties[] { new FluidTankProperties(this.getFluid(),1000) };
-    }
-    public int fill(FluidStack resource, boolean doFill) {
-        return 0;
-    }
-    public FluidStack drain(FluidStack resource, boolean doDrain) {
-        return this.getFluid();
-    }
-    public FluidStack drain(int maxDrain, boolean doDrain) {
-        return this.getFluid();
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
@@ -5,21 +5,15 @@ import WayofTime.bloodmagic.iface.ISigil;
 import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
-
-import net.minecraftforge.fluids.capability.IFluidHandler;
-
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
 
@@ -28,7 +22,7 @@ public class ItemSigilLava extends ItemSigilFluidBase {
     public ItemSigilLava() {
         super("lava", 1000, new FluidStack(FluidRegistry.LAVA, 1000));
     }
-    
+
     @Override
     public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
         ItemStack stack = player.getHeldItem(hand);
@@ -39,32 +33,34 @@ public class ItemSigilLava extends ItemSigilFluidBase {
 
         if (!world.isRemote && !isUnusable(stack)) {
             RayTraceResult rayTrace = this.rayTrace(world, player, false);
-            
+
             if (rayTrace == null || rayTrace.typeOfHit != RayTraceResult.Type.BLOCK) {
                 return ActionResult.newResult(EnumActionResult.PASS, stack);
             }
-            
+
             BlockPos blockPos = rayTrace.getBlockPos();
-            
-            if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
+
+            if (world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)) {
                 //Case for if block at blockPos is a fluid handler like a tank
-                  //Try to put fluid into tank
+                //Try to put fluid into tank
                 IFluidHandler destination = getFluidHandler(world, blockPos, null);
-                if(destination != null && tryInsertSigilFluid(destination, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                if (destination != null && tryInsertSigilFluid(destination, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
                     boolean result = tryInsertSigilFluid(destination, true);
-                    if (result) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                    if (result)
+                        return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
                 }
                 //Do the same as above, but use sidedness to interact with the fluid handler.
                 IFluidHandler destinationSide = getFluidHandler(world, blockPos, rayTrace.sideHit);
-                if(destinationSide != null && tryInsertSigilFluid(destinationSide, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                if (destinationSide != null && tryInsertSigilFluid(destinationSide, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
                     boolean result = tryInsertSigilFluid(destinationSide, true);
-                    if (result) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                    if (result)
+                        return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
                 }
                 //Case for if block at blockPos is not a tank
                 //Place fluid in world
-                if (destination == null && destinationSide == null){
+                if (destination == null && destinationSide == null) {
                     BlockPos targetPos = blockPos.offset(rayTrace.sideHit);
-                    if (tryPlaceSigilFluid(player, world, targetPos) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()){
+                    if (tryPlaceSigilFluid(player, world, targetPos) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
                         return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
                     }
                 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilVoid.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilVoid.java
@@ -41,65 +41,52 @@ public class ItemSigilVoid extends ItemSigilBase implements IFluidHandlerItem {
 
         if (!world.isRemote && !isUnusable(stack)) {
             RayTraceResult rayTrace = this.rayTrace(world, player, true);
-			
+            
             ActionResult<ItemStack> ret = ForgeEventFactory.onBucketUse(player, world, stack, rayTrace);
             if (ret != null) return ret;
-			
-			if (rayTrace == null || rayTrace.typeOfHit != RayTraceResult.Type.BLOCK) {
-				return ActionResult.newResult(EnumActionResult.PASS, stack);
-			}
-			
-			BlockPos blockPos = rayTrace.getBlockPos();
-			
-			if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
-				/* Case for if block at blockPos is a fluid handler like a tank
-  				 * Put fluid into tank
-				 */
-				IFluidHandler destination = FluidUtil.getFluidHandler(world, blockPos, null);
-				if(destination != null && FluidUtil.tryFluidTransfer(this, destination, 1000, false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-					//Attempt to put fluid in sidelessly first
-					FluidStack result = FluidUtil.tryFluidTransfer(this, destination, 1000, true);
-					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
-				}
-				//Do the same as above, but use sidedness to interact with the fluid handler.
-				IFluidHandler destinationSide = FluidUtil.getFluidHandler(world, blockPos, rayTrace.sideHit);
-				if(destinationSide != null && FluidUtil.tryFluidTransfer(this, destinationSide, 1000, false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-					//Attempt to put fluid in sidelessly first
-					FluidStack result = FluidUtil.tryFluidTransfer(this, destinationSide, 1000, true);
-					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
-				}
-				/*
-				//Case for if block at blockPos is not a tank
-				//Remove fluid from the world
-				BlockPos targetPos = blockPos.offset(rayTrace.sideHit);
-				IFluidHandler destination = FluidUtil.getFluidHandler(world, targetPos, rayTrace.sideHit);
-				if(destination != null && FluidUtil.tryFluidTransfer(this, destination, 1000, false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-					//Attempt to put fluid in sidelessly first
-					FluidStack result = FluidUtil.tryFluidTransfer(this, destination, 1000, true);
-					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
-				}*/
-			}
+            
+            if (rayTrace == null || rayTrace.typeOfHit != RayTraceResult.Type.BLOCK) {
+                return ActionResult.newResult(EnumActionResult.PASS, stack);
+            }
+            
+            BlockPos blockPos = rayTrace.getBlockPos();
+            
+            if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
+                //Void is simpler than the other fluid sigils, because getFluidHandler grabs fluid blocks just fine
+                //So extract from fluid tanks with a null side; or drain fluid blocks.
+                IFluidHandler destination = FluidUtil.getFluidHandler(world, blockPos, null);
+                if(destination != null && FluidUtil.tryFluidTransfer(this, destination, 1000, false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                    FluidStack result = FluidUtil.tryFluidTransfer(this, destination, 1000, true);
+                    if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                }
+                //Do the same as above, but use sidedness to interact with the fluid handler.
+                IFluidHandler destinationSide = FluidUtil.getFluidHandler(world, blockPos, rayTrace.sideHit);
+                if(destinationSide != null && FluidUtil.tryFluidTransfer(this, destinationSide, 1000, false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                    FluidStack result = FluidUtil.tryFluidTransfer(this, destinationSide, 1000, true);
+                    if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                }
+            }
         }
 
         return super.onItemRightClick(world, player, hand);
     }
-	
-	public ItemStack getContainer() {
-		return this.getDefaultInstance();
-	}
-	public FluidStack getFluid() {
-		return null;
-	}
-	public IFluidTankProperties[] getTankProperties() {
-		return new FluidTankProperties[] { new FluidTankProperties(null,Integer.MAX_VALUE, true, false) };
-	}
-	public int fill(FluidStack resource, boolean doFill) {
-		return 1000;
-	}
-	public FluidStack drain(FluidStack resource, boolean doDrain) {
-		return null;
-	}
-	public FluidStack drain(int maxDrain, boolean doDrain) {
-		return null;
-	}
+    
+    public ItemStack getContainer() {
+        return this.getDefaultInstance();
+    }
+    public FluidStack getFluid() {
+        return null;
+    }
+    public IFluidTankProperties[] getTankProperties() {
+        return new FluidTankProperties[] { new FluidTankProperties(null,Integer.MAX_VALUE, true, false) };
+    }
+    public int fill(FluidStack resource, boolean doFill) {
+        return 1000;
+    }
+    public FluidStack drain(FluidStack resource, boolean doDrain) {
+        return null;
+    }
+    public FluidStack drain(int maxDrain, boolean doDrain) {
+        return null;
+    }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilVoid.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilVoid.java
@@ -4,20 +4,14 @@ import WayofTime.bloodmagic.core.data.SoulTicket;
 import WayofTime.bloodmagic.iface.ISigil;
 import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
-import net.minecraft.block.BlockCauldron;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
-import net.minecraftforge.fluids.FluidRegistry;
-import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
 public class ItemSigilVoid extends ItemSigilFluidBase {
@@ -35,24 +29,26 @@ public class ItemSigilVoid extends ItemSigilFluidBase {
 
         if (!world.isRemote && !isUnusable(stack)) {
             RayTraceResult rayTrace = this.rayTrace(world, player, true);
-            
+
             if (rayTrace == null || rayTrace.typeOfHit != RayTraceResult.Type.BLOCK) {
                 return ActionResult.newResult(EnumActionResult.PASS, stack);
             }
-            
+
             BlockPos blockPos = rayTrace.getBlockPos();
-            
-            if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
+
+            if (world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)) {
                 //Void is simpler than the other fluid sigils, because getFluidHandler grabs fluid blocks just fine
                 //So extract from fluid tanks with a null side; or drain fluid blocks.
                 IFluidHandler destination = getFluidHandler(world, blockPos, null);
-                if(destination != null && tryRemoveFluid(destination, 1000, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-                    if (tryRemoveFluid(destination, 1000, true)) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                if (destination != null && tryRemoveFluid(destination, 1000, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                    if (tryRemoveFluid(destination, 1000, true))
+                        return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
                 }
                 //Do the same as above, but use sidedness to interact with the fluid handler.
                 IFluidHandler destinationSide = getFluidHandler(world, blockPos, rayTrace.sideHit);
-                if(destinationSide != null && tryRemoveFluid(destinationSide, 1000, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-                    if (tryRemoveFluid(destinationSide, 1000, true)) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                if (destinationSide != null && tryRemoveFluid(destinationSide, 1000, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                    if (tryRemoveFluid(destinationSide, 1000, true))
+                        return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
                 }
             }
         }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilVoid.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilVoid.java
@@ -1,24 +1,32 @@
 package WayofTime.bloodmagic.item.sigil;
 
-import WayofTime.bloodmagic.core.data.SoulNetwork;
 import WayofTime.bloodmagic.core.data.SoulTicket;
 import WayofTime.bloodmagic.iface.ISigil;
 import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
+import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.*;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.IFluidBlock;
-import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.FluidActionResult;
+import net.minecraftforge.fluids.capability.IFluidTankProperties;
+import net.minecraftforge.fluids.capability.FluidTankProperties;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
-public class ItemSigilVoid extends ItemSigilBase {
+public class ItemSigilVoid extends ItemSigilBase implements IFluidHandlerItem {
     public ItemSigilVoid() {
         super("void", 50);
     }
@@ -33,82 +41,65 @@ public class ItemSigilVoid extends ItemSigilBase {
 
         if (!world.isRemote && !isUnusable(stack)) {
             RayTraceResult rayTrace = this.rayTrace(world, player, true);
-
-            if (rayTrace != null) {
-                ActionResult<ItemStack> ret = ForgeEventFactory.onBucketUse(player, world, stack, rayTrace);
-                if (ret != null)
-                    return ret;
-
-                if (rayTrace.typeOfHit == RayTraceResult.Type.BLOCK) {
-                    BlockPos blockpos = rayTrace.getBlockPos();
-
-                    if (!world.isBlockModifiable(player, blockpos)) {
-                        return super.onItemRightClick(world, player, hand);
-                    }
-
-                    if (!player.canPlayerEdit(blockpos.offset(rayTrace.sideHit), rayTrace.sideHit, stack)) {
-                        return super.onItemRightClick(world, player, hand);
-                    }
-
-                    if (!player.canPlayerEdit(blockpos, rayTrace.sideHit, stack)) {
-                        return super.onItemRightClick(world, player, hand);
-                    }
-
-                    if (world.getBlockState(blockpos).getBlock().getMaterial(world.getBlockState(blockpos)).isLiquid() && NetworkHelper.getSoulNetwork(player).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-                        world.setBlockToAir(blockpos);
-                        return super.onItemRightClick(world, player, hand);
-                    }
-                }
-            } else {
-                return super.onItemRightClick(world, player, hand);
-            }
-
-            if (!player.capabilities.isCreativeMode)
-                setUnusable(stack, !NetworkHelper.getSoulNetwork(player).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess());
+			
+            ActionResult<ItemStack> ret = ForgeEventFactory.onBucketUse(player, world, stack, rayTrace);
+            if (ret != null) return ret;
+			
+			if (rayTrace == null || rayTrace.typeOfHit != RayTraceResult.Type.BLOCK) {
+				return ActionResult.newResult(EnumActionResult.PASS, stack);
+			}
+			
+			BlockPos blockPos = rayTrace.getBlockPos();
+			
+			if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
+				/* Case for if block at blockPos is a fluid handler like a tank
+  				 * Put fluid into tank
+				 */
+				IFluidHandler destination = FluidUtil.getFluidHandler(world, blockPos, null);
+				if(destination != null && FluidUtil.tryFluidTransfer(this, destination, 1000, false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+					//Attempt to put fluid in sidelessly first
+					FluidStack result = FluidUtil.tryFluidTransfer(this, destination, 1000, true);
+					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+				}
+				//Do the same as above, but use sidedness to interact with the fluid handler.
+				IFluidHandler destinationSide = FluidUtil.getFluidHandler(world, blockPos, rayTrace.sideHit);
+				if(destinationSide != null && FluidUtil.tryFluidTransfer(this, destinationSide, 1000, false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+					//Attempt to put fluid in sidelessly first
+					FluidStack result = FluidUtil.tryFluidTransfer(this, destinationSide, 1000, true);
+					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+				}
+				/*
+				//Case for if block at blockPos is not a tank
+				//Remove fluid from the world
+				BlockPos targetPos = blockPos.offset(rayTrace.sideHit);
+				IFluidHandler destination = FluidUtil.getFluidHandler(world, targetPos, rayTrace.sideHit);
+				if(destination != null && FluidUtil.tryFluidTransfer(this, destination, 1000, false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+					//Attempt to put fluid in sidelessly first
+					FluidStack result = FluidUtil.tryFluidTransfer(this, destination, 1000, true);
+					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+				}*/
+			}
         }
 
         return super.onItemRightClick(world, player, hand);
     }
-
-    @Override
-    public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos blockPos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
-        ItemStack stack = player.getHeldItem(hand);
-        if (PlayerHelper.isFakePlayer(player))
-            return EnumActionResult.FAIL;
-
-        if (world.isRemote || player.isSneaking() || isUnusable(stack)) {
-            return EnumActionResult.FAIL;
-        }
-
-        if (!world.canMineBlockBody(player, blockPos)) {
-            return EnumActionResult.FAIL;
-        }
-
-        SoulNetwork network = NetworkHelper.getSoulNetwork(getBinding(stack));
-        TileEntity tile = world.getTileEntity(blockPos);
-        if (tile != null && tile.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side)) {
-            IFluidHandler handler = tile.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
-            FluidStack amount = handler.drain(1000, false);
-
-            if (amount != null && amount.amount > 0 && network.syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-                handler.drain(1000, true);
-                return EnumActionResult.SUCCESS;
-            }
-
-            return EnumActionResult.FAIL;
-        }
-
-        BlockPos newPos = blockPos.offset(side);
-
-        if (!player.canPlayerEdit(newPos, side, stack)) {
-            return EnumActionResult.FAIL;
-        }
-
-        if (world.getBlockState(newPos).getBlock() instanceof IFluidBlock && network.syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-            world.setBlockToAir(newPos);
-            return EnumActionResult.SUCCESS;
-        }
-
-        return EnumActionResult.FAIL;
-    }
+	
+	public ItemStack getContainer() {
+		return this.getDefaultInstance();
+	}
+	public FluidStack getFluid() {
+		return null;
+	}
+	public IFluidTankProperties[] getTankProperties() {
+		return new FluidTankProperties[] { new FluidTankProperties(null,Integer.MAX_VALUE, true, false) };
+	}
+	public int fill(FluidStack resource, boolean doFill) {
+		return 1000;
+	}
+	public FluidStack drain(FluidStack resource, boolean doDrain) {
+		return null;
+	}
+	public FluidStack drain(int maxDrain, boolean doDrain) {
+		return null;
+	}
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
@@ -8,20 +8,17 @@ import net.minecraft.block.BlockCauldron;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
-
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
-public class ItemSigilWater extends ItemSigilFluidBase{
+public class ItemSigilWater extends ItemSigilFluidBase {
     public ItemSigilWater() {
         super("water", 100, new FluidStack(FluidRegistry.WATER, 1000));
     }
@@ -36,39 +33,41 @@ public class ItemSigilWater extends ItemSigilFluidBase{
 
         if (!world.isRemote && !isUnusable(stack)) {
             RayTraceResult rayTrace = this.rayTrace(world, player, false);
-            
+
             if (rayTrace == null || rayTrace.typeOfHit != RayTraceResult.Type.BLOCK) {
                 return ActionResult.newResult(EnumActionResult.PASS, stack);
             }
-            
+
             BlockPos blockPos = rayTrace.getBlockPos();
-            
-            if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
+
+            if (world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)) {
                 //Case for if block at blockPos is a fluid handler like a tank
-                  //Try to put fluid into tank
+                //Try to put fluid into tank
                 IFluidHandler destination = getFluidHandler(world, blockPos, null);
-                if(destination != null && tryInsertSigilFluid(destination, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                if (destination != null && tryInsertSigilFluid(destination, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
                     boolean result = tryInsertSigilFluid(destination, true);
-                    if (result) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                    if (result)
+                        return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
                 }
                 //Do the same as above, but use sidedness to interact with the fluid handler.
                 IFluidHandler destinationSide = getFluidHandler(world, blockPos, rayTrace.sideHit);
-                if(destinationSide != null && tryInsertSigilFluid(destinationSide, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                if (destinationSide != null && tryInsertSigilFluid(destinationSide, false) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
                     boolean result = tryInsertSigilFluid(destinationSide, true);
-                    if (result) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                    if (result)
+                        return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
                 }
 
                 //Special vanilla cauldron handling, yay.
-                if(world.getBlockState(blockPos).getBlock() == Blocks.CAULDRON && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                if (world.getBlockState(blockPos).getBlock() == Blocks.CAULDRON && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
                     world.setBlockState(blockPos, Blocks.CAULDRON.getDefaultState().withProperty(BlockCauldron.LEVEL, 3));
                     return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
                 }
-                
+
                 //Case for if block at blockPos is not a tank
                 //Place fluid in world
-                if (destination == null && destinationSide == null){
+                if (destination == null && destinationSide == null) {
                     BlockPos targetPos = blockPos.offset(rayTrace.sideHit);
-                    if (tryPlaceSigilFluid(player, world, targetPos) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()){
+                    if (tryPlaceSigilFluid(player, world, targetPos) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
                         return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
                     }
                 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
@@ -42,66 +42,66 @@ public class ItemSigilWater extends ItemSigilBase implements IFluidHandlerItem {
 
         if (!world.isRemote && !isUnusable(stack)) {
             RayTraceResult rayTrace = this.rayTrace(world, player, false);
-			
+            
             ActionResult<ItemStack> ret = ForgeEventFactory.onBucketUse(player, world, stack, rayTrace);
             if (ret != null) return ret;
-			
-			if (rayTrace == null || rayTrace.typeOfHit != RayTraceResult.Type.BLOCK) {
-				return ActionResult.newResult(EnumActionResult.PASS, stack);
-			}
-			
-			BlockPos blockPos = rayTrace.getBlockPos();
-			
-			if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
-				//Case for if block at blockPos is a fluid handler like a tank
-  				//Try to put fluid into tank
-				IFluidHandler destination = FluidUtil.getFluidHandler(world, blockPos, null);
-				if(destination != null && FluidUtil.tryFluidTransfer(destination, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-					FluidStack result = FluidUtil.tryFluidTransfer(destination, this, this.getFluid(), true);
-					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
-				}
-				//Do the same as above, but use sidedness to interact with the fluid handler for weird handlers.
-				IFluidHandler destinationSide = FluidUtil.getFluidHandler(world, blockPos, rayTrace.sideHit);
-				if(destinationSide != null && FluidUtil.tryFluidTransfer(destinationSide, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-					FluidStack result = FluidUtil.tryFluidTransfer(destinationSide, this, this.getFluid(), true);
-					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
-				}
-				//Special vanilla cauldron handling, yay.
-				if(world.getBlockState(blockPos).getBlock() == Blocks.CAULDRON && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+            
+            if (rayTrace == null || rayTrace.typeOfHit != RayTraceResult.Type.BLOCK) {
+                return ActionResult.newResult(EnumActionResult.PASS, stack);
+            }
+            
+            BlockPos blockPos = rayTrace.getBlockPos();
+            
+            if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
+                //Case for if block at blockPos is a fluid handler like a tank
+                  //Try to put fluid into tank
+                IFluidHandler destination = FluidUtil.getFluidHandler(world, blockPos, null);
+                if(destination != null && FluidUtil.tryFluidTransfer(destination, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                    FluidStack result = FluidUtil.tryFluidTransfer(destination, this, this.getFluid(), true);
+                    if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                }
+                //Do the same as above, but use sidedness to interact with the fluid handler for weird handlers.
+                IFluidHandler destinationSide = FluidUtil.getFluidHandler(world, blockPos, rayTrace.sideHit);
+                if(destinationSide != null && FluidUtil.tryFluidTransfer(destinationSide, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                    FluidStack result = FluidUtil.tryFluidTransfer(destinationSide, this, this.getFluid(), true);
+                    if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                }
+                //Special vanilla cauldron handling, yay.
+                if(world.getBlockState(blockPos).getBlock() == Blocks.CAULDRON && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
                     world.setBlockState(blockPos, Blocks.CAULDRON.getDefaultState().withProperty(BlockCauldron.LEVEL, 3));
-					return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
-				}
-				
-				//Case for if block at blockPos is not a tank
-				//Place fluid in world
-				if (destination == null && destinationSide == null){
-					BlockPos targetPos = blockPos.offset(rayTrace.sideHit);
-					if (FluidUtil.tryPlaceFluid(player, world, targetPos, this, this.getFluid()) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()){
-						return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
-					}
-				}
-			}
+                    return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                }
+                
+                //Case for if block at blockPos is not a tank
+                //Place fluid in world
+                if (destination == null && destinationSide == null){
+                    BlockPos targetPos = blockPos.offset(rayTrace.sideHit);
+                    if (FluidUtil.tryPlaceFluid(player, world, targetPos, this, this.getFluid()) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()){
+                        return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+                    }
+                }
+            }
         }
 
         return super.onItemRightClick(world, player, hand);
     }
-	
-	public ItemStack getContainer() {
-		return this.getDefaultInstance();
-	}
-	public FluidStack getFluid() {
-		return new FluidStack(FluidRegistry.WATER, 1000);
-	}
-	public IFluidTankProperties[] getTankProperties() {
-		return new FluidTankProperties[] { new FluidTankProperties(this.getFluid(),1000) };
-	}
-	public int fill(FluidStack resource, boolean doFill) {
-		return 0;
-	}
-	public FluidStack drain(FluidStack resource, boolean doDrain) {
-		return this.getFluid();
-	}
-	public FluidStack drain(int maxDrain, boolean doDrain) {
-		return this.getFluid();
-	}
+    
+    public ItemStack getContainer() {
+        return this.getDefaultInstance();
+    }
+    public FluidStack getFluid() {
+        return new FluidStack(FluidRegistry.WATER, 1000);
+    }
+    public IFluidTankProperties[] getTankProperties() {
+        return new FluidTankProperties[] { new FluidTankProperties(this.getFluid(),1000) };
+    }
+    public int fill(FluidStack resource, boolean doFill) {
+        return 0;
+    }
+    public FluidStack drain(FluidStack resource, boolean doDrain) {
+        return this.getFluid();
+    }
+    public FluidStack drain(int maxDrain, boolean doDrain) {
+        return this.getFluid();
+    }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
@@ -53,19 +53,16 @@ public class ItemSigilWater extends ItemSigilBase implements IFluidHandlerItem {
 			BlockPos blockPos = rayTrace.getBlockPos();
 			
 			if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
-				/* Case for if block at blockPos is a fluid handler like a tank
-  				 * Put fluid into tank
-				 */
+				//Case for if block at blockPos is a fluid handler like a tank
+  				//Try to put fluid into tank
 				IFluidHandler destination = FluidUtil.getFluidHandler(world, blockPos, null);
 				if(destination != null && FluidUtil.tryFluidTransfer(destination, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-					//Attempt to put fluid in sidelessly first
 					FluidStack result = FluidUtil.tryFluidTransfer(destination, this, this.getFluid(), true);
 					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
 				}
-				//Do the same as above, but use sidedness to interact with the fluid handler.
+				//Do the same as above, but use sidedness to interact with the fluid handler for weird handlers.
 				IFluidHandler destinationSide = FluidUtil.getFluidHandler(world, blockPos, rayTrace.sideHit);
 				if(destinationSide != null && FluidUtil.tryFluidTransfer(destinationSide, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-					//Attempt to put fluid in sidelessly first
 					FluidStack result = FluidUtil.tryFluidTransfer(destinationSide, this, this.getFluid(), true);
 					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
 				}

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
@@ -11,16 +11,23 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.*;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
+import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.capability.IFluidTankProperties;
+import net.minecraftforge.fluids.capability.FluidTankProperties;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
-public class ItemSigilWater extends ItemSigilBase {
+public class ItemSigilWater extends ItemSigilBase implements IFluidHandlerItem {
     public ItemSigilWater() {
         super("water", 100);
     }
@@ -35,99 +42,69 @@ public class ItemSigilWater extends ItemSigilBase {
 
         if (!world.isRemote && !isUnusable(stack)) {
             RayTraceResult rayTrace = this.rayTrace(world, player, false);
-
-            if (rayTrace != null) {
-                ActionResult<ItemStack> ret = net.minecraftforge.event.ForgeEventFactory.onBucketUse(player, world, stack, rayTrace);
-                if (ret != null)
-                    return ret;
-
-                if (rayTrace.typeOfHit == RayTraceResult.Type.BLOCK) {
-                    BlockPos blockpos = rayTrace.getBlockPos();
-
-                    if (!world.isBlockModifiable(player, blockpos))
-                        return super.onItemRightClick(world, player, hand);
-
-                    if (!player.canPlayerEdit(blockpos.offset(rayTrace.sideHit), rayTrace.sideHit, stack))
-                        return super.onItemRightClick(world, player, hand);
-
-                    BlockPos blockpos1 = blockpos.offset(rayTrace.sideHit);
-
-                    if (!player.canPlayerEdit(blockpos1, rayTrace.sideHit, stack))
-                        return super.onItemRightClick(world, player, hand);
-
-                    if (canPlaceWater(world, blockpos1) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess() && tryPlaceWater(world, blockpos1))
-                        return super.onItemRightClick(world, player, hand);
-                }
-            }
+			
+            ActionResult<ItemStack> ret = ForgeEventFactory.onBucketUse(player, world, stack, rayTrace);
+            if (ret != null) return ret;
+			
+			if (rayTrace == null || rayTrace.typeOfHit != RayTraceResult.Type.BLOCK) {
+				return ActionResult.newResult(EnumActionResult.PASS, stack);
+			}
+			
+			BlockPos blockPos = rayTrace.getBlockPos();
+			
+			if(world.isBlockModifiable(player, blockPos) && player.canPlayerEdit(blockPos, rayTrace.sideHit, stack)){
+				/* Case for if block at blockPos is a fluid handler like a tank
+  				 * Put fluid into tank
+				 */
+				IFluidHandler destination = FluidUtil.getFluidHandler(world, blockPos, null);
+				if(destination != null && FluidUtil.tryFluidTransfer(destination, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+					//Attempt to put fluid in sidelessly first
+					FluidStack result = FluidUtil.tryFluidTransfer(destination, this, this.getFluid(), true);
+					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+				}
+				//Do the same as above, but use sidedness to interact with the fluid handler.
+				IFluidHandler destinationSide = FluidUtil.getFluidHandler(world, blockPos, rayTrace.sideHit);
+				if(destinationSide != null && FluidUtil.tryFluidTransfer(destinationSide, this, getFluid(), false) != null && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+					//Attempt to put fluid in sidelessly first
+					FluidStack result = FluidUtil.tryFluidTransfer(destinationSide, this, this.getFluid(), true);
+					if (result != null) return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+				}
+				//Special vanilla cauldron handling, yay.
+				if(world.getBlockState(blockPos).getBlock() == Blocks.CAULDRON && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
+                    world.setBlockState(blockPos, Blocks.CAULDRON.getDefaultState().withProperty(BlockCauldron.LEVEL, 3));
+					return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+				}
+				
+				//Case for if block at blockPos is not a tank
+				//Place fluid in world
+				if (destination == null && destinationSide == null){
+					BlockPos targetPos = blockPos.offset(rayTrace.sideHit);
+					if (FluidUtil.tryPlaceFluid(player, world, targetPos, this, this.getFluid()) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()){
+						return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
+					}
+				}
+			}
         }
 
         return super.onItemRightClick(world, player, hand);
     }
-
-    @Override
-    public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos blockPos, EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ) {
-        ItemStack stack = player.getHeldItem(hand);
-        if (world.isRemote || player.isSneaking() || isUnusable(stack))
-            return EnumActionResult.FAIL;
-
-        if (!world.canMineBlockBody(player, blockPos))
-            return EnumActionResult.FAIL;
-
-        TileEntity tile = world.getTileEntity(blockPos);
-        if (tile != null && tile.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side)) {
-            IFluidHandler handler = tile.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
-            FluidStack fluid = new FluidStack(FluidRegistry.WATER, 1000);
-            int amount = handler.fill(fluid, false);
-
-            if (amount > 0 && NetworkHelper.getSoulNetwork(player).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-                handler.fill(fluid, true);
-                return EnumActionResult.SUCCESS;
-            }
-
-            return EnumActionResult.FAIL;
-        }
-
-        if (world.getBlockState(blockPos).getBlock() == Blocks.CAULDRON && NetworkHelper.getSoulNetwork(player).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess()) {
-            world.setBlockState(blockPos, Blocks.CAULDRON.getDefaultState().withProperty(BlockCauldron.LEVEL, 3));
-            return EnumActionResult.SUCCESS;
-        }
-
-        return EnumActionResult.FAIL;
-    }
-
-    public boolean canPlaceWater(World world, BlockPos blockPos) {
-        if (!world.isAirBlock(blockPos) && world.getBlockState(blockPos).getBlock().getMaterial(world.getBlockState(blockPos)).isSolid())
-            return false;
-        else if ((world.getBlockState(blockPos).getBlock() == Blocks.WATER || world.getBlockState(blockPos).getBlock() == Blocks.FLOWING_WATER) && world.getBlockState(blockPos).getBlock().getMetaFromState(world.getBlockState(blockPos)) == 0)
-            return false;
-        else
-            return true;
-    }
-
-    public boolean tryPlaceWater(World worldIn, BlockPos pos) {
-
-        Material material = worldIn.getBlockState(pos).getBlock().getMaterial(worldIn.getBlockState(pos));
-        boolean notSolid = !material.isSolid();
-
-        if (!worldIn.isAirBlock(pos) && !notSolid) {
-            return false;
-        } else {
-            if (worldIn.provider.doesWaterVaporize()) {
-                int i = pos.getX();
-                int j = pos.getY();
-                int k = pos.getZ();
-                worldIn.playSound(null, i, j, k, SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.BLOCKS, 0.5F, 2.6F + (worldIn.rand.nextFloat() - worldIn.rand.nextFloat()) * 0.8F);
-
-                for (int l = 0; l < 8; ++l)
-                    worldIn.spawnParticle(EnumParticleTypes.SMOKE_LARGE, (double) i + Math.random(), (double) j + Math.random(), (double) k + Math.random(), 0.0D, 0.0D, 0.0D, 0);
-            } else {
-                if (!worldIn.isRemote && notSolid && !material.isLiquid())
-                    worldIn.destroyBlock(pos, true);
-
-                worldIn.setBlockState(pos, Blocks.FLOWING_WATER.getDefaultState(), 3);
-            }
-
-            return true;
-        }
-    }
+	
+	public ItemStack getContainer() {
+		return this.getDefaultInstance();
+	}
+	public FluidStack getFluid() {
+		return new FluidStack(FluidRegistry.WATER, 1000);
+	}
+	public IFluidTankProperties[] getTankProperties() {
+		return new FluidTankProperties[] { new FluidTankProperties(this.getFluid(),1000) };
+	}
+	public int fill(FluidStack resource, boolean doFill) {
+		return 0;
+	}
+	public FluidStack drain(FluidStack resource, boolean doDrain) {
+		return this.getFluid();
+	}
+	public FluidStack drain(int maxDrain, boolean doDrain) {
+		return this.getFluid();
+	}
 }


### PR DESCRIPTION
This addresses the issues numbered #1382 and #1301 as well as a minor issue of total incompatibility with certain kinds of tanks by making the water, lava, and void sigils largely use Forge's internal FluidUtils and more strongly implementing the IFluidHandler interface for everything they do.
Of note for anyone testing this out, there is an issue with Blood Tanks in that they do not visually update when used with a sigil. But even if they don't visually update, Blood Tanks _do_ receive the respective fluids from the sigils. This can be seen by using a sigil on a blood tank and breaking it with a pickaxe.