### PR TITLE
Trickshot - Sentient Arrows Implementation

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientBow.java
+++ b/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientBow.java
@@ -305,6 +305,40 @@ public class ItemSentientBow extends ItemBow implements IMultiWillTool, ISentien
         return entityArrow;
     }
 
+    public EntitySentientArrow getDuplicateArrow(ItemStack bowStack, World world, EntityPlayer player,
+            double reimburseMultiplier) {
+
+        EnumDemonWillType willType = this.getCurrentType(bowStack);
+        ItemStack arrow = this.getFiredArrow(player);
+
+        ItemArrow itemarrow = ((ItemArrow) (arrow.getItem() instanceof ItemArrow ? arrow.getItem() : Items.ARROW));
+        EntitySentientArrow entityArrow;
+        double reimburseAmount = (this.getDropOfActivatedBow(bowStack) * world.rand.nextDouble()
+            + this.getStaticDropOfActivatedBow(bowStack)) * reimburseMultiplier;
+
+        if (itemarrow == Items.ARROW) {
+            double soulsRemaining = PlayerDemonWillHandler.getTotalDemonWill(willType, player);
+            entityArrow = new EntitySentientArrow(world, player, willType, reimburseAmount, getLevel(soulsRemaining),
+                (PotionType) null);
+        } else if (itemarrow == Items.TIPPED_ARROW) {
+            double soulsRemaining = PlayerDemonWillHandler.getTotalDemonWill(willType, player);
+            entityArrow = new EntitySentientArrow(world, player, willType, reimburseAmount, getLevel(soulsRemaining),
+                arrow);
+        } else if (itemarrow == Items.SPECTRAL_ARROW) {
+            double soulsRemaining = PlayerDemonWillHandler.getTotalDemonWill(willType, player);
+            entityArrow = new EntitySentientArrow(world, player, willType, reimburseAmount, getLevel(soulsRemaining),
+                new PotionType(new PotionEffect(MobEffects.GLOWING, 200, 0)));
+        } else {
+            double soulsRemaining = PlayerDemonWillHandler.getTotalDemonWill(willType, player);
+            entityArrow = new EntitySentientArrow(world, player, willType, reimburseAmount, getLevel(soulsRemaining),
+                itemarrow.createArrow(world, bowStack, player));
+        }
+
+        player.addStat(StatList.getObjectUseStats(this));
+
+        return entityArrow;
+    }
+    
     @Override
     public void onPlayerStoppedUsing(ItemStack stack, World world, EntityLivingBase entityLiving, int timeLeft) {
         if (entityLiving instanceof EntityPlayer) {

--- a/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientBow.java
+++ b/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientBow.java
@@ -305,37 +305,30 @@ public class ItemSentientBow extends ItemBow implements IMultiWillTool, ISentien
         return entityArrow;
     }
 
-    public EntitySentientArrow getDuplicateArrow(ItemStack bowStack, World world, EntityPlayer player,
-            double reimburseMultiplier) {
+    public EntitySentientArrow getDuplicateArrow(ItemStack bowStack, World world, EntityPlayer player, double reimburseMultiplier) {
 
         EnumDemonWillType willType = this.getCurrentType(bowStack);
         ItemStack arrow = this.getFiredArrow(player);
 
         ItemArrow itemarrow = ((ItemArrow) (arrow.getItem() instanceof ItemArrow ? arrow.getItem() : Items.ARROW));
         EntitySentientArrow entityArrow;
-        double reimburseAmount = (this.getDropOfActivatedBow(bowStack) * world.rand.nextDouble()
-            + this.getStaticDropOfActivatedBow(bowStack)) * reimburseMultiplier;
+        double reimburseAmount = (this.getDropOfActivatedBow(bowStack) * world.rand.nextDouble() + this.getStaticDropOfActivatedBow(bowStack)) * reimburseMultiplier;
 
         if (itemarrow == Items.ARROW) {
             double soulsRemaining = PlayerDemonWillHandler.getTotalDemonWill(willType, player);
-            entityArrow = new EntitySentientArrow(world, player, willType, reimburseAmount, getLevel(soulsRemaining),
-                (PotionType) null);
+            entityArrow = new EntitySentientArrow(world, player, willType, reimburseAmount, getLevel(soulsRemaining), (PotionType) null);
         } else if (itemarrow == Items.TIPPED_ARROW) {
             double soulsRemaining = PlayerDemonWillHandler.getTotalDemonWill(willType, player);
-            entityArrow = new EntitySentientArrow(world, player, willType, reimburseAmount, getLevel(soulsRemaining),
-                arrow);
+            entityArrow = new EntitySentientArrow(world, player, willType, reimburseAmount, getLevel(soulsRemaining), arrow);
         } else if (itemarrow == Items.SPECTRAL_ARROW) {
             double soulsRemaining = PlayerDemonWillHandler.getTotalDemonWill(willType, player);
-            entityArrow = new EntitySentientArrow(world, player, willType, reimburseAmount, getLevel(soulsRemaining),
-                new PotionType(new PotionEffect(MobEffects.GLOWING, 200, 0)));
+            entityArrow = new EntitySentientArrow(world, player, willType, reimburseAmount, getLevel(soulsRemaining), new PotionType(new PotionEffect(MobEffects.GLOWING, 200, 0)));
         } else {
             double soulsRemaining = PlayerDemonWillHandler.getTotalDemonWill(willType, player);
-            entityArrow = new EntitySentientArrow(world, player, willType, reimburseAmount, getLevel(soulsRemaining),
-                itemarrow.createArrow(world, bowStack, player));
+            entityArrow = new EntitySentientArrow(world, player, willType, reimburseAmount, getLevel(soulsRemaining), itemarrow.createArrow(world, bowStack, player));
         }
 
         player.addStat(StatList.getObjectUseStats(this));
-
         return entityArrow;
     }
     

--- a/src/main/java/WayofTime/bloodmagic/util/handler/event/LivingArmourHandler.java
+++ b/src/main/java/WayofTime/bloodmagic/util/handler/event/LivingArmourHandler.java
@@ -5,6 +5,7 @@ import WayofTime.bloodmagic.util.Constants;
 import WayofTime.bloodmagic.livingArmour.LivingArmourUpgrade;
 import WayofTime.bloodmagic.core.RegistrarBloodMagic;
 import WayofTime.bloodmagic.item.armour.ItemLivingArmour;
+import WayofTime.bloodmagic.item.soul.ItemSentientBow;
 import WayofTime.bloodmagic.livingArmour.LivingArmour;
 import WayofTime.bloodmagic.livingArmour.downgrade.LivingArmourUpgradeCrippledArm;
 import WayofTime.bloodmagic.livingArmour.downgrade.LivingArmourUpgradeQuenched;
@@ -314,6 +315,7 @@ public class LivingArmourHandler
         World world = event.getEntityPlayer().getEntityWorld();
         ItemStack stack = event.getBow();
         EntityPlayer player = event.getEntityPlayer();
+        boolean sentientShot = false;
 
         if (world.isRemote)
             return;
@@ -338,13 +340,21 @@ public class LivingArmourHandler
 
                     if (velocity > 1.0F)
                         velocity = 1.0F;
-
+                    if (event.getBow().getItem() instanceof ItemSentientBow) {
+                        sentientShot = true;
+                    }
                     int extraArrows = ((LivingArmourUpgradeArrowShot) upgrade).getExtraArrows();
                     for (int n = 0; n < extraArrows; n++)
                     {
                         ItemStack arrowStack = new ItemStack(Items.ARROW);
                         ItemArrow itemarrow = (ItemArrow) ((stack.getItem() instanceof ItemArrow ? arrowStack.getItem() : Items.ARROW));
-                        EntityArrow entityarrow = itemarrow.createArrow(world, arrowStack, player);
+                        EntityArrow entityarrow;
+                        if (sentientShot) { // if the arrow was fired from a sentient bow
+                            ItemSentientBow sentientBow = (ItemSentientBow) stack.getItem();
+                            entityarrow = sentientBow.getDuplicateArrow(stack, world, player, 1 / extraArrows);
+                        } else {
+                            entityarrow = itemarrow.createArrow(world, arrowStack, player);
+                        }
                         entityarrow.shoot(player, player.rotationPitch, player.rotationYaw, 0.0F, velocity * 3.0F, 1.0F);
                         entityarrow.addTag("arrow_shot");
                         float velocityModifier = 0.6f * velocity;


### PR DESCRIPTION
Before creating additional arrows, trickshot now checks whether the arrows were shot from a sentient bow. If they were, instead of creating them the typical way it will call a new method, getDuplicateArrow in ItemSentientBow.

getDuplicateArrow is a copy of the method getEntitySentientArrow, without the side effects such as burning up will and arrows. In addition, some of the if statements were removed as their conditions were already checked in LivingArmourHandler before this method would be called.

Total Effect: Trickshot arrows now apply will effects and potion effects. The total will-reimbursement amount is double [If they would get X will, then with any level of trickshot they get 2X will, if every arrow hits]