### PR TITLE
Bounding boxes / Collision boxes rework

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/block/BlockAlchemyTable.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockAlchemyTable.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
 public class BlockAlchemyTable extends Block implements IBMBlock {
     public static final PropertyBool INVISIBLE = PropertyBool.create("invisible");
     public static final PropertyEnum<EnumFacing> DIRECTION = PropertyEnum.create("direction", EnumFacing.class);
-    private static final AxisAlignedBB BODY = new AxisAlignedBB(0, 0, 0, 16 / 16F, 14 / 16F, 16 / 16F);
+    private static final AxisAlignedBB BODY = new AxisAlignedBB(0, 0, 0, 16 / 16F, 13 / 16F, 16 / 16F);
 
     public BlockAlchemyTable() {
         super(Material.ROCK);

--- a/src/main/java/WayofTime/bloodmagic/block/BlockAlchemyTable.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockAlchemyTable.java
@@ -1,9 +1,9 @@
 package WayofTime.bloodmagic.block;
 
 import WayofTime.bloodmagic.BloodMagic;
-import WayofTime.bloodmagic.util.Constants;
 import WayofTime.bloodmagic.item.block.ItemBlockAlchemyTable;
 import WayofTime.bloodmagic.tile.TileAlchemyTable;
+import WayofTime.bloodmagic.util.Constants;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyBool;
@@ -17,6 +17,7 @@ import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -26,6 +27,7 @@ import javax.annotation.Nullable;
 public class BlockAlchemyTable extends Block implements IBMBlock {
     public static final PropertyBool INVISIBLE = PropertyBool.create("invisible");
     public static final PropertyEnum<EnumFacing> DIRECTION = PropertyEnum.create("direction", EnumFacing.class);
+    private static final AxisAlignedBB BODY = new AxisAlignedBB(0, 0, 0, 16 / 16F, 14 / 16F, 16 / 16F);
 
     public BlockAlchemyTable() {
         super(Material.ROCK);
@@ -38,6 +40,10 @@ public class BlockAlchemyTable extends Block implements IBMBlock {
         setHarvestLevel("pickaxe", 0);
 
 //        setBlockBounds(0.3F, 0F, 0.3F, 0.72F, 1F, 0.72F);
+    }
+
+    public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
+        return BODY;
     }
 
     @Override

--- a/src/main/java/WayofTime/bloodmagic/block/BlockAltar.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockAltar.java
@@ -1,7 +1,10 @@
 package WayofTime.bloodmagic.block;
 
 import WayofTime.bloodmagic.BloodMagic;
-import WayofTime.bloodmagic.altar.*;
+import WayofTime.bloodmagic.altar.AltarUtil;
+import WayofTime.bloodmagic.altar.ComponentType;
+import WayofTime.bloodmagic.altar.IAltarManipulator;
+import WayofTime.bloodmagic.altar.IBloodAltar;
 import WayofTime.bloodmagic.client.IVariantProvider;
 import WayofTime.bloodmagic.core.data.Binding;
 import WayofTime.bloodmagic.core.data.SoulNetwork;
@@ -23,6 +26,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentTranslation;
@@ -35,6 +39,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class BlockAltar extends Block implements IVariantProvider, IDocumentedBlock, IBMBlock {
+    private static final AxisAlignedBB BODY = new AxisAlignedBB(0, 0, 0, 16 / 16F, 12 / 16F, 16 / 16F);
+
     public BlockAltar() {
         super(Material.ROCK);
 
@@ -43,6 +49,10 @@ public class BlockAltar extends Block implements IVariantProvider, IDocumentedBl
         setHardness(2.0F);
         setResistance(5.0F);
         setHarvestLevel("pickaxe", 1);
+    }
+
+    public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
+        return BODY;
     }
 
     @Override

--- a/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrucible.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrucible.java
@@ -6,9 +6,11 @@ import WayofTime.bloodmagic.soul.IDemonWillGem;
 import WayofTime.bloodmagic.soul.IDiscreteDemonWill;
 import WayofTime.bloodmagic.tile.TileDemonCrucible;
 import WayofTime.bloodmagic.util.Utils;
+import com.google.common.collect.Lists;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
@@ -16,13 +18,34 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class BlockDemonCrucible extends Block implements IVariantProvider, IBMBlock {
+    protected static final AxisAlignedBB BODY = new AxisAlignedBB(2 / 16F, 7 / 16F, 2 / 16F, 14 / 16F, 15 / 16F, 14 / 16F);
+    private static final AxisAlignedBB[] ARMS = {
+            new AxisAlignedBB(5 / 16F, 13 / 16F, 0 / 16F, 11 / 16F, 25 / 16F, 2 / 16F), // N
+            new AxisAlignedBB(14 / 16F, 13 / 16F, 5 / 16F, 16 / 16F, 25 / 16F, 11 / 16F), // E
+            new AxisAlignedBB(5 / 16F, 13 / 16F, 14 / 16F, 11 / 16F, 25 / 16F, 16 / 16F), // S
+            new AxisAlignedBB(0 / 16F, 13 / 16F, 5 / 16F, 2 / 16F, 25 / 16F, 11 / 16F)  // W
+    };
+    private static final AxisAlignedBB[] FEET = {
+            new AxisAlignedBB(10 / 16F, 0F, 2 / 16F, 14 / 16F, 7 / 16F, 6 / 16F), // NE
+            new AxisAlignedBB(10 / 16F, 0F, 10 / 16F, 14 / 16F, 7 / 16F, 14 / 16F), // SE
+            new AxisAlignedBB(2 / 16F, 0F, 10 / 16F, 6 / 16F, 7 / 16F, 14 / 16F), // SW
+            new AxisAlignedBB(2 / 16F, 0F, 2 / 16F, 6 / 16F, 7 / 16F, 6 / 16F)  // NW
+    };
+
+
     public BlockDemonCrucible() {
         super(Material.ROCK);
 
@@ -33,6 +56,18 @@ public class BlockDemonCrucible extends Block implements IVariantProvider, IBMBl
         setHarvestLevel("pickaxe", 0);
 
 //        setBlockBounds(0.3F, 0F, 0.3F, 0.72F, 1F, 0.72F);
+    }
+
+    private static List<AxisAlignedBB> getCollisionBoxList(IBlockState state) {
+        ArrayList<AxisAlignedBB> collBox = new ArrayList<>(Arrays.asList(ARMS));
+        collBox.add(BODY);
+        collBox.addAll(Arrays.asList(FEET));
+        return collBox;
+    }
+
+    @Override
+    public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
+        return BODY;
     }
 
     @Override
@@ -98,5 +133,40 @@ public class BlockDemonCrucible extends Block implements IVariantProvider, IBMBl
     @Override
     public ItemBlock getItem() {
         return new ItemBlock(this);
+    }
+
+    @Override
+    public RayTraceResult collisionRayTrace(IBlockState blockState, World worldIn, BlockPos pos, Vec3d start, Vec3d end) {
+        List<RayTraceResult> list = Lists.newArrayList();
+
+
+        for (AxisAlignedBB axisalignedbb : getCollisionBoxList(this.getActualState(blockState, worldIn, pos))) {
+            list.add(this.rayTrace(pos, start, end, axisalignedbb));
+        }
+
+        RayTraceResult rayTrace = null;
+        double d1 = 0.0D;
+
+        for (RayTraceResult raytraceresult : list) {
+            if (raytraceresult != null) {
+                double d0 = raytraceresult.hitVec.squareDistanceTo(end);
+
+                if (d0 > d1) {
+                    rayTrace = raytraceresult;
+                    d1 = d0;
+                }
+            }
+        }
+
+        return rayTrace;
+    }
+
+    @Override
+    public void addCollisionBoxToList(IBlockState state, World worldIn, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean bool) {
+        state = this.getActualState(state, worldIn, pos);
+
+        for (AxisAlignedBB axisalignedbb : getCollisionBoxList(state)) {
+            addCollisionBoxToList(pos, entityBox, collidingBoxes, axisalignedbb);
+        }
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrystal.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrystal.java
@@ -7,6 +7,7 @@ import WayofTime.bloodmagic.item.block.ItemBlockDemonCrystal;
 import WayofTime.bloodmagic.soul.EnumDemonWillType;
 import WayofTime.bloodmagic.soul.PlayerDemonWillHandler;
 import WayofTime.bloodmagic.tile.TileDemonCrystal;
+import com.google.common.collect.Lists;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -15,6 +16,7 @@ import net.minecraft.block.properties.PropertyInteger;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
@@ -23,17 +25,82 @@ import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.NonNullList;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.EnumMap;
+import java.util.List;
 
 public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvider {
+
     public static final PropertyInteger AGE = PropertyInteger.create("age", 0, 6);
     public static final PropertyEnum<EnumDemonWillType> TYPE = PropertyEnum.create("type", EnumDemonWillType.class);
     public static final PropertyEnum<EnumFacing> ATTACHED = PropertyEnum.create("attached", EnumFacing.class);
+    private static final EnumMap<EnumFacing, AxisAlignedBB> bounds = new EnumMap<>(EnumFacing.class);
+    //Bounding / collision / selection boxes
+    private static final AxisAlignedBB AABB_UP0 = new AxisAlignedBB(6 / 16F, 0, 5 / 16F, 10 / 16F, 13 / 16F, 9 / 16F);
+    private static final AxisAlignedBB AABB_DOWN0 = new AxisAlignedBB(6 / 16F, 3 / 16F, 7 / 16F, 10 / 16F, 16 / 16F, 11 / 16F);
+    private static final AxisAlignedBB AABB_NORTH0 = new AxisAlignedBB(6 / 16F, 5 / 16F, 3 / 16F, 10 / 16F, 9 / 16F, 16 / 16F);
+    private static final AxisAlignedBB AABB_SOUTH0 = new AxisAlignedBB(6 / 16F, 7 / 16F, 0 / 16F, 10 / 16F, 11 / 16F, 13 / 16F);
+    private static final AxisAlignedBB AABB_EAST0 = new AxisAlignedBB(0, 6 / 16F, 5 / 16F, 13 / 16F, 10 / 16F, 9 / 16F);
+    private static final AxisAlignedBB AABB_WEST0 = new AxisAlignedBB(3 / 16F, 6 / 16F, 5 / 16F, 16 / 16F, 10 / 16F, 9 / 16F);
+    //Stairs recycled
+    private static final AxisAlignedBB AABB_UP1 = new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F);
+    private static final AxisAlignedBB AABB_UP2 = new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F);
+    private static final AxisAlignedBB AABB_UP3 = new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F);
+    private static final AxisAlignedBB AABB_UP4 = new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F);
+    private static final AxisAlignedBB AABB_UP5 = new AxisAlignedBB(0, 0, 7 / 16F, 6 / 16F, 6 / 16F, 10 / 16F);
+    private static final AxisAlignedBB AABB_UP6 = new AxisAlignedBB(10 / 16F, 0, 6 / 16F, 15 / 16F, 6 / 16F, 9 / 16F);
+
+    private static final AxisAlignedBB AABB_DOWN1 = new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F);
+    private static final AxisAlignedBB AABB_DOWN2 = new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F);
+    private static final AxisAlignedBB AABB_DOWN3 = new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F);
+    private static final AxisAlignedBB AABB_DOWN4 = new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F);
+    private static final AxisAlignedBB AABB_DOWN5 = new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D);
+    private static final AxisAlignedBB AABB_DOWN6 = new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D);
+
+    private static final AxisAlignedBB AABB_NORTH1 = new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F);
+    private static final AxisAlignedBB AABB_NORTH2 = new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F);
+    private static final AxisAlignedBB AABB_NORTH3 = new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F);
+    private static final AxisAlignedBB AABB_NORTH4 = new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F);
+    private static final AxisAlignedBB AABB_NORTH5 = new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D);
+    private static final AxisAlignedBB AABB_NORTH6 = new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D);
+
+    private static final AxisAlignedBB AABB_SOUTH1 = new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F);
+    private static final AxisAlignedBB AABB_SOUTH2 = new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F);
+    private static final AxisAlignedBB AABB_SOUTH3 = new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F);
+    private static final AxisAlignedBB AABB_SOUTH4 = new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F);
+    private static final AxisAlignedBB AABB_SOUTH5 = new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D);
+    private static final AxisAlignedBB AABB_SOUTH6 = new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D);
+
+    private static final AxisAlignedBB AABB_EAST1 = new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F);
+    private static final AxisAlignedBB AABB_EAST2 = new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F);
+    private static final AxisAlignedBB AABB_EAST3 = new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F);
+    private static final AxisAlignedBB AABB_EAST4 = new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F);
+    private static final AxisAlignedBB AABB_EAST5 = new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D);
+    private static final AxisAlignedBB AABB_EAST6 = new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D);
+
+    private static final AxisAlignedBB AABB_WEST1 = new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F);
+    private static final AxisAlignedBB AABB_WEST2 = new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F);
+    private static final AxisAlignedBB AABB_WEST3 = new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F);
+    private static final AxisAlignedBB AABB_WEST4 = new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F);
+    private static final AxisAlignedBB AABB_WEST5 = new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D);
+    private static final AxisAlignedBB AABB_WEST6 = new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D);
+
+    static {
+        bounds.put(EnumFacing.UP, AABB_UP0);
+        bounds.put(EnumFacing.DOWN, AABB_DOWN0);
+        bounds.put(EnumFacing.NORTH, AABB_NORTH0);
+        bounds.put(EnumFacing.SOUTH, AABB_SOUTH0);
+        bounds.put(EnumFacing.WEST, AABB_WEST0);
+        bounds.put(EnumFacing.EAST, AABB_EAST0);
+    }
 
     public BlockDemonCrystal() {
         super(Material.ROCK);
@@ -44,6 +111,150 @@ public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvid
         setHardness(2.0F);
         setResistance(5.0F);
         setHarvestLevel("pickaxe", 2);
+    }
+
+    public static ItemStack getItemStackDropped(EnumDemonWillType type, int crystalNumber) {
+        ItemStack stack = ItemStack.EMPTY;
+        switch (type) {
+            case CORROSIVE:
+                stack = EnumDemonWillType.CORROSIVE.getStack();
+                break;
+            case DEFAULT:
+                stack = EnumDemonWillType.DEFAULT.getStack();
+                break;
+            case DESTRUCTIVE:
+                stack = EnumDemonWillType.DESTRUCTIVE.getStack();
+                break;
+            case STEADFAST:
+                stack = EnumDemonWillType.STEADFAST.getStack();
+                break;
+            case VENGEFUL:
+                stack = EnumDemonWillType.VENGEFUL.getStack();
+                break;
+        }
+
+        stack.setCount(crystalNumber);
+        return stack;
+    }
+
+    private static AxisAlignedBB makeAABB(int fromX, int fromY, int fromZ, int toX, int toY, int toZ) {
+        return new AxisAlignedBB(fromX / 16F, fromY / 16F, fromZ / 16F, toX / 16F, toY / 16F, toZ / 16F);
+    }
+
+    private static List<AxisAlignedBB> getCollisionBoxList(IBlockState state) {
+        List<AxisAlignedBB> list = Lists.newArrayList();
+        Integer age = state.getValue(BlockDemonCrystal.AGE);
+        switch (state.getValue(BlockDemonCrystal.ATTACHED)) {
+            case UP:
+                switch (age) {
+                    case 6:
+                        list.add(AABB_UP6);
+                    case 5:
+                        list.add(AABB_UP5);
+                    case 4:
+                        list.add(AABB_UP4);
+                    case 3:
+                        list.add(AABB_UP3);
+                    case 2:
+                        list.add(AABB_UP2);
+                    case 1:
+                        list.add(AABB_UP1);
+                    case 0:
+                    default:
+                        list.add(AABB_UP0);
+                        break;
+                }
+                break;
+            case DOWN:
+                switch (age) {
+                    case 6:
+                    case 5:
+                    case 4:
+                    case 3:
+                    case 2:
+                    case 1:
+                    case 0:
+                    default:
+                        list.add(AABB_DOWN0);
+                        break;
+                }
+                break;
+            case NORTH:
+                switch (age) {
+                    case 6:
+                    case 5:
+                    case 4:
+                    case 3:
+                    case 2:
+                    case 1:
+                    case 0:
+                    default:
+                        list.add(AABB_NORTH0);
+                        break;
+                }
+                break;
+            case SOUTH:
+                switch (age) {
+                    case 6:
+                    case 5:
+                    case 4:
+                    case 3:
+                    case 2:
+                    case 1:
+                    case 0:
+                    default:
+                        list.add(AABB_SOUTH0);
+                        break;
+                }
+                break;
+            case WEST:
+                switch (age) {
+                    case 6:
+                    case 5:
+                    case 4:
+                    case 3:
+                    case 2:
+                    case 1:
+                    case 0:
+                    default:
+                        list.add(AABB_WEST0);
+                        break;
+                }
+                break;
+            case EAST:
+                switch (age) {
+                    case 6:
+                    case 5:
+                    case 4:
+                    case 3:
+                    case 2:
+                    case 1:
+                    case 0:
+                    default:
+                        list.add(AABB_EAST0);
+                        break;
+                }
+                break;
+        }
+
+
+        /* if (stairShape == BlockStairs.EnumShape.STRAIGHT || stairShape == BlockStairs.EnumShape.INNER_LEFT || stairShape == BlockStairs.EnumShape.INNER_RIGHT) {
+            list.add(getCollQuarterBlock(state));
+        }
+
+        if (stairShape != BlockStairs.EnumShape.STRAIGHT) {
+            list.add(getCollEighthBlock(state));
+        }
+*/
+        return list;
+    }
+
+    @Override
+    public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
+        TileEntity tile = source.getTileEntity(pos);
+        if (tile != null)
+            state = getActualState(state, tile.getWorld(), pos);
+        return bounds.get(state.getValue(ATTACHED));
     }
 
     @Override
@@ -62,7 +273,7 @@ public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvid
                 if (!crystal.getWorld().isRemote && isCreative && holdsCrystal) {
                     if (crystal.crystalCount < 7) {
                         crystal.internalCounter = 0;
-                        if(crystal.progressToNextCrystal > 0)
+                        if (crystal.progressToNextCrystal > 0)
                             crystal.progressToNextCrystal--;
                         crystal.crystalCount++;
                         crystal.markDirty();
@@ -167,6 +378,7 @@ public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvid
 
     @Override
     public int getMetaFromState(IBlockState state) {
+
         return state.getValue(TYPE).ordinal();
     }
 
@@ -186,30 +398,6 @@ public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvid
         return new TileDemonCrystal();
     }
 
-    public static ItemStack getItemStackDropped(EnumDemonWillType type, int crystalNumber) {
-        ItemStack stack = ItemStack.EMPTY;
-        switch (type) {
-            case CORROSIVE:
-                stack = EnumDemonWillType.CORROSIVE.getStack();
-                break;
-            case DEFAULT:
-                stack = EnumDemonWillType.DEFAULT.getStack();
-                break;
-            case DESTRUCTIVE:
-                stack = EnumDemonWillType.DESTRUCTIVE.getStack();
-                break;
-            case STEADFAST:
-                stack = EnumDemonWillType.STEADFAST.getStack();
-                break;
-            case VENGEFUL:
-                stack = EnumDemonWillType.VENGEFUL.getStack();
-                break;
-        }
-
-        stack.setCount(crystalNumber);
-        return stack;
-    }
-
     @Override
     public ItemBlock getItem() {
         return new ItemBlockDemonCrystal(this);
@@ -220,4 +408,39 @@ public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvid
         for (EnumDemonWillType willType : EnumDemonWillType.values())
             variants.put(willType.ordinal(), "age=3,attached=up,type=" + willType.getName());
     }
+
+    @Override
+    public RayTraceResult collisionRayTrace(IBlockState blockState, World worldIn, BlockPos pos, Vec3d start, Vec3d end) {
+        List<RayTraceResult> list = Lists.newArrayList();
+
+        for (AxisAlignedBB axisalignedbb : getCollisionBoxList(this.getActualState(blockState, worldIn, pos))) {
+            list.add(this.rayTrace(pos, start, end, axisalignedbb));
+        }
+
+        RayTraceResult rayTrace = null;
+        double d1 = 0.0D;
+
+        for (RayTraceResult raytraceresult : list) {
+            if (raytraceresult != null) {
+                double d0 = raytraceresult.hitVec.squareDistanceTo(end);
+
+                if (d0 > d1) {
+                    rayTrace = raytraceresult;
+                    d1 = d0;
+                }
+            }
+        }
+
+        return rayTrace;
+    }
+
+    @Override
+    public void addCollisionBoxToList(IBlockState state, World worldIn, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean bool) {
+        state = this.getActualState(state, worldIn, pos);
+
+        for (AxisAlignedBB axisalignedbb : getCollisionBoxList(state)) {
+            addCollisionBoxToList(pos, entityBox, collidingBoxes, axisalignedbb);
+        }
+    }
+
 }

--- a/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrystal.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrystal.java
@@ -34,6 +34,7 @@ import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
 
@@ -43,64 +44,63 @@ public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvid
     public static final PropertyEnum<EnumDemonWillType> TYPE = PropertyEnum.create("type", EnumDemonWillType.class);
     public static final PropertyEnum<EnumFacing> ATTACHED = PropertyEnum.create("attached", EnumFacing.class);
     private static final EnumMap<EnumFacing, AxisAlignedBB> bounds = new EnumMap<>(EnumFacing.class);
-    //Bounding / collision / selection boxes
-    private static final AxisAlignedBB AABB_UP0 = new AxisAlignedBB(6 / 16F, 0, 5 / 16F, 10 / 16F, 13 / 16F, 9 / 16F);
-    private static final AxisAlignedBB AABB_DOWN0 = new AxisAlignedBB(6 / 16F, 3 / 16F, 7 / 16F, 10 / 16F, 16 / 16F, 11 / 16F);
-    private static final AxisAlignedBB AABB_NORTH0 = new AxisAlignedBB(6 / 16F, 5 / 16F, 3 / 16F, 10 / 16F, 9 / 16F, 16 / 16F);
-    private static final AxisAlignedBB AABB_SOUTH0 = new AxisAlignedBB(6 / 16F, 7 / 16F, 0 / 16F, 10 / 16F, 11 / 16F, 13 / 16F);
-    private static final AxisAlignedBB AABB_EAST0 = new AxisAlignedBB(0, 6 / 16F, 5 / 16F, 13 / 16F, 10 / 16F, 9 / 16F);
-    private static final AxisAlignedBB AABB_WEST0 = new AxisAlignedBB(3 / 16F, 6 / 16F, 5 / 16F, 16 / 16F, 10 / 16F, 9 / 16F);
-    //Stairs recycled
-    private static final AxisAlignedBB AABB_UP1 = new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F);
-    private static final AxisAlignedBB AABB_UP2 = new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F);
-    private static final AxisAlignedBB AABB_UP3 = new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F);
-    private static final AxisAlignedBB AABB_UP4 = new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F);
-    private static final AxisAlignedBB AABB_UP5 = new AxisAlignedBB(0, 0, 7 / 16F, 6 / 16F, 6 / 16F, 10 / 16F);
-    private static final AxisAlignedBB AABB_UP6 = new AxisAlignedBB(10 / 16F, 0, 6 / 16F, 15 / 16F, 6 / 16F, 9 / 16F);
 
-    private static final AxisAlignedBB AABB_DOWN1 = new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F);
-    private static final AxisAlignedBB AABB_DOWN2 = new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F);
-    private static final AxisAlignedBB AABB_DOWN3 = new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F);
-    private static final AxisAlignedBB AABB_DOWN4 = new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F);
-    private static final AxisAlignedBB AABB_DOWN5 = new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D);
-    private static final AxisAlignedBB AABB_DOWN6 = new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D);
+    // Bounding / Collision boxes
+    private static final AxisAlignedBB[] UP = {
+            new AxisAlignedBB(6 / 16F, 0, 5 / 16F, 10 / 16F, 13 / 16F, 9 / 16F),
+            new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F),
+            new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F),
+            new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F),
+            new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F),
+            new AxisAlignedBB(0, 0, 7 / 16F, 6 / 16F, 6 / 16F, 10 / 16F),
+            new AxisAlignedBB(10 / 16F, 0, 6 / 16F, 15 / 16F, 6 / 16F, 9 / 16F)
+    };
+    private static final AxisAlignedBB[] DOWN = {
+            new AxisAlignedBB(6 / 16F, 3 / 16F, 7 / 16F, 10 / 16F, 16 / 16F, 11 / 16F),
+            new AxisAlignedBB(7 / 16F, 10 / 16F, 11 / 16F, 13 / 16F, 16 / 16F, 16 / 16F),
+            new AxisAlignedBB(9 / 16F, 11 / 16F, 2 / 16F, 13 / 16F, 16 / 16F, 7 / 16F),
+            new AxisAlignedBB(2 / 16F, 9 / 16F, 11 / 16F, 7 / 16F, 16 / 16F, 15 / 16F),
+            new AxisAlignedBB(5 / 16F, 9 / 16F, 1 / 16F, 9 / 16F, 16 / 16F, 7 / 16F),
+            new AxisAlignedBB(0, 10 / 16F, 6 / 16F, 6 / 16F, 16 / 16F, 9 / 16F),
+            new AxisAlignedBB(10 / 16F, 11 / 16F, 7 / 16F, 15 / 16F, 16 / 16F, 10 / 16F)
+    };
+    private static final AxisAlignedBB[] NORTH = {
+            new AxisAlignedBB(6 / 16F, 5 / 16F, 3 / 16F, 10 / 16F, 9 / 16F, 16 / 16F),
+            new AxisAlignedBB(9 / 16F, 0, 6 / 16F, 13 / 16F, 5 / 16F, 16 / 16F),
+            new AxisAlignedBB(8 / 16F, 9 / 16F, 11 / 16F, 13 / 16F, 14 / 16F, 16 / 16F),
+            new AxisAlignedBB(2 / 16F, 1 / 16F, 9 / 16F, 7 / 16F, 7 / 16F, 16 / 16F),
+            new AxisAlignedBB(5 / 16F, 9 / 16F, 9 / 16F, 9 / 16F, 15 / 16F, 16 / 16F),
+            new AxisAlignedBB(0, 7 / 16F, 10 / 16F, 6 / 16F, 10 / 16F, 16 / 16F),
+            new AxisAlignedBB(10 / 16F, 7 / 16F, 10 / 16F, 15 / 16F, 9 / 16F, 15 / 16F),
+    };
+    private static final AxisAlignedBB[] SOUTH = {
+            new AxisAlignedBB(6 / 16F, 7 / 16F, 0 / 16F, 10 / 16F, 11 / 16F, 13 / 16F),
+            new AxisAlignedBB(7 / 16F, 11 / 16F, 0, 13 / 16F, 16 / 16F, 6 / 16F),
+            new AxisAlignedBB(8 / 16F, 2 / 16F, 9 / 16F, 13 / 16F, 7 / 16F, 14 / 16F),
+            new AxisAlignedBB(2 / 16F, 9 / 16F, 1 / 16F, 7 / 16F, 14 / 16F, 7 / 16F),
+            new AxisAlignedBB(5 / 16F, 1 / 16F, 9 / 16F, 9 / 16F, 7 / 16F, 9 / 16F),
+            new AxisAlignedBB(0, 6 / 16F, 1 / 16F, 6 / 16F, 9 / 16F, 7 / 16F),
+            new AxisAlignedBB(10 / 16F, 8 / 16F, 1 / 16F, 15 / 16F, 10 / 16F, 6 / 16F)
+    };
+    private static final AxisAlignedBB[] EAST = {
+            new AxisAlignedBB(0, 6 / 16F, 5 / 16F, 13 / 16F, 10 / 16F, 9 / 16F),
+            new AxisAlignedBB(0, 3 / 16F, 0, 6 / 16F, 9 / 16F, 5 / 16F),
 
-    private static final AxisAlignedBB AABB_NORTH1 = new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F);
-    private static final AxisAlignedBB AABB_NORTH2 = new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F);
-    private static final AxisAlignedBB AABB_NORTH3 = new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F);
-    private static final AxisAlignedBB AABB_NORTH4 = new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F);
-    private static final AxisAlignedBB AABB_NORTH5 = new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D);
-    private static final AxisAlignedBB AABB_NORTH6 = new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D);
-
-    private static final AxisAlignedBB AABB_SOUTH1 = new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F);
-    private static final AxisAlignedBB AABB_SOUTH2 = new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F);
-    private static final AxisAlignedBB AABB_SOUTH3 = new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F);
-    private static final AxisAlignedBB AABB_SOUTH4 = new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F);
-    private static final AxisAlignedBB AABB_SOUTH5 = new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D);
-    private static final AxisAlignedBB AABB_SOUTH6 = new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D);
-
-    private static final AxisAlignedBB AABB_EAST1 = new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F);
-    private static final AxisAlignedBB AABB_EAST2 = new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F);
-    private static final AxisAlignedBB AABB_EAST3 = new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F);
-    private static final AxisAlignedBB AABB_EAST4 = new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F);
-    private static final AxisAlignedBB AABB_EAST5 = new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D);
-    private static final AxisAlignedBB AABB_EAST6 = new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D);
-
-    private static final AxisAlignedBB AABB_WEST1 = new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F);
-    private static final AxisAlignedBB AABB_WEST2 = new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F);
-    private static final AxisAlignedBB AABB_WEST3 = new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F);
-    private static final AxisAlignedBB AABB_WEST4 = new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F);
-    private static final AxisAlignedBB AABB_WEST5 = new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D);
-    private static final AxisAlignedBB AABB_WEST6 = new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D);
-
-    static {
-        bounds.put(EnumFacing.UP, AABB_UP0);
-        bounds.put(EnumFacing.DOWN, AABB_DOWN0);
-        bounds.put(EnumFacing.NORTH, AABB_NORTH0);
-        bounds.put(EnumFacing.SOUTH, AABB_SOUTH0);
-        bounds.put(EnumFacing.WEST, AABB_WEST0);
-        bounds.put(EnumFacing.EAST, AABB_EAST0);
-    }
+            new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F),
+            new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F),
+            new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F),
+            new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D),
+            new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D)
+    };
+    private static final AxisAlignedBB[] WEST = {
+            new AxisAlignedBB(3 / 16F, 6 / 16F, 5 / 16F, 16 / 16F, 10 / 16F, 9 / 16F),
+            new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F),
+            new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F),
+            new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F),
+            new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F),
+            new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D),
+            new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D)
+    };
 
     public BlockDemonCrystal() {
         super(Material.ROCK);
@@ -137,116 +137,23 @@ public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvid
         return stack;
     }
 
-    private static AxisAlignedBB makeAABB(int fromX, int fromY, int fromZ, int toX, int toY, int toZ) {
-        return new AxisAlignedBB(fromX / 16F, fromY / 16F, fromZ / 16F, toX / 16F, toY / 16F, toZ / 16F);
-    }
-
     private static List<AxisAlignedBB> getCollisionBoxList(IBlockState state) {
-        List<AxisAlignedBB> list = Lists.newArrayList();
-        Integer age = state.getValue(BlockDemonCrystal.AGE);
+        int age = state.getValue(BlockDemonCrystal.AGE) + 1;
         switch (state.getValue(BlockDemonCrystal.ATTACHED)) {
-            case UP:
-                switch (age) {
-                    case 6:
-                        list.add(AABB_UP6);
-                    case 5:
-                        list.add(AABB_UP5);
-                    case 4:
-                        list.add(AABB_UP4);
-                    case 3:
-                        list.add(AABB_UP3);
-                    case 2:
-                        list.add(AABB_UP2);
-                    case 1:
-                        list.add(AABB_UP1);
-                    case 0:
-                    default:
-                        list.add(AABB_UP0);
-                        break;
-                }
-                break;
             case DOWN:
-                switch (age) {
-                    case 6:
-                    case 5:
-                    case 4:
-                    case 3:
-                    case 2:
-                    case 1:
-                    case 0:
-                    default:
-                        list.add(AABB_DOWN0);
-                        break;
-                }
-                break;
+                return Arrays.asList(DOWN).subList(0, age);
             case NORTH:
-                switch (age) {
-                    case 6:
-                    case 5:
-                    case 4:
-                    case 3:
-                    case 2:
-                    case 1:
-                    case 0:
-                    default:
-                        list.add(AABB_NORTH0);
-                        break;
-                }
-                break;
+                return Arrays.asList(NORTH).subList(0, age);
             case SOUTH:
-                switch (age) {
-                    case 6:
-                    case 5:
-                    case 4:
-                    case 3:
-                    case 2:
-                    case 1:
-                    case 0:
-                    default:
-                        list.add(AABB_SOUTH0);
-                        break;
-                }
-                break;
+                return Arrays.asList(SOUTH).subList(0, age);
             case WEST:
-                switch (age) {
-                    case 6:
-                    case 5:
-                    case 4:
-                    case 3:
-                    case 2:
-                    case 1:
-                    case 0:
-                    default:
-                        list.add(AABB_WEST0);
-                        break;
-                }
-                break;
+                return Arrays.asList(WEST).subList(0, age);
             case EAST:
-                switch (age) {
-                    case 6:
-                    case 5:
-                    case 4:
-                    case 3:
-                    case 2:
-                    case 1:
-                    case 0:
-                    default:
-                        list.add(AABB_EAST0);
-                        break;
-                }
-                break;
+                return Arrays.asList(EAST).subList(0, age);
+            case UP:
+            default:
+                return Arrays.asList(UP).subList(0, age);
         }
-
-
-        /* if (stairShape == BlockStairs.EnumShape.STRAIGHT || stairShape == BlockStairs.EnumShape.INNER_LEFT || stairShape == BlockStairs.EnumShape.INNER_RIGHT) {
-            list.add(getCollQuarterBlock(state));
-        }
-
-        if (stairShape != BlockStairs.EnumShape.STRAIGHT) {
-            list.add(getCollEighthBlock(state));
-        }
-*/
-        return list;
     }
 
     @Override
@@ -254,7 +161,21 @@ public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvid
         TileEntity tile = source.getTileEntity(pos);
         if (tile != null)
             state = getActualState(state, tile.getWorld(), pos);
-        return bounds.get(state.getValue(ATTACHED));
+        switch (state.getValue(ATTACHED)) {
+            case DOWN:
+                return DOWN[0];
+            case NORTH:
+                return NORTH[0];
+            case SOUTH:
+                return SOUTH[0];
+            case EAST:
+                return EAST[0];
+            case WEST:
+                return WEST[0];
+            case UP:
+            default:
+                return UP[0];
+        }
     }
 
     @Override
@@ -412,6 +333,7 @@ public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvid
     @Override
     public RayTraceResult collisionRayTrace(IBlockState blockState, World worldIn, BlockPos pos, Vec3d start, Vec3d end) {
         List<RayTraceResult> list = Lists.newArrayList();
+
 
         for (AxisAlignedBB axisalignedbb : getCollisionBoxList(this.getActualState(blockState, worldIn, pos))) {
             list.add(this.rayTrace(pos, start, end, axisalignedbb));

--- a/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrystal.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrystal.java
@@ -85,16 +85,16 @@ public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvid
     private static final AxisAlignedBB[] EAST = {
             new AxisAlignedBB(0, 6 / 16F, 5 / 16F, 13 / 16F, 10 / 16F, 9 / 16F),
             new AxisAlignedBB(0, 3 / 16F, 0, 6 / 16F, 9 / 16F, 5 / 16F),
-
-            new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F),
-            new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F),
-            new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F),
-            new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D),
-            new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D)
+            new AxisAlignedBB(0 / 16F, 3 / 16F, 9 / 16F, 5 / 16F, 8 / 16F, 14 / 16F),
+            new AxisAlignedBB(1 / 16F, 9 / 16F, 1 / 16F, 7 / 16F, 13 / 16F, 7 / 16F),
+            new AxisAlignedBB(1 / 16F, 0, 9 / 16F, 7 / 16F, 11 / 16F, 15 / 16F),
+            new AxisAlignedBB(0, 10 / 16F, 7 / 16F, 6 / 16F, 16 / 16F, 10 / 16F),
+            new AxisAlignedBB(0, 1 / 16F, 6 / 16F, 5 / 16F, 6 / 16F, 9 / 16F)
     };
     private static final AxisAlignedBB[] WEST = {
             new AxisAlignedBB(3 / 16F, 6 / 16F, 5 / 16F, 16 / 16F, 10 / 16F, 9 / 16F),
-            new AxisAlignedBB(7 / 16F, 0, 0, 13 / 16F, 6 / 16F, 5 / 16F),
+            new AxisAlignedBB(9 / 16F, 7 / 16F, 0, 16 / 16F, 12 / 16F, 5 / 16F),
+            
             new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F),
             new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F),
             new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F),

--- a/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrystal.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrystal.java
@@ -136,6 +136,7 @@ public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvid
         return stack;
     }
 
+    // collects a sublist from 0 to age for the collision boxes
     private static List<AxisAlignedBB> getCollisionBoxList(IBlockState state) {
         int age = state.getValue(BlockDemonCrystal.AGE) + 1;
         switch (state.getValue(BlockDemonCrystal.ATTACHED)) {

--- a/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrystal.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockDemonCrystal.java
@@ -94,12 +94,11 @@ public class BlockDemonCrystal extends Block implements IBMBlock, IVariantProvid
     private static final AxisAlignedBB[] WEST = {
             new AxisAlignedBB(3 / 16F, 6 / 16F, 5 / 16F, 16 / 16F, 10 / 16F, 9 / 16F),
             new AxisAlignedBB(9 / 16F, 7 / 16F, 0, 16 / 16F, 12 / 16F, 5 / 16F),
-            
-            new AxisAlignedBB(9 / 16F, 0, 9 / 16F, 13 / 16F, 5 / 16F, 14 / 16F),
-            new AxisAlignedBB(2 / 16F, 0, 1 / 16F, 7 / 16F, 6 / 16F, 7 / 16F),
-            new AxisAlignedBB(5 / 16F, 0, 9 / 16F, 9 / 16F, 7 / 16F, 15 / 16F),
-            new AxisAlignedBB(0.0D, 0.5D, 0.0D, 0.5D, 1.0D, 0.5D),
-            new AxisAlignedBB(0.5D, 0.5D, 0.0D, 1.0D, 1.0D, 0.5D)
+            new AxisAlignedBB(11 / 16F, 4 / 16F, 9 / 16F, 16 / 16F, 13 / 16F, 14 / 16F),
+            new AxisAlignedBB(9 / 16F, 3 / 16F, 1 / 16F, 16 / 16F, 8 / 16F, 7 / 16F),
+            new AxisAlignedBB(9 / 16F, 6 / 16F, 9 / 16F, 16 / 16F, 8 / 16F, 15 / 16F),
+            new AxisAlignedBB(10 / 16F, 1 / 16F, 7 / 16F, 16 / 16F, 6 / 16F, 10 / 16F),
+            new AxisAlignedBB(10 / 16F, 6 / 16F, 6 / 16F, 15 / 16F, 15 / 16F, 9 / 16F)
     };
 
     public BlockDemonCrystal() {

--- a/src/main/java/WayofTime/bloodmagic/block/BlockDemonPylon.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockDemonPylon.java
@@ -3,19 +3,36 @@ package WayofTime.bloodmagic.block;
 import WayofTime.bloodmagic.BloodMagic;
 import WayofTime.bloodmagic.client.IVariantProvider;
 import WayofTime.bloodmagic.tile.TileDemonPylon;
+import com.google.common.collect.Lists;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class BlockDemonPylon extends BlockContainer implements IBMBlock, IVariantProvider {
-    protected static final AxisAlignedBB AABB = new AxisAlignedBB(2 / 16F, 0F, 2 / 16F, 14 / 16F, 20 / 16F, 14 / 16F);
+    protected static final AxisAlignedBB BODY = new AxisAlignedBB(2 / 16F, 7 / 16F, 2 / 16F, 14 / 16F, 20 / 16F, 14 / 16F);
+    private static final AxisAlignedBB[] FEET = {
+            new AxisAlignedBB(10 / 16F, 0F, 2 / 16F, 14 / 16F, 7 / 16F, 6 / 16F), // NE
+            new AxisAlignedBB(10 / 16F, 0F, 10 / 16F, 14 / 16F, 7 / 16F, 14 / 16F), // SE
+            new AxisAlignedBB(2 / 16F, 0F, 10 / 16F, 6 / 16F, 7 / 16F, 14 / 16F), // SW
+            new AxisAlignedBB(2 / 16F, 0F, 2 / 16F, 6 / 16F, 7 / 16F, 6 / 16F)  // NW
+    };
+    private static final AxisAlignedBB[] ARMS = {};
+
     public BlockDemonPylon() {
         super(Material.ROCK);
 
@@ -28,9 +45,16 @@ public class BlockDemonPylon extends BlockContainer implements IBMBlock, IVarian
 //        setBlockBounds(0.3F, 0F, 0.3F, 0.72F, 1F, 0.72F);
     }
 
+    private static List<AxisAlignedBB> getCollisionBoxList(IBlockState state) {
+        ArrayList<AxisAlignedBB> collBox = new ArrayList<>(Arrays.asList(ARMS));
+        collBox.add(BODY);
+        collBox.addAll(Arrays.asList(FEET));
+        return collBox;
+    }
+
     @Override
     public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
-        return AABB;
+        return BODY;
     }
 
     @Override
@@ -66,5 +90,40 @@ public class BlockDemonPylon extends BlockContainer implements IBMBlock, IVarian
     @Override
     public ItemBlock getItem() {
         return new ItemBlock(this);
+    }
+
+    @Override
+    public RayTraceResult collisionRayTrace(IBlockState blockState, World worldIn, BlockPos pos, Vec3d start, Vec3d end) {
+        List<RayTraceResult> list = Lists.newArrayList();
+
+
+        for (AxisAlignedBB axisalignedbb : getCollisionBoxList(this.getActualState(blockState, worldIn, pos))) {
+            list.add(this.rayTrace(pos, start, end, axisalignedbb));
+        }
+
+        RayTraceResult rayTrace = null;
+        double d1 = 0.0D;
+
+        for (RayTraceResult raytraceresult : list) {
+            if (raytraceresult != null) {
+                double d0 = raytraceresult.hitVec.squareDistanceTo(end);
+
+                if (d0 > d1) {
+                    rayTrace = raytraceresult;
+                    d1 = d0;
+                }
+            }
+        }
+
+        return rayTrace;
+    }
+
+    @Override
+    public void addCollisionBoxToList(IBlockState state, World worldIn, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean bool) {
+        state = this.getActualState(state, worldIn, pos);
+
+        for (AxisAlignedBB axisalignedbb : getCollisionBoxList(state)) {
+            addCollisionBoxToList(pos, entityBox, collidingBoxes, axisalignedbb);
+        }
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/block/BlockDemonPylon.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockDemonPylon.java
@@ -9,11 +9,13 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumBlockRenderType;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 public class BlockDemonPylon extends BlockContainer implements IBMBlock, IVariantProvider {
+    protected static final AxisAlignedBB AABB = new AxisAlignedBB(2 / 16F, 0F, 2 / 16F, 14 / 16F, 20 / 16F, 14 / 16F);
     public BlockDemonPylon() {
         super(Material.ROCK);
 
@@ -24,6 +26,11 @@ public class BlockDemonPylon extends BlockContainer implements IBMBlock, IVarian
         setHarvestLevel("pickaxe", 0);
 
 //        setBlockBounds(0.3F, 0F, 0.3F, 0.72F, 1F, 0.72F);
+    }
+
+    @Override
+    public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
+        return AABB;
     }
 
     @Override

--- a/src/main/java/WayofTime/bloodmagic/block/BlockIncenseAltar.java
+++ b/src/main/java/WayofTime/bloodmagic/block/BlockIncenseAltar.java
@@ -17,7 +17,7 @@ import net.minecraft.world.World;
 import javax.annotation.Nullable;
 
 public class BlockIncenseAltar extends Block implements IVariantProvider, IBMBlock {
-    protected static final AxisAlignedBB AABB = new AxisAlignedBB(0.3F, 0F, 0.3F, 0.72F, 1F, 0.72F);
+    protected static final AxisAlignedBB AABB = new AxisAlignedBB(5 / 16F, 0F, 5 / 16F, 12 / 16F, 1F, 11 / 16F);
 
     public BlockIncenseAltar() {
         super(Material.ROCK);


### PR DESCRIPTION
The following blocks' collision boxes were changed to better fit the model:

- Demon Crystal block
- Alchemy table
- Blood Altar
- Demon Pylon
- Demon Crucible

Collision boxes for some details (Alchemy table devices/details/fluff, Blood Altar fancy corners, pylon antenna and arms, crucible "bowl" (I would be grateful for a proper term) have not been added/changed.