### PR TITLE
Seer Sigil can now be used in place of divination sigil in additon to its own functions for HUD elements

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/client/hud/element/ElementDivinedInformation.java
+++ b/src/main/java/WayofTime/bloodmagic/client/hud/element/ElementDivinedInformation.java
@@ -25,13 +25,13 @@ public abstract class ElementDivinedInformation<T extends TileEntity> extends El
         ItemStack sigilStack = player.getHeldItem(EnumHand.MAIN_HAND);
         boolean flag = false;
         if (simple) {
-            if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_DIVINATION)
+            if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_DIVINATION || sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_SEER)
                 flag = true;
             else flag = isFlagSigilHolding(sigilStack, true);
 
             if (!flag) {
                 sigilStack = player.getHeldItem(EnumHand.OFF_HAND);
-                if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_DIVINATION)
+                if (sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_DIVINATION || sigilStack.getItem() == RegistrarBloodMagicItems.SIGIL_SEER)
                     flag = true;
                 else flag = isFlagSigilHolding(sigilStack, true);
             }


### PR DESCRIPTION
(not sure if there might be edge cases that it tries to display both the divination sigil and seer sigil information at the same time (as could be possible for the blood altar), however it doesn't seem to be the case as removing elements from blood_altar_adv removes them from the seer sigil view)

#1526