### PR TITLE
 Implemented Ritual of Grounding, a Ritual to change gravity behavior

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/BloodMagic.java
+++ b/src/main/java/WayofTime/bloodmagic/BloodMagic.java
@@ -91,6 +91,7 @@ public class BloodMagic {
 
         ModRecipes.init();
         ModRituals.initHarvestHandlers();
+        ModRituals.initCuttingFluids();
         MeteorConfigHandler.init(new File(configDir, "meteors"));
         ModArmourTrackers.init();
         NetworkRegistry.INSTANCE.registerGuiHandler(BloodMagic.instance, new GuiHandler());

--- a/src/main/java/WayofTime/bloodmagic/core/RegistrarBloodMagic.java
+++ b/src/main/java/WayofTime/bloodmagic/core/RegistrarBloodMagic.java
@@ -59,6 +59,9 @@ public class RegistrarBloodMagic
     public static final Potion CLING = MobEffects.HASTE;
     public static final Potion SACRIFICIAL_LAMB = MobEffects.HASTE;
     public static final Potion FLIGHT = MobEffects.HASTE;
+    public static final Potion GROUNDED = MobEffects.HASTE;
+    public static final Potion HEAVY_HEART = MobEffects.HASTE;
+    public static final Potion SUSPENDED = MobEffects.HASTE;
 
     public static IForgeRegistry<BloodOrb> BLOOD_ORBS = null;
 
@@ -95,8 +98,11 @@ public class RegistrarBloodMagic
                 new PotionBloodMagic("Bounce", false, 0x000000, 1, 1).setRegistryName("bounce"),
                 new PotionBloodMagic("Cling", false, 0x000000, 2, 1).setRegistryName("cling"),
                 new PotionBloodMagic("S. Lamb", false, 0x000000, 3, 1).setRegistryName("sacrificial_lamb"),
-                new PotionBloodMagic("Flight", false, 0x000000, 4, 0).setRegistryName("flight")
-                );
+                new PotionBloodMagic("Flight", false, 0x000000, 4, 0).setRegistryName("flight"),
+                new PotionBloodMagic("Grounded", true, 0x000000, 1, 0).setRegistryName("grounded"),
+                new PotionBloodMagic("Suspended", false, 0x000000, 1, 0).setRegistryName("suspended"),
+                new PotionBloodMagic("Heavy Heart", true, 0x000000, 1, 0).setRegistryName("heavy_heart")
+        );
     }
 
     @SubscribeEvent

--- a/src/main/java/WayofTime/bloodmagic/potion/PotionEventHandlers.java
+++ b/src/main/java/WayofTime/bloodmagic/potion/PotionEventHandlers.java
@@ -1,13 +1,12 @@
 package WayofTime.bloodmagic.potion;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
+import WayofTime.bloodmagic.BloodMagic;
+import WayofTime.bloodmagic.core.RegistrarBloodMagic;
+import WayofTime.bloodmagic.event.SacrificeKnifeUsedEvent;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.IProjectile;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.projectile.EntityArrow;
 import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.potion.PotionEffect;
@@ -15,53 +14,59 @@ import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraftforge.event.entity.living.EnderTeleportEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import WayofTime.bloodmagic.BloodMagic;
-import WayofTime.bloodmagic.core.RegistrarBloodMagic;
-import WayofTime.bloodmagic.event.SacrificeKnifeUsedEvent;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Mod.EventBusSubscriber(modid = BloodMagic.MODID)
-public class PotionEventHandlers
-{
-    public static List<EntityPlayer> flightList = new ArrayList<EntityPlayer>();
+public class PotionEventHandlers {
+    public static List<EntityPlayer> flightList = new ArrayList<>();
+    public static List<EntityLivingBase> noGravityList = new ArrayList<>();
 
     @SubscribeEvent
-    public static void onLivingJumpEvent(LivingEvent.LivingJumpEvent event)
-    {
-        if (event.getEntityLiving().isPotionActive(RegistrarBloodMagic.BOOST))
-        {
-            int i = event.getEntityLiving().getActivePotionEffect(RegistrarBloodMagic.BOOST).getAmplifier();
-            event.getEntityLiving().motionY += (0.1f) * (2 + i);
+    public static void onLivingJumpEvent(LivingEvent.LivingJumpEvent event) {
+        EntityLivingBase eventEntityLiving = event.getEntityLiving();
+
+        if (eventEntityLiving.isPotionActive(RegistrarBloodMagic.BOOST)) {
+            int i = eventEntityLiving.getActivePotionEffect(RegistrarBloodMagic.BOOST).getAmplifier();
+            eventEntityLiving.motionY += (0.1f) * (2 + i);
         }
 
-        // if (event.getEntityLiving().isPotionActive(ModPotions.heavyHeart)) {
-        // event.getEntityLiving().motionY = 0;
-        // }
+        if (eventEntityLiving.isPotionActive(RegistrarBloodMagic.GROUNDED))
+            eventEntityLiving.motionY = 0;
     }
 
     @SubscribeEvent
-    public static void onEntityUpdate(LivingEvent.LivingUpdateEvent event)
-    {
-        if (event.getEntityLiving() instanceof EntityPlayer)
-        {
-            EntityPlayer player = (EntityPlayer) event.getEntityLiving();
-            if (!player.world.isRemote)
-            {
-                if (player.isPotionActive(RegistrarBloodMagic.FLIGHT))
-                {
-                    if (!player.isSpectator() && !player.capabilities.allowFlying)
-                    {
+    public static void onLivingFall(LivingFallEvent event) {
+        EntityLivingBase eventEntityLiving = event.getEntityLiving();
+
+        if (eventEntityLiving.isPotionActive(RegistrarBloodMagic.HEAVY_HEART)) {
+            int i = eventEntityLiving.getActivePotionEffect(RegistrarBloodMagic.HEAVY_HEART).getAmplifier() + 1;
+            event.setDamageMultiplier(event.getDamageMultiplier() + i);
+            event.setDistance(event.getDistance() + i);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onEntityUpdate(LivingEvent.LivingUpdateEvent event) {
+        EntityLivingBase eventEntityLiving = event.getEntityLiving();
+
+        if (eventEntityLiving instanceof EntityPlayer) {
+            EntityPlayer player = (EntityPlayer) eventEntityLiving;
+            if (!player.world.isRemote) {
+                if (player.isPotionActive(RegistrarBloodMagic.FLIGHT)) {
+                    if (!player.isSpectator() && !player.capabilities.allowFlying) {
                         player.capabilities.allowFlying = true;
                         player.sendPlayerAbilities();
                         flightList.add(player);
                     }
-                } else
-                {
-                    if (flightList.contains(player))
-                    {
+                } else {
+                    if (flightList.contains(player)) {
                         player.capabilities.allowFlying = false;
                         player.capabilities.isFlying = false;
                         player.sendPlayerAbilities();
@@ -70,30 +75,41 @@ public class PotionEventHandlers
                 }
             }
         }
-//        if (event.getEntityLiving().isPotionActive(ModPotions.boost))
+//        if (eventEntityLiving.isPotionActive(ModPotions.boost))
 //        {
-//            int i = event.getEntityLiving().getActivePotionEffect(ModPotions.boost).getAmplifier();
+//            int i = eventEntityLiving.getActivePotionEffect(ModPotions.boost).getAmplifier();
 //            {
 //                float percentIncrease = (i + 1) * 0.05f;
 //
-//                if (event.getEntityLiving() instanceof EntityPlayer)
+//                if (eventEntityLiving instanceof EntityPlayer)
 //                {
-//                    EntityPlayer entityPlayer = (EntityPlayer) event.getEntityLiving();
+//                    EntityPlayer entityPlayer = (EntityPlayer) eventEntityLiving;
 //
 //                    if ((entityPlayer.onGround || entityPlayer.capabilities.isFlying) && entityPlayer.moveForward > 0F)
 //                        entityPlayer.moveFlying(0F, 1F, entityPlayer.capabilities.isFlying ? (percentIncrease / 2.0f) : percentIncrease);
 //                }
 //            }
 //        }
+        if ((!(eventEntityLiving instanceof EntityPlayer) || !((EntityPlayer) eventEntityLiving).isSpectator()) && eventEntityLiving.isPotionActive(RegistrarBloodMagic.SUSPENDED)) {
+            eventEntityLiving.setNoGravity(true);
+            noGravityList.add(eventEntityLiving);
+        } else {
+            eventEntityLiving.setNoGravity(false);
+            noGravityList.remove(eventEntityLiving);
+        }
 
-        if (event.getEntityLiving().isPotionActive(RegistrarBloodMagic.WHIRLWIND))
-        {
+        if (eventEntityLiving.isPotionActive(RegistrarBloodMagic.GROUNDED))
+            if (eventEntityLiving instanceof EntityPlayer && ((EntityPlayer) eventEntityLiving).capabilities.isFlying)
+                eventEntityLiving.motionY -= (0.05D * (double) (eventEntityLiving.getActivePotionEffect(RegistrarBloodMagic.GROUNDED).getAmplifier() + 1) - eventEntityLiving.motionY) * 0.2D;
+            else
+                eventEntityLiving.motionY -= (0.1D * (double) (eventEntityLiving.getActivePotionEffect(RegistrarBloodMagic.GROUNDED).getAmplifier() + 1) - eventEntityLiving.motionY) * 0.2D;
+
+        if (eventEntityLiving.isPotionActive(RegistrarBloodMagic.WHIRLWIND)) {
             int d0 = 3;
-            AxisAlignedBB axisAlignedBB = new AxisAlignedBB(event.getEntityLiving().posX - 0.5, event.getEntityLiving().posY - 0.5, event.getEntityLiving().posZ - 0.5, event.getEntityLiving().posX + 0.5, event.getEntityLiving().posY + 0.5, event.getEntityLiving().posZ + 0.5).expand(d0, d0, d0);
-            List<Entity> entityList = event.getEntityLiving().getEntityWorld().getEntitiesWithinAABB(Entity.class, axisAlignedBB);
+            AxisAlignedBB axisAlignedBB = new AxisAlignedBB(eventEntityLiving.posX - 0.5, eventEntityLiving.posY - 0.5, eventEntityLiving.posZ - 0.5, eventEntityLiving.posX + 0.5, eventEntityLiving.posY + 0.5, eventEntityLiving.posZ + 0.5).expand(d0, d0, d0);
+            List<Entity> entityList = eventEntityLiving.getEntityWorld().getEntitiesWithinAABB(Entity.class, axisAlignedBB);
 
-            for (Entity projectile : entityList)
-            {
+            for (Entity projectile : entityList) {
                 if (projectile == null)
                     continue;
                 if (!(projectile instanceof IProjectile))
@@ -106,12 +122,12 @@ public class PotionEventHandlers
                 else if (projectile instanceof EntityThrowable)
                     throwingEntity = ((EntityThrowable) projectile).getThrower();
 
-                if (throwingEntity != null && throwingEntity.equals(event.getEntityLiving()))
+                if (throwingEntity != null && throwingEntity.equals(eventEntityLiving))
                     continue;
 
-                double delX = projectile.posX - event.getEntityLiving().posX;
-                double delY = projectile.posY - event.getEntityLiving().posY;
-                double delZ = projectile.posZ - event.getEntityLiving().posZ;
+                double delX = projectile.posX - eventEntityLiving.posX;
+                double delY = projectile.posY - eventEntityLiving.posY;
+                double delZ = projectile.posZ - eventEntityLiving.posZ;
 
                 double angle = (delX * projectile.motionX + delY * projectile.motionY + delZ * projectile.motionZ) / (Math.sqrt(delX * delX + delY * delY + delZ * delZ) * Math.sqrt(projectile.motionX * projectile.motionX + projectile.motionY * projectile.motionY + projectile.motionZ * projectile.motionZ));
 
@@ -120,8 +136,7 @@ public class PotionEventHandlers
                 if (angle < 3 * (Math.PI / 4))
                     continue; // angle is < 135 degrees
 
-                if (throwingEntity != null)
-                {
+                if (throwingEntity != null) {
                     delX = -projectile.posX + throwingEntity.posX;
                     delY = -projectile.posY + (throwingEntity.posY + throwingEntity.getEyeHeight());
                     delZ = -projectile.posZ + throwingEntity.posZ;
@@ -141,31 +156,26 @@ public class PotionEventHandlers
     }
 
     @SubscribeEvent
-    public static void onPlayerRespawn(PlayerEvent.Clone event)
-    {
+    public static void onPlayerRespawn(PlayerEvent.Clone event) {
         if (event.isWasDeath())
             event.getEntityPlayer().addPotionEffect(new PotionEffect(RegistrarBloodMagic.SOUL_FRAY, 400));
     }
 
     @SubscribeEvent
-    public static void onSacrificeKnifeUsed(SacrificeKnifeUsedEvent event)
-    {
+    public static void onSacrificeKnifeUsed(SacrificeKnifeUsedEvent event) {
         if (event.player.isPotionActive(RegistrarBloodMagic.SOUL_FRAY))
             event.lpAdded = (int) (event.lpAdded * 0.1D);
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
-    public static void onPlayerDamageEvent(LivingAttackEvent event)
-    {
+    public static void onPlayerDamageEvent(LivingAttackEvent event) {
         if (event.getEntityLiving().isPotionActive(RegistrarBloodMagic.WHIRLWIND) && event.isCancelable() && event.getSource().isProjectile())
             event.setCanceled(true);
     }
 
     @SubscribeEvent
-    public static void onEndermanTeleportEvent(EnderTeleportEvent event)
-    {
-        if (event.getEntityLiving().isPotionActive(RegistrarBloodMagic.PLANAR_BINDING) && event.isCancelable())
-        {
+    public static void onEndermanTeleportEvent(EnderTeleportEvent event) {
+        if (event.getEntityLiving().isPotionActive(RegistrarBloodMagic.PLANAR_BINDING) && event.isCancelable()) {
             event.setCanceled(true);
         }
     }

--- a/src/main/java/WayofTime/bloodmagic/registry/ModRituals.java
+++ b/src/main/java/WayofTime/bloodmagic/registry/ModRituals.java
@@ -1,5 +1,8 @@
 package WayofTime.bloodmagic.registry;
 
+import WayofTime.bloodmagic.item.alchemy.ItemCuttingFluid;
+import WayofTime.bloodmagic.ritual.crushing.CrushingHandlerCuttingFluid;
+import WayofTime.bloodmagic.ritual.crushing.CrushingRegistry;
 import WayofTime.bloodmagic.ritual.harvest.HarvestRegistry;
 import WayofTime.bloodmagic.ritual.harvest.HarvestHandlerPlantable;
 import WayofTime.bloodmagic.ritual.harvest.HarvestHandlerStem;
@@ -18,5 +21,11 @@ public class ModRituals
         HarvestRegistry.registerHandler(new HarvestHandlerPlantable());
         HarvestRegistry.registerHandler(new HarvestHandlerTall());
         HarvestRegistry.registerHandler(new HarvestHandlerStem());
+    }
+
+    public static void initCuttingFluids()
+    {
+        CrushingRegistry.registerCuttingFluid(new CrushingHandlerCuttingFluid(ItemCuttingFluid.FluidType.BASIC.getStack(), 250, 0.5));
+        CrushingRegistry.registerCuttingFluid(new CrushingHandlerCuttingFluid(ItemCuttingFluid.FluidType.EXPLOSIVE.getStack(), 25, 0.05));
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/ritual/crushing/CrushingHandlerCuttingFluid.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/crushing/CrushingHandlerCuttingFluid.java
@@ -1,0 +1,49 @@
+package WayofTime.bloodmagic.ritual.crushing;
+
+import WayofTime.bloodmagic.api.impl.BloodMagicAPI;
+import WayofTime.bloodmagic.api.impl.recipe.RecipeAlchemyTable;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CrushingHandlerCuttingFluid implements ICrushingHandler {
+
+    private int lpDrain;
+
+    private double willDrain;
+
+    private ItemStack cuttingStack;
+
+    public CrushingHandlerCuttingFluid(ItemStack cuttingStack, int lpDrain, double willDrain) {
+        this.lpDrain = lpDrain;
+        this.willDrain = willDrain;
+        this.cuttingStack = cuttingStack;
+    }
+
+    @Override
+    @Nonnull
+    public ItemStack getRecipeOutput(ItemStack inputStack, World world, BlockPos pos) {
+        List<ItemStack> inputList = new ArrayList<>();
+        inputList.add(cuttingStack);
+        inputList.add(inputStack.copy());
+        RecipeAlchemyTable recipeAlchemyTable = BloodMagicAPI.INSTANCE.getRecipeRegistrar().getAlchemyTable(inputList);
+
+        if (recipeAlchemyTable != null) {
+            return recipeAlchemyTable.getOutput().copy();
+        }
+
+        return ItemStack.EMPTY;
+    }
+
+    public double getWillDrain() {
+        return willDrain;
+    }
+
+    public int getLpDrain() {
+        return lpDrain;
+    }
+}

--- a/src/main/java/WayofTime/bloodmagic/ritual/crushing/CrushingRegistry.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/crushing/CrushingRegistry.java
@@ -1,0 +1,20 @@
+package WayofTime.bloodmagic.ritual.crushing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+
+
+public class CrushingRegistry {
+
+    private static List<ICrushingHandler> crushingHandlerList = new ArrayList<>();
+
+    public static void registerCuttingFluid(ICrushingHandler handler) {
+        crushingHandlerList.add(handler);
+    }
+
+    public static List<ICrushingHandler> getCrushingHandlerList() {
+        return crushingHandlerList;
+    }
+}

--- a/src/main/java/WayofTime/bloodmagic/ritual/crushing/ICrushingHandler.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/crushing/ICrushingHandler.java
@@ -1,0 +1,14 @@
+package WayofTime.bloodmagic.ritual.crushing;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
+
+public interface ICrushingHandler {
+    @Nonnull
+    ItemStack getRecipeOutput(ItemStack input, World world, BlockPos pos);
+    int getLpDrain();
+    double getWillDrain();
+}

--- a/src/main/java/WayofTime/bloodmagic/ritual/types/RitualCondor.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/types/RitualCondor.java
@@ -52,7 +52,7 @@ public class RitualCondor extends Ritual {
 
     @Override
     public int getRefreshCost() {
-        return getBlockRange(FLIGHT_RANGE).getVolume() / 10000; // cost of 2 LP per second per player with default configuration
+        return Math.max(1, getBlockRange(FLIGHT_RANGE).getVolume() / 10000); // cost of 2 LP per second per player with default configuration
     }
 
     @Override

--- a/src/main/java/WayofTime/bloodmagic/ritual/types/RitualCrushing.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/types/RitualCrushing.java
@@ -5,6 +5,8 @@ import WayofTime.bloodmagic.compress.CompressionRegistry;
 import WayofTime.bloodmagic.recipe.alchemyTable.AlchemyTableRecipe;
 import WayofTime.bloodmagic.core.registry.AlchemyTableRecipeRegistry;
 import WayofTime.bloodmagic.ritual.*;
+import WayofTime.bloodmagic.ritual.crushing.CrushingRegistry;
+import WayofTime.bloodmagic.ritual.crushing.ICrushingHandler;
 import WayofTime.bloodmagic.soul.EnumDemonWillType;
 import WayofTime.bloodmagic.core.RegistrarBloodMagicBlocks;
 import WayofTime.bloodmagic.demonAura.WorldDemonWillHandler;
@@ -117,29 +119,19 @@ public class RitualCrushing extends Ritual {
 
                 ItemStack copyStack = checkStack.copy();
 
-                for (Entry<ItemStack, Integer> entry : cuttingFluidLPMap.entrySet()) {
-                    ItemStack cuttingStack = entry.getKey();
-                    int lpDrain = entry.getValue();
-                    double willDrain = cuttingFluidWillMap.containsKey(cuttingStack) ? cuttingFluidWillMap.get(cuttingStack) : 0;
+                for (ICrushingHandler handler : CrushingRegistry.getCrushingHandlerList()) {
+                   int lpDrain = handler.getLpDrain();
+                   double willDrain = handler.getWillDrain();
 
-                    if (corrosiveWill < willDrain || currentEssence < lpDrain + getRefreshCost()) {
-                        continue;
-                    }
+                   if (corrosiveWill < willDrain || currentEssence < lpDrain + getRefreshCost()) {
+                       continue;
+                   }
 
-                    cuttingStack = cuttingStack.copy();
-                    List<ItemStack> input = new ArrayList<>();
-                    input.add(cuttingStack);
-                    input.add(copyStack);
+                   ItemStack result = handler.getRecipeOutput(copyStack, world, pos);
 
-                    AlchemyTableRecipe recipe = AlchemyTableRecipeRegistry.getMatchingRecipe(input, world, pos);
-                    if (recipe == null) {
-                        continue;
-                    }
-
-                    ItemStack result = recipe.getRecipeOutput(input);
-                    if (result.isEmpty()) {
-                        continue;
-                    }
+                   if (result.isEmpty()) {
+                      continue;
+                   }
 
                     if (tile != null) {
                         result = Utils.insertStackIntoTile(result, tile, EnumFacing.DOWN);
@@ -158,6 +150,7 @@ public class RitualCrushing extends Ritual {
 
                     isBlockClaimed = true;
                 }
+
             }
 
             if (!isBlockClaimed && isSilkTouch && block.canSilkHarvest(world, newPos, state, getFakePlayer((WorldServer) world))) {

--- a/src/main/java/WayofTime/bloodmagic/ritual/types/RitualGrounding.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/types/RitualGrounding.java
@@ -160,7 +160,7 @@ public class RitualGrounding extends Ritual {
         /* Combination of corrosive + vengeful will: Levitation */
         if (corrosiveWill >= willDrain && vengefulWill >= willDrain) {
 
-            entity.addPotionEffect(new PotionEffect(MobEffects.LEVITATION, 10, 10));
+            entity.addPotionEffect(new PotionEffect(MobEffects.LEVITATION, 20, 10));
             vengefulDrained += willDrain;
             corrosiveDrained += willDrain;
 

--- a/src/main/java/WayofTime/bloodmagic/ritual/types/RitualGrounding.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/types/RitualGrounding.java
@@ -1,0 +1,199 @@
+package WayofTime.bloodmagic.ritual.types;
+
+import WayofTime.bloodmagic.BloodMagic;
+import WayofTime.bloodmagic.core.RegistrarBloodMagic;
+import WayofTime.bloodmagic.demonAura.WorldDemonWillHandler;
+import WayofTime.bloodmagic.ritual.*;
+import WayofTime.bloodmagic.soul.DemonWillHolder;
+import WayofTime.bloodmagic.soul.EnumDemonWillType;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.MoverType;
+import net.minecraft.entity.boss.EntityDragon;
+import net.minecraft.entity.boss.EntityWither;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.MobEffects;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+@RitualRegister("grounding")
+public class RitualGrounding extends Ritual {
+
+    public static final int willRefreshTime = 20;
+    public static final String GROUNDING_RANGE = "groundingRange";
+    public static final double willDrain = 0.5;
+
+    public RitualGrounding() {
+        super("ritualGrounding", 0, 5000, "ritual." + BloodMagic.MODID + ".groundingRitual");
+        addBlockRange(GROUNDING_RANGE, new AreaDescriptor.Rectangle(new BlockPos(0, 0, 0), 10, 30, 10)); //10 30 10
+        setMaximumVolumeAndDistanceOfRange(GROUNDING_RANGE, 0, 200, 200);
+    }
+
+    @Override
+    public void performRitual(IMasterRitualStone masterRitualStone) {
+        /* Default Ritual Stuff */
+        World world = masterRitualStone.getWorldObj();
+        int currentEssence = masterRitualStone.getOwnerNetwork().getCurrentEssence();
+        BlockPos pos = masterRitualStone.getBlockPos();
+
+        if (currentEssence < getRefreshCost()) {
+            masterRitualStone.getOwnerNetwork().causeNausea();
+            return;
+        }
+
+        int maxEffects = currentEssence / getRefreshCost();
+        int totalEffects = 0;
+
+        /* Default will augment stuff */
+        List<EnumDemonWillType> willConfig = masterRitualStone.getActiveWillConfig();
+        DemonWillHolder holder = WorldDemonWillHandler.getWillHolder(world, pos);
+
+        double rawWill = this.getWillRespectingConfig(world, pos, EnumDemonWillType.DEFAULT, willConfig);
+        double corrosiveWill = this.getWillRespectingConfig(world, pos, EnumDemonWillType.CORROSIVE, willConfig);
+        double destructiveWill = this.getWillRespectingConfig(world, pos, EnumDemonWillType.DESTRUCTIVE, willConfig);
+        double steadfastWill = this.getWillRespectingConfig(world, pos, EnumDemonWillType.STEADFAST, willConfig);
+        double vengefulWill = this.getWillRespectingConfig(world, pos, EnumDemonWillType.VENGEFUL, willConfig);
+
+        double rawDrained = 0;
+        double corrosiveDrained = 0;
+        double destructiveDrained = 0;
+        double steadfastDrained = 0;
+        double vengefulDrained = 0;
+
+        /* Actual ritual stuff begins here */
+        AreaDescriptor groundingRange = getBlockRange(GROUNDING_RANGE);
+        List<EntityLivingBase> entities = world.getEntitiesWithinAABB(EntityLivingBase.class, groundingRange.getAABB(pos).expand(-10, 0, -10));
+        for (EntityLivingBase entity : entities) {
+            if (totalEffects >= maxEffects) {
+                break;
+            }
+
+            if (entity instanceof EntityPlayer && ((EntityPlayer) entity).isCreative())
+                continue;
+
+            totalEffects++;
+
+
+            if (entity instanceof EntityPlayer) {
+                /* Raw will effect: Affects players */
+                if (world.getTotalWorldTime() % 10 == 0) {
+                    if (rawWill >= willDrain) {
+
+                        rawDrained += willDrain;
+
+                        double[] drainagePlayer = sharedWillEffects(world, entity, corrosiveWill, destructiveWill, vengefulWill, corrosiveDrained, destructiveDrained, vengefulDrained);
+
+                        corrosiveDrained += drainagePlayer[0];
+                        destructiveDrained += drainagePlayer[1];
+                        vengefulDrained += drainagePlayer[2];
+                    }
+                }
+            } else if (entity.isNonBoss()) {
+                if (world.getTotalWorldTime() % 10 == 0) {
+                    double[] drainageEntity = sharedWillEffects(world, entity, corrosiveWill, destructiveWill, vengefulWill, corrosiveDrained, destructiveDrained, vengefulDrained);
+
+                    corrosiveDrained += drainageEntity[0];
+                    destructiveDrained += drainageEntity[1];
+                    vengefulDrained += drainageEntity[2];
+                }
+            } else if (!entity.isNonBoss()) {
+                /* Steadfast will effect: Affects bosses
+                (some bosses, like the wither, have a restriction to motion modification,
+                others, like the Ender Dragon, don't do potions) */
+                if (steadfastWill >= willDrain) {
+                    if (entity instanceof EntityWither || entity instanceof EntityDragon)
+                        entity.move(MoverType.SELF, 0, -0.05, 0); // to work on Wither and EnderDragon without interfering with other mod author's decisions (looking at you, Vazkii)
+
+                    steadfastDrained += willDrain / 10f;
+
+                    double[] drainagePlayer = sharedWillEffects(world, entity, corrosiveWill, destructiveWill, vengefulWill, corrosiveDrained, destructiveDrained, vengefulDrained);
+
+                    corrosiveDrained += drainagePlayer[0];
+                    destructiveDrained += drainagePlayer[1];
+                    vengefulDrained += drainagePlayer[2];
+                }
+            }
+        }
+
+
+        if (rawDrained > 0)
+            WorldDemonWillHandler.drainWill(world, pos, EnumDemonWillType.DEFAULT, rawDrained, true);
+        if (corrosiveDrained > 0)
+            WorldDemonWillHandler.drainWill(world, pos, EnumDemonWillType.CORROSIVE, corrosiveDrained, true);
+        if (destructiveDrained > 0)
+            WorldDemonWillHandler.drainWill(world, pos, EnumDemonWillType.DESTRUCTIVE, destructiveDrained, true);
+        if (steadfastDrained > 0)
+            WorldDemonWillHandler.drainWill(world, pos, EnumDemonWillType.STEADFAST, steadfastDrained, true);
+        if (vengefulDrained > 0)
+            WorldDemonWillHandler.drainWill(world, pos, EnumDemonWillType.VENGEFUL, vengefulDrained, true);
+
+        masterRitualStone.getOwnerNetwork().syphon(masterRitualStone.ticket(getRefreshCost() * totalEffects));
+    }
+
+    @Override
+    public int getRefreshTime() {
+        return 1;
+    }
+
+    @Override
+    public int getRefreshCost() {
+        return Math.max(1, getBlockRange(GROUNDING_RANGE).getVolume() / 10000);
+    }
+
+    @Override
+    public void gatherComponents(Consumer<RitualComponent> components) {
+        addParallelRunes(components, 1, 0, EnumRuneType.DUSK);
+        addCornerRunes(components, 2, 2, EnumRuneType.EARTH);
+        addCornerRunes(components, 3, 3, EnumRuneType.EARTH);
+    }
+
+
+    @Override
+    public Ritual getNewCopy() {
+        return new RitualGrounding();
+    }
+
+    public double[] sharedWillEffects(World world, EntityLivingBase entity, double corrosiveWill, double destructiveWill, double vengefulWill, double corrosiveDrained, double destructiveDrained, double vengefulDrained) {
+        /* Combination of corrosive + vengeful will: Levitation */
+        if (corrosiveWill >= willDrain && vengefulWill >= willDrain) {
+
+            entity.addPotionEffect(new PotionEffect(MobEffects.LEVITATION, 10, 10));
+            vengefulDrained += willDrain;
+            corrosiveDrained += willDrain;
+
+            /* Corrosive will effect: Suspension */
+        } else if (corrosiveWill >= willDrain) {
+
+            entity.addPotionEffect(new PotionEffect(RegistrarBloodMagic.SUSPENDED, 20, 0));
+            corrosiveDrained += willDrain;
+
+            /* Vengeful will effect: Stronger effect */
+        } else if (vengefulWill >= willDrain) {
+
+            vengefulDrained += willDrain;
+            entity.addPotionEffect(new PotionEffect(RegistrarBloodMagic.GROUNDED, 40, 20));
+
+        } else
+
+            entity.addPotionEffect(new PotionEffect(RegistrarBloodMagic.GROUNDED, 20, 10));
+
+        /* Destructive will effect: Increased fall damage */
+        if (destructiveWill >= willDrain) {
+            destructiveDrained += willDrain;
+
+            /* Combination of destructive + vengeful will: stronger destructive effect */
+            if (vengefulWill >= willDrain + vengefulDrained) {
+                if (world.getTotalWorldTime() % 100 == 0) {
+                    vengefulDrained += willDrain;
+                    entity.addPotionEffect(new PotionEffect(RegistrarBloodMagic.HEAVY_HEART, 200, 2));
+                }
+
+            } else if (world.getTotalWorldTime() % 50 == 0)
+                entity.addPotionEffect(new PotionEffect(RegistrarBloodMagic.HEAVY_HEART, 100, 1));
+        }
+        return new double[]{corrosiveDrained, destructiveDrained, vengefulDrained};
+    }
+}

--- a/src/main/java/WayofTime/bloodmagic/ritual/types/RitualHarvest.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/types/RitualHarvest.java
@@ -2,8 +2,8 @@ package WayofTime.bloodmagic.ritual.types;
 
 import WayofTime.bloodmagic.BloodMagic;
 import WayofTime.bloodmagic.ritual.*;
-import WayofTime.bloodmagic.ritual.harvest.IHarvestHandler;
 import WayofTime.bloodmagic.ritual.harvest.HarvestRegistry;
+import WayofTime.bloodmagic.ritual.harvest.IHarvestHandler;
 import com.google.common.collect.Lists;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.inventory.InventoryHelper;
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
  * <p>
  * This ritual includes a way to change the range based on what block is above
  * the MasterRitualStone. You can use
- * {@link HarvestRegistry#registerRangeAmplifier(net.minecraft.block.state.IBlockState, int)} to register a
+ * {@link HarvestRegistry#registerRangeAmplifier(IBlockState, int)} to register a
  * new amplifier.
  */
 @RitualRegister("harvest")
@@ -77,30 +77,10 @@ public class RitualHarvest extends Ritual {
 
     @Override
     public void gatherComponents(Consumer<RitualComponent> components) {
-        components.accept(new RitualComponent(new BlockPos(1, 0, 1), EnumRuneType.DUSK));
-        components.accept(new RitualComponent(new BlockPos(1, 0, -1), EnumRuneType.DUSK));
-        components.accept(new RitualComponent(new BlockPos(-1, 0, -1), EnumRuneType.DUSK));
-        components.accept(new RitualComponent(new BlockPos(-1, 0, 1), EnumRuneType.DUSK));
-        components.accept(new RitualComponent(new BlockPos(2, 0, 0), EnumRuneType.EARTH));
-        components.accept(new RitualComponent(new BlockPos(-2, 0, 0), EnumRuneType.EARTH));
-        components.accept(new RitualComponent(new BlockPos(0, 0, 2), EnumRuneType.EARTH));
-        components.accept(new RitualComponent(new BlockPos(0, 0, -2), EnumRuneType.EARTH));
-        components.accept(new RitualComponent(new BlockPos(3, 0, 1), EnumRuneType.EARTH));
-        components.accept(new RitualComponent(new BlockPos(3, 0, -1), EnumRuneType.EARTH));
-        components.accept(new RitualComponent(new BlockPos(-3, 0, 1), EnumRuneType.EARTH));
-        components.accept(new RitualComponent(new BlockPos(-3, 0, -1), EnumRuneType.EARTH));
-        components.accept(new RitualComponent(new BlockPos(1, 0, 3), EnumRuneType.EARTH));
-        components.accept(new RitualComponent(new BlockPos(-1, 0, 3), EnumRuneType.EARTH));
-        components.accept(new RitualComponent(new BlockPos(1, 0, -3), EnumRuneType.EARTH));
-        components.accept(new RitualComponent(new BlockPos(-1, 0, -3), EnumRuneType.EARTH));
-        components.accept(new RitualComponent(new BlockPos(2, 0, 3), EnumRuneType.WATER));
-        components.accept(new RitualComponent(new BlockPos(3, 0, 2), EnumRuneType.WATER));
-        components.accept(new RitualComponent(new BlockPos(2, 0, -3), EnumRuneType.WATER));
-        components.accept(new RitualComponent(new BlockPos(-3, 0, 2), EnumRuneType.WATER));
-        components.accept(new RitualComponent(new BlockPos(-2, 0, 3), EnumRuneType.WATER));
-        components.accept(new RitualComponent(new BlockPos(3, 0, -2), EnumRuneType.WATER));
-        components.accept(new RitualComponent(new BlockPos(-2, 0, -3), EnumRuneType.WATER));
-        components.accept(new RitualComponent(new BlockPos(-3, 0, -2), EnumRuneType.WATER));
+        addCornerRunes(components, 1, 0, EnumRuneType.DUSK);
+        addParallelRunes(components, 2, 0, EnumRuneType.EARTH);
+        addOffsetRunes(components, 3, 1, 0, EnumRuneType.EARTH);
+        addOffsetRunes(components, 3, 2, 0, EnumRuneType.WATER);
     }
 
     @Override

--- a/src/main/resources/assets/bloodmagic/lang/en_US.lang
+++ b/src/main/resources/assets/bloodmagic/lang/en_US.lang
@@ -620,6 +620,7 @@ ritual.bloodmagic.downgradeRitual=Penance of the Leadened Soul
 ritual.bloodmagic.crystalSplitRitual=Resonance of the Faceted Crystal
 ritual.bloodmagic.condorRitual=Reverence of the Condor
 ritual.bloodmagic.eternalSoulRitual=Cry of the Eternal Soul
+ritual.bloodmagic.groundingRitual=Ritual of Grounding
 
 ritual.bloodmagic.waterRitual.info=Generates a source of water from the master ritual stone.
 ritual.bloodmagic.lavaRitual.info=Generates a source of lava from the master ritual stone.
@@ -665,6 +666,14 @@ ritual.bloodmagic.animalGrowthRitual.steadfast.info=(Steadfast) Automatically br
 ritual.bloodmagic.animalGrowthRitual.default.info=(Raw) Increases the speed of the ritual based on the total Will in the Aura.
 ritual.bloodmagic.animalGrowthRitual.destructive.info=(Destructive) Causes adults that have not bred lately to run at mobs and explode.
 ritual.bloodmagic.animalGrowthRitual.corrosive.info=(Corrosive) Unimplemented.
+ritual.bloodmagic.groundingRitual.info=Forces entities on the ground and prevents jumping.
+ritual.bloodmagic.groundingRitual.default.info=(Raw) Affects players.
+ritual.bloodmagic.groundingRitual.corrosive.info=(Corrosive) Disables gravity (+Vengeful) Applies Levitation.
+ritual.bloodmagic.groundingRitual.destructive.info=(Destructive) Applies Heavy Heart (increases fall damage) (+Vengeful) Stronger effect.
+ritual.bloodmagic.groundingRitual.steadfast.info=(Steadfast) Affects Bosses. Doesn't affect bosses that are immune against motion change or immune against potions (except Wither and Ender Dragon).
+ritual.bloodmagic.groundingRitual.vengeful.info=(Vengeful) Makes effects stronger. (+Corrosive) Applies Levitation. (+Destructive) Higher Heavy Heart amplifier.
+ritual.bloodmagic.condorRitual.info=Provides flight in an area around the ritual.
+ritual.bloodmagic.eternalSoulRitual.info=Capable of transferring Life Essence from a Network back into an Altar at a cost.
 
 ritual.bloodmagic.crystalSplitRitual.info=Splits apart a well-grown Raw crystal cluster into seperal aspected crystal clusters.
 ritual.bloodmagic.fullStomachRitual.info=Takes food from the linked chest and fills the player's saturation with it.
@@ -749,10 +758,6 @@ ritual.bloodmagic.downgradeRitual.dialogue.slowHeal.1=Beware, mortal, for you ar
 ritual.bloodmagic.downgradeRitual.dialogue.slowHeal.100=Unlike my comrades, I offer one of the most grim deals that you could possibly hope for as a magician that deals in your own health.
 ritual.bloodmagic.downgradeRitual.dialogue.slowHeal.300=Although your wounds may heal, they will do so slowly if you accept my "offering," and the stings of battle will plague you even more.
 ritual.bloodmagic.downgradeRitual.dialogue.slowHeal.500=So think carefully before you rush into something that you may regret, since even though your cup may be empty it will be almost impossible to fill once more...
-
-ritual.bloodmagic.condorRitual.info=Provides flight in an area around the ritual.
-
-ritual.bloodmagic.eternalSoulRitual.info=Capable of transferring Life Essence from a Network back into an Altar at a cost.
 
 # Chat
 chat.bloodmagic.altarMaker.setTier=Set Tier to: %d


### PR DESCRIPTION
[x] <- x are new potion effects
 - (NoMod) moves entities towards the ground, prevents jumping [Grounded]
 - (Raw) affects players
 - (Corrosive) disables gravity [Suspension]
 - (Destructive) increases fall damage [Heavy Heart]
 - (Steadfast) affects bosses
 - (Vengeful) stronger effects, (+Corrosive) applies levitation (+Destructive) stronger effect

 [Grounded] prevents jumping and moves entities towards the ground, higher amplifiers cause a faster descend, interesting interaction with Sigil of Air

 [Suspension] disables gravity (keeps movement)

 [Heavy Heart] increases fall height and fall damage multiplier by 1 per level.

 Fixed a possible division by 0 in RitualConder.
 Saved event entity variable in PotionEventHandlers.
 Made rune configuration more readable in RitualHarvest.

Signed-off-by: tobias <angryaeon@icloud.com>