### PR TITLE
Sentient Bow without Demon Will (Issue 1421)

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientBow.java
+++ b/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientBow.java
@@ -47,6 +47,7 @@ public class ItemSentientBow extends ItemBow implements IMultiWillTool, ISentien
     public static double[] soulDrainPerSwing = new double[] { 0.05, 0.1, 0.2, 0.4, 0.75, 1, 1.5 }; //TODO
     public static double[] soulDrop = new double[] { 2, 4, 7, 10, 13, 16, 24 };
     public static double[] staticDrop = new double[] { 1, 1, 2, 3, 3, 3, 4 };
+    public static float soullessShotVelocity = 2.5F;
 
     public ItemSentientBow()
     {
@@ -117,7 +118,7 @@ public class ItemSentientBow extends ItemBow implements IMultiWillTool, ISentien
 //        setStaticDropOfActivatedSword(stack, level >= 0 ? staticDrop[level] : 1);
 //        setDropOfActivatedSword(stack, level >= 0 ? soulDrop[level] : 0);
 
-        setVelocityOfArrow(stack, level >= 0 ? 3 + getVelocityModifier(type, level) : 0);
+        setVelocityOfArrow(stack, level >= 0 ? 3 + getVelocityModifier(type, level) : soullessShotVelocity);
         setDamageAdded(stack, level >= 0 ? getDamageModifier(type, level) : 0);
     }
 
@@ -385,10 +386,9 @@ public class ItemSentientBow extends ItemBow implements IMultiWillTool, ISentien
                             entityArrow = itemarrow.createArrow(world, itemstack, player);
                         entityArrow.shoot(player, player.rotationPitch, player.rotationYaw, 0.0F, newArrowVelocity, 1.0F);
 
-                        if (newArrowVelocity == 0)
+                        if (Float.compare(getVelocityOfArrow(stack), soullessShotVelocity) < Float.MIN_NORMAL)
                         {
                             world.playSound(null, player.getPosition(), SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.NEUTRAL, 0.4F, 1.0F);
-                            return;
                         }
 
                         if (arrowVelocity == 1.0F)


### PR DESCRIPTION
Fixing the previous commit mess. Sorry about that, and sorry about this being a new PR too.

Added a soullessShotVelocity constant for arrow velocity when fired without demon souls. Applied it in the recalculatePowers method, so that if there is no Demon Will (when level >=0 in line 121), it would use the soullessShotVelocity as the arrow velocity.
Modified the onPlayerStoppedUsing function so that it would fire an arrow no matter what, but if there are no demon souls it would play the same fire extinguish sound as before.

Overall result:
If you fire the bow without Demon Will, it will fire at a velocity lower than a normal bow and play the fire extinguished sound. As opposed to what is described in issue 1421 (#1421)

