### PR TITLE
Hymn of Syphoning (pump) tank render fix

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/ritual/types/RitualPump.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/types/RitualPump.java
@@ -80,7 +80,7 @@ public class RitualPump extends Ritual {
                 masterRitualStone.getOwnerNetwork().syphon(masterRitualStone.ticket(getRefreshCost()));
                 fluidHandler.fill(posInfo.getRight(), true);
                 world.setBlockState(posInfo.getLeft(), Blocks.STONE.getDefaultState());
-                world.notifyBlockUpdate(posInfo.getLeft(), tankState, tankState, 3);
+                world.notifyBlockUpdate(posInfo.getLeft(), Blocks.STONE.getDefaultState(), Blocks.STONE.getDefaultState(), 3);
                 world.notifyBlockUpdate(tileEntity.getPos(), tankState, tankState, 3);
                 blockPosIterator.remove();
             }

--- a/src/main/java/WayofTime/bloodmagic/ritual/types/RitualPump.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/types/RitualPump.java
@@ -81,6 +81,7 @@ public class RitualPump extends Ritual {
                 fluidHandler.fill(posInfo.getRight(), true);
                 world.setBlockState(posInfo.getLeft(), Blocks.STONE.getDefaultState());
                 world.notifyBlockUpdate(posInfo.getLeft(), tankState, tankState, 3);
+                world.notifyBlockUpdate(tileEntity.getPos(), tankState, tankState, 3);
                 blockPosIterator.remove();
             }
         }


### PR DESCRIPTION
Every Hymn of Syphoning (RitualPump) filling of the IFluidHandler now also triggers a block update for the block above the MRS, rerendering the tank contents to be up to date with the new fill status immediatly.