### PR TITLE
Trickshot Arrows to reset hurtresistancetime. (#1487)

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/util/handler/event/LivingArmourHandler.java
+++ b/src/main/java/WayofTime/bloodmagic/util/handler/event/LivingArmourHandler.java
@@ -344,7 +344,7 @@ public class LivingArmourHandler
                         ItemArrow itemarrow = (ItemArrow) ((stack.getItem() instanceof ItemArrow ? arrowStack.getItem() : Items.ARROW));
                         EntityArrow entityarrow = itemarrow.createArrow(world, arrowStack, player);
                         entityarrow.shoot(player, player.rotationPitch, player.rotationYaw, 0.0F, velocity * 3.0F, 1.0F);
-                        entityarrow.addTag("Arrow Shot");
+                        entityarrow.addTag("arrow_shot");
                         float velocityModifier = 0.6f * velocity;
 
                         entityarrow.motionX += (event.getWorld().rand.nextDouble() - 0.5) * velocityModifier;
@@ -380,7 +380,7 @@ public class LivingArmourHandler
     @SubscribeEvent
     public static void onProjectileImpact(ProjectileImpactEvent.Arrow event)
     {
-        if (event.getArrow().removeTag("Arrow Shot"))
+        if (event.getArrow().removeTag("arrow_shot"))
         {
             Entity entity = event.getRayTraceResult().entityHit;
 

--- a/src/main/java/WayofTime/bloodmagic/util/handler/event/LivingArmourHandler.java
+++ b/src/main/java/WayofTime/bloodmagic/util/handler/event/LivingArmourHandler.java
@@ -29,6 +29,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumHand;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.event.entity.ProjectileImpactEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.living.LivingHealEvent;
@@ -161,10 +162,12 @@ public class LivingArmourHandler
                     if (event.getItemStack().getItemUseAction() == EnumAction.DRINK)
                     {
                         ItemStack drinkStack = event.getItemStack();
-                        if(!(drinkStack.getItem() instanceof ItemSplashPotion)) {
+                        if (!(drinkStack.getItem() instanceof ItemSplashPotion))
+                        {
                             LivingArmourUpgrade upgrade = ItemLivingArmour.getUpgrade(BloodMagic.MODID + ".upgrade.quenched", chestStack);
 
-                            if (upgrade instanceof LivingArmourUpgradeQuenched) {
+                            if (upgrade instanceof LivingArmourUpgradeQuenched)
+                            {
                                 event.setCanceled(true);
                             }
                         }
@@ -341,7 +344,7 @@ public class LivingArmourHandler
                         ItemArrow itemarrow = (ItemArrow) ((stack.getItem() instanceof ItemArrow ? arrowStack.getItem() : Items.ARROW));
                         EntityArrow entityarrow = itemarrow.createArrow(world, arrowStack, player);
                         entityarrow.shoot(player, player.rotationPitch, player.rotationYaw, 0.0F, velocity * 3.0F, 1.0F);
-
+                        entityarrow.addTag("Arrow Shot");
                         float velocityModifier = 0.6f * velocity;
 
                         entityarrow.motionX += (event.getWorld().rand.nextDouble() - 0.5) * velocityModifier;
@@ -369,6 +372,21 @@ public class LivingArmourHandler
                         world.spawnEntity(entityarrow);
                     }
                 }
+            }
+        }
+    }
+
+    // Applies: Arrow Shot
+    @SubscribeEvent
+    public static void onProjectileImpact(ProjectileImpactEvent.Arrow event)
+    {
+        if (event.getArrow().removeTag("Arrow Shot"))
+        {
+            Entity entity = event.getRayTraceResult().entityHit;
+
+            if (entity != null)
+            {
+                entity.hurtResistantTime = 0;
             }
         }
     }


### PR DESCRIPTION
(#1487)
Added a subscribeevent method for the onProjectileImpact event that
removes the tag and sets the hurtresistanttime to zero.

Allows all trickshot arrows to hit the target, rather than all but the 1st bouncing off.

[lines 164 and 167 were changed so that their formatting would align with how the rest of the file was already formatted]