### PR TITLE
This should fix a few existing issues with Teleposers

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/tile/TileTeleposer.java
+++ b/src/main/java/WayofTime/bloodmagic/tile/TileTeleposer.java
@@ -1,16 +1,15 @@
 package WayofTime.bloodmagic.tile;
 
+import WayofTime.bloodmagic.block.BlockTeleposer;
 import WayofTime.bloodmagic.core.data.Binding;
 import WayofTime.bloodmagic.core.data.SoulTicket;
-import WayofTime.bloodmagic.util.Constants;
 import WayofTime.bloodmagic.event.TeleposeEvent;
-import WayofTime.bloodmagic.teleport.TeleportQueue;
-import WayofTime.bloodmagic.util.helper.NetworkHelper;
-import WayofTime.bloodmagic.util.helper.PlayerHelper;
-import WayofTime.bloodmagic.block.BlockTeleposer;
 import WayofTime.bloodmagic.item.ItemTelepositionFocus;
 import WayofTime.bloodmagic.ritual.portal.Teleports;
+import WayofTime.bloodmagic.teleport.TeleportQueue;
+import WayofTime.bloodmagic.util.Constants;
 import WayofTime.bloodmagic.util.Utils;
+import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -77,7 +76,7 @@ public class TileTeleposer extends TileInventory implements ITickable {
                 final int focusLevel = (getStackInSlot(0).getItemDamage() + 1);
                 final int lpToBeDrained = (int) (0.5F * Math.sqrt((pos.getX() - focusPos.getX()) * (pos.getX() - focusPos.getX()) + (pos.getY() - focusPos.getY() + 1) * (pos.getY() - focusPos.getY() + 1) + (pos.getZ() - focusPos.getZ()) * (pos.getZ() - focusPos.getZ())));
 
-                if (NetworkHelper.getSoulNetwork(binding).syphonAndDamage(PlayerHelper.getPlayerFromUUID(binding.getOwnerId()), SoulTicket.block(world, pos, lpToBeDrained * (focusLevel * 2 - 1) * (focusLevel * 2 - 1) * (focusLevel * 2 - 1))).isSuccess()) {
+                if (NetworkHelper.syphonFromContainer(focusStack, SoulTicket.block(world, pos, lpToBeDrained * (focusLevel * 2 - 1) * (focusLevel * 2 - 1) * (focusLevel * 2 - 1)))) {
                     int blocksTransported = 0;
 
                     for (int i = -(focusLevel - 1); i <= (focusLevel - 1); i++) {


### PR DESCRIPTION
Teleposers no longer try to call syphonAndDamage on the bound player in some weird hacky way. They just call syphonFromContainer in their own code, just like lava crystals, and syphon itself in the TeleportQueue code.
So they shouldn't throw any more null pointers from syphonAndDamage and they shouldn't have issues running when the teleposer owner is offline. I did some testing on the subject but there's no telling if the actual issue with the latter case was more exotic than just getting caught on that code.