### PR TITLE
(#1415) Soft Fall / fallProtect Implementation

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/livingArmour/upgrade/LivingArmourUpgradeFallProtect.java
+++ b/src/main/java/WayofTime/bloodmagic/livingArmour/upgrade/LivingArmourUpgradeFallProtect.java
@@ -8,7 +8,7 @@ import net.minecraft.util.DamageSource;
 
 public class LivingArmourUpgradeFallProtect extends LivingArmourUpgrade {
     public static final int[] costs = new int[]{2, 5, 9, 15, 25};
-    public static final float[] protectionLevel = new float[]{0.2f, 0.4f, 0.6f, 0.8f, 1f};
+    public static final float[] protectionLevel = new float[]{0.2F, 0.4F, 0.6F, 0.8F, 1F};
 
     public LivingArmourUpgradeFallProtect(int level) {
         super(level);
@@ -16,7 +16,7 @@ public class LivingArmourUpgradeFallProtect extends LivingArmourUpgrade {
 
     
     public float getDamageMultiplier() {
-        return 1-protectionLevel[this.level];
+        return 1 - protectionLevel[this.level];
     }
 
     @Override

--- a/src/main/java/WayofTime/bloodmagic/livingArmour/upgrade/LivingArmourUpgradeFallProtect.java
+++ b/src/main/java/WayofTime/bloodmagic/livingArmour/upgrade/LivingArmourUpgradeFallProtect.java
@@ -8,19 +8,15 @@ import net.minecraft.util.DamageSource;
 
 public class LivingArmourUpgradeFallProtect extends LivingArmourUpgrade {
     public static final int[] costs = new int[]{2, 5, 9, 15, 25};
-    public static final double[] protectionLevel = new double[]{0.2, 0.4, 0.6, 0.8, 1};
+    public static final float[] protectionLevel = new float[]{0.2f, 0.4f, 0.6f, 0.8f, 1f};
 
     public LivingArmourUpgradeFallProtect(int level) {
         super(level);
     }
 
-    @Override
-    public double getArmourProtection(EntityLivingBase wearer, DamageSource source) {
-        if (source.equals(DamageSource.FALL)) {
-            return protectionLevel[this.level];
-        }
-
-        return 0;
+    
+    public float getDamageMultiplier() {
+        return 1-protectionLevel[this.level];
     }
 
     @Override

--- a/src/main/java/WayofTime/bloodmagic/util/handler/event/LivingArmourHandler.java
+++ b/src/main/java/WayofTime/bloodmagic/util/handler/event/LivingArmourHandler.java
@@ -389,11 +389,11 @@ public class LivingArmourHandler
                 LivingArmour armour = ItemLivingArmour.getLivingArmour(chestStack);
                 if (armour != null)
                 {
-                    StatTrackerFallProtect.incrementCounter(armour, event.getDamageMultiplier()*(event.getDistance()-3));
+                    StatTrackerFallProtect.incrementCounter(armour, event.getDamageMultiplier() * (event.getDistance() - 3));
                     LivingArmourUpgrade upgrade = ItemLivingArmour.getUpgrade(BloodMagic.MODID + ".upgrade.fallProtect", chestStack);
                     if (upgrade instanceof LivingArmourUpgradeFallProtect) {
                         LivingArmourUpgradeFallProtect fallUpgrade = (LivingArmourUpgradeFallProtect) upgrade;
-                        event.setDamageMultiplier(event.getDamageMultiplier()*fallUpgrade.getDamageMultiplier());
+                        event.setDamageMultiplier(event.getDamageMultiplier() * fallUpgrade.getDamageMultiplier());
                     }
                 }
             }

--- a/src/main/java/WayofTime/bloodmagic/util/handler/event/LivingArmourHandler.java
+++ b/src/main/java/WayofTime/bloodmagic/util/handler/event/LivingArmourHandler.java
@@ -11,6 +11,7 @@ import WayofTime.bloodmagic.livingArmour.downgrade.LivingArmourUpgradeQuenched;
 import WayofTime.bloodmagic.livingArmour.downgrade.LivingArmourUpgradeSlowHeal;
 import WayofTime.bloodmagic.livingArmour.downgrade.LivingArmourUpgradeStormTrooper;
 import WayofTime.bloodmagic.livingArmour.tracker.StatTrackerArrowShot;
+import WayofTime.bloodmagic.livingArmour.tracker.StatTrackerFallProtect;
 import WayofTime.bloodmagic.livingArmour.tracker.StatTrackerGrimReaperSprint;
 import WayofTime.bloodmagic.livingArmour.tracker.StatTrackerJump;
 import WayofTime.bloodmagic.livingArmour.upgrade.*;
@@ -31,6 +32,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHealEvent;
 import net.minecraftforge.event.entity.player.ArrowLooseEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -367,6 +369,31 @@ public class LivingArmourHandler
                         entityarrow.pickupStatus = EntityArrow.PickupStatus.CREATIVE_ONLY;
 
                         world.spawnEntity(entityarrow);
+                    }
+                }
+            }
+        }
+    }
+    
+    // Applies: Softfall
+    @SubscribeEvent
+    public static void onPlayerFall(LivingFallEvent event) {
+        if (event.getEntityLiving() instanceof EntityPlayer)
+        {
+            EntityPlayer player = (EntityPlayer) event.getEntityLiving();
+
+            if (LivingArmour.hasFullSet(player))
+            {
+
+                ItemStack chestStack = player.getItemStackFromSlot(EntityEquipmentSlot.CHEST);
+                LivingArmour armour = ItemLivingArmour.getLivingArmour(chestStack);
+                if (armour != null)
+                {
+                    StatTrackerFallProtect.incrementCounter(armour, event.getDamageMultiplier()*(event.getDistance()-3));
+                    LivingArmourUpgrade upgrade = ItemLivingArmour.getUpgrade(BloodMagic.MODID + ".upgrade.fallProtect", chestStack);
+                    if (upgrade instanceof LivingArmourUpgradeFallProtect) {
+                        LivingArmourUpgradeFallProtect fallUpgrade = (LivingArmourUpgradeFallProtect) upgrade;
+                        event.setDamageMultiplier(event.getDamageMultiplier()*fallUpgrade.getDamageMultiplier());
                     }
                 }
             }


### PR DESCRIPTION
(#1415)
Fixed softFall / fallProtect upgrade for living armour. Previously it relied on regular armor properties, which fall damage bypasses by being marked is unblockable. 

Created a method subscribed to onPlayerFall which
applies the damage multiplier and the fallProtect stat-tracker. Removed
the armorProperties method of LivingAmourUpgradeFallProtect.java and
replaced it with getDamageMultiplier.