### PR TITLE
Step Assist while Sneaking

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/util/handler/event/LivingArmourHandler.java
+++ b/src/main/java/WayofTime/bloodmagic/util/handler/event/LivingArmourHandler.java
@@ -265,8 +265,14 @@ public class LivingArmourHandler
 
                         if (upgrade instanceof LivingArmourUpgradeStepAssist)
                         {
-                            player.stepHeight = ((LivingArmourUpgradeStepAssist) upgrade).getStepAssist();
-                            hasAssist = true;
+                            if (!player.isSneaking()) 
+                            {
+                                player.stepHeight = ((LivingArmourUpgradeStepAssist) upgrade).getStepAssist();
+                                hasAssist = true;
+                            } else
+                            {
+                                player.stepHeight = 0.6F;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
[Issue 1430](https://github.com/WayofTime/BloodMagic/issues/1430)
Modified Living Armour's Step Assist to check whether the player is sneaking before applying effects.

Outcome:
While sneaking, the player will be able to climb slabs like regular, but will not be able to step up blocks. Also stops the player from sneaking down 1 block heights.