### PR TITLE
Removed some redundant stuff for Bindable items, improved inheritance

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/item/ItemBindableBase.java
+++ b/src/main/java/WayofTime/bloodmagic/item/ItemBindableBase.java
@@ -3,7 +3,6 @@ package WayofTime.bloodmagic.item;
 import WayofTime.bloodmagic.BloodMagic;
 import WayofTime.bloodmagic.core.data.Binding;
 import WayofTime.bloodmagic.iface.IBindable;
-import WayofTime.bloodmagic.util.helper.TextHelper;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -29,7 +28,7 @@ public class ItemBindableBase extends Item implements IBindable {
         if (stack.hasTagCompound()) {
             Binding binding = getBinding(stack);
             if (binding != null) {
-                tooltip.add(TextHelper.localizeEffect("tooltip.bloodmagic.currentOwner", binding.getOwnerName()));
+                tooltip.add(new TextComponentTranslation("tooltip.bloodmagic.currentOwner", binding.getOwnerName()).getFormattedText());
                 return;
             }
         }

--- a/src/main/java/WayofTime/bloodmagic/item/ItemBindableBase.java
+++ b/src/main/java/WayofTime/bloodmagic/item/ItemBindableBase.java
@@ -7,6 +7,8 @@ import WayofTime.bloodmagic.util.helper.TextHelper;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -24,11 +26,15 @@ public class ItemBindableBase extends Item implements IBindable {
     @Override
     @SideOnly(Side.CLIENT)
     public void addInformation(ItemStack stack, World world, List<String> tooltip, ITooltipFlag flag) {
-        if (!stack.hasTagCompound())
-            return;
-
-        Binding binding = getBinding(stack);
-        if (binding != null)
-            tooltip.add(TextHelper.localizeEffect("tooltip.bloodmagic.currentOwner", binding.getOwnerName()));
+        if (stack.hasTagCompound()) {
+            Binding binding = getBinding(stack);
+            if (binding != null) {
+                tooltip.add(TextHelper.localizeEffect("tooltip.bloodmagic.currentOwner", binding.getOwnerName()));
+                return;
+            }
+        }
+        TextComponentTranslation tooltipUnbound = new TextComponentTranslation("tooltip.bloodmagic.unbound");
+        tooltipUnbound.getStyle().setColor(TextFormatting.RED);
+        tooltip.add(tooltipUnbound.getFormattedText());
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/ItemBindableBase.java
+++ b/src/main/java/WayofTime/bloodmagic/item/ItemBindableBase.java
@@ -7,7 +7,6 @@ import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextComponentTranslation;
-import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -29,11 +28,7 @@ public class ItemBindableBase extends Item implements IBindable {
             Binding binding = getBinding(stack);
             if (binding != null) {
                 tooltip.add(new TextComponentTranslation("tooltip.bloodmagic.currentOwner", binding.getOwnerName()).getFormattedText());
-                return;
             }
         }
-        TextComponentTranslation tooltipUnbound = new TextComponentTranslation("tooltip.bloodmagic.unbound");
-        tooltipUnbound.getStyle().setColor(TextFormatting.RED);
-        tooltip.add(tooltipUnbound.getFormattedText());
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/ItemBindableBase.java
+++ b/src/main/java/WayofTime/bloodmagic/item/ItemBindableBase.java
@@ -24,11 +24,11 @@ public class ItemBindableBase extends Item implements IBindable {
     @Override
     @SideOnly(Side.CLIENT)
     public void addInformation(ItemStack stack, World world, List<String> tooltip, ITooltipFlag flag) {
-        if (stack.hasTagCompound()) {
-            Binding binding = getBinding(stack);
-            if (binding != null) {
-                tooltip.add(new TextComponentTranslation("tooltip.bloodmagic.currentOwner", binding.getOwnerName()).getFormattedText());
-            }
-        }
+        if (!stack.hasTagCompound())
+            return;
+
+        Binding binding = getBinding(stack);
+        if (binding != null)
+            tooltip.add(new TextComponentTranslation("tooltip.bloodmagic.currentOwner", binding.getOwnerName()).getFormattedText());
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigil.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigil.java
@@ -1,16 +1,15 @@
 package WayofTime.bloodmagic.item.sigil;
 
-import WayofTime.bloodmagic.util.Constants;
-import WayofTime.bloodmagic.iface.IBindable;
 import WayofTime.bloodmagic.iface.ISigil;
+import WayofTime.bloodmagic.item.ItemBindableBase;
+import WayofTime.bloodmagic.util.Constants;
 import WayofTime.bloodmagic.util.helper.NBTHelper;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 /**
  * Base class for all (static) sigils.
  */
-public class ItemSigil extends Item implements IBindable, ISigil {
+public class ItemSigil extends ItemBindableBase implements ISigil {
     private int lpUsed;
 
     public ItemSigil(int lpUsed) {

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilBase.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilBase.java
@@ -2,7 +2,6 @@ package WayofTime.bloodmagic.item.sigil;
 
 import WayofTime.bloodmagic.BloodMagic;
 import WayofTime.bloodmagic.client.IVariantProvider;
-import WayofTime.bloodmagic.core.data.Binding;
 import WayofTime.bloodmagic.util.helper.TextHelper;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.client.util.ITooltipFlag;
@@ -24,7 +23,6 @@ public class ItemSigilBase extends ItemSigil implements IVariantProvider {
         super(lpUsed);
 
         setUnlocalizedName(BloodMagic.MODID + ".sigil." + name);
-        setCreativeTab(BloodMagic.TAB_BM);
 
         this.name = name;
         this.tooltipBase = "tooltip.bloodmagic.sigil." + name + ".";
@@ -39,13 +37,6 @@ public class ItemSigilBase extends ItemSigil implements IVariantProvider {
     public void addInformation(ItemStack stack, World world, List<String> tooltip, ITooltipFlag flag) {
         if (TextHelper.canTranslate(tooltipBase + "desc"))
             tooltip.addAll(Arrays.asList(TextHelper.cutLongString(TextHelper.localizeEffect(tooltipBase + "desc"))));
-
-        if (!stack.hasTagCompound())
-            return;
-
-        Binding binding = getBinding(stack);
-        if (binding != null)
-            tooltip.add(TextHelper.localizeEffect("tooltip.bloodmagic.currentOwner", binding.getOwnerName()));
 
         super.addInformation(stack, world, tooltip, flag);
     }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilBase.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilBase.java
@@ -6,9 +6,11 @@ import WayofTime.bloodmagic.util.helper.TextHelper;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import org.apache.commons.lang3.text.WordUtils;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -36,7 +38,7 @@ public class ItemSigilBase extends ItemSigil implements IVariantProvider {
     @SideOnly(Side.CLIENT)
     public void addInformation(ItemStack stack, World world, List<String> tooltip, ITooltipFlag flag) {
         if (TextHelper.canTranslate(tooltipBase + "desc"))
-            tooltip.addAll(Arrays.asList(TextHelper.cutLongString(TextHelper.localizeEffect(tooltipBase + "desc"))));
+            tooltip.addAll(Arrays.asList(WordUtils.wrap(new TextComponentTranslation(tooltipBase + "desc").getFormattedText(), 30, "/cut", false).split("/cut")));
 
         super.addInformation(stack, world, tooltip, flag);
     }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilToggleableBase.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilToggleableBase.java
@@ -3,7 +3,6 @@ package WayofTime.bloodmagic.item.sigil;
 import WayofTime.bloodmagic.BloodMagic;
 import WayofTime.bloodmagic.client.IMeshProvider;
 import WayofTime.bloodmagic.client.mesh.CustomMeshDefinitionActivatable;
-import WayofTime.bloodmagic.core.data.Binding;
 import WayofTime.bloodmagic.util.helper.TextHelper;
 import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.util.ITooltipFlag;
@@ -39,10 +38,6 @@ public class ItemSigilToggleableBase extends ItemSigilToggleable implements IMes
             return;
 
         tooltip.add(TextHelper.localizeEffect("tooltip.bloodmagic." + (getActivated(stack) ? "activated" : "deactivated")));
-
-        Binding binding = getBinding(stack);
-        if (binding != null)
-            tooltip.add(TextHelper.localizeEffect("tooltip.bloodmagic.currentOwner", binding.getOwnerName()));
     }
 
     @Override

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilToggleableBase.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilToggleableBase.java
@@ -3,10 +3,10 @@ package WayofTime.bloodmagic.item.sigil;
 import WayofTime.bloodmagic.BloodMagic;
 import WayofTime.bloodmagic.client.IMeshProvider;
 import WayofTime.bloodmagic.client.mesh.CustomMeshDefinitionActivatable;
-import WayofTime.bloodmagic.util.helper.TextHelper;
 import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -37,7 +37,7 @@ public class ItemSigilToggleableBase extends ItemSigilToggleable implements IMes
         if (!stack.hasTagCompound())
             return;
 
-        tooltip.add(TextHelper.localizeEffect("tooltip.bloodmagic." + (getActivated(stack) ? "activated" : "deactivated")));
+        tooltip.add(new TextComponentTranslation("tooltip.bloodmagic." + (getActivated(stack) ? "activated" : "deactivated")).getFormattedText());
     }
 
     @Override

--- a/src/main/resources/assets/bloodmagic/lang/en_US.lang
+++ b/src/main/resources/assets/bloodmagic/lang/en_US.lang
@@ -385,7 +385,6 @@ tooltip.bloodmagic.currentOwner=Current owner: %s
 tooltip.bloodmagic.currentTier=Current tier: %d
 tooltip.bloodmagic.config.disabled=Currently disabled in the Config
 tooltip.bloodmagic.tier=Tier %d
-tooltip.bloodmagic.unbound=This item is not bound.
 
 tooltip.bloodmagic.activated=Activated
 tooltip.bloodmagic.deactivated=Deactivated

--- a/src/main/resources/assets/bloodmagic/lang/en_US.lang
+++ b/src/main/resources/assets/bloodmagic/lang/en_US.lang
@@ -385,6 +385,7 @@ tooltip.bloodmagic.currentOwner=Current owner: %s
 tooltip.bloodmagic.currentTier=Current tier: %d
 tooltip.bloodmagic.config.disabled=Currently disabled in the Config
 tooltip.bloodmagic.tier=Tier %d
+tooltip.bloodmagic.unbound=This item is not bound.
 
 tooltip.bloodmagic.activated=Activated
 tooltip.bloodmagic.deactivated=Deactivated


### PR DESCRIPTION
- Streamlined inheritance. All Sigils now extend ItemBindableBase at some point.

- removed redundant hasTagCompound check

- removed usage of TextHelper in affected files

#910 (Nevermind this, it's a tooltip request)