### PR TITLE
Cleanup Alchemy Array's lang file entry

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/compat/waila/provider/DataProviderAlchemyArray.java
+++ b/src/main/java/WayofTime/bloodmagic/compat/waila/provider/DataProviderAlchemyArray.java
@@ -13,6 +13,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
@@ -25,7 +26,7 @@ public class DataProviderAlchemyArray implements IWailaDataProvider {
     @Nonnull
     @Override
     public ItemStack getWailaStack(IWailaDataAccessor accessor, IWailaConfigHandler config) {
-        return new ItemStack(RegistrarBloodMagicItems.ARCANE_ASHES).setStackDisplayName(TextHelper.getFormattedText(RegistrarBloodMagicBlocks.ALCHEMY_ARRAY.getLocalizedName()));
+        return new ItemStack(RegistrarBloodMagicItems.ARCANE_ASHES).setStackDisplayName(TextFormatting.WHITE + RegistrarBloodMagicBlocks.ALCHEMY_ARRAY.getLocalizedName());
     }
 
     @Nonnull

--- a/src/main/resources/assets/bloodmagic/lang/de_DE.lang
+++ b/src/main/resources/assets/bloodmagic/lang/de_DE.lang
@@ -201,7 +201,7 @@ tile.bloodmagic.stone.ritual.imperfect.name=Imperfekter Ritualstein
 tile.bloodmagic.stone.ritual.inverted.name=Umgekehrter Meisterritualstein
 
 tile.bloodmagic.altar.name=Blutaltar
-tile.bloodmagic.alchemyArray.name=&r&fAlchemische Anordnung
+tile.bloodmagic.alchemyArray.name=Alchemische Anordnung
 
 tile.bloodmagic.rune.blank.name=Leere Rune
 tile.bloodmagic.rune.speed.name=Geschwindigkeitsrune

--- a/src/main/resources/assets/bloodmagic/lang/en_US.lang
+++ b/src/main/resources/assets/bloodmagic/lang/en_US.lang
@@ -201,7 +201,7 @@ tile.bloodmagic.stone.ritual.imperfect.name=Imperfect Ritual Stone
 tile.bloodmagic.stone.ritual.inverted.name=Inverted Master Ritual Stone
 
 tile.bloodmagic.altar.name=Blood Altar
-tile.bloodmagic.alchemyArray.name=&r&fAlchemy Array
+tile.bloodmagic.alchemyArray.name=Alchemy Array
 
 tile.bloodmagic.rune.blank.name=Blank Rune
 tile.bloodmagic.rune.speed.name=Speed Rune

--- a/src/main/resources/assets/bloodmagic/lang/fr_FR.lang
+++ b/src/main/resources/assets/bloodmagic/lang/fr_FR.lang
@@ -181,7 +181,7 @@ tile.bloodmagic.stone.ritual.master.name=Pierre Rituelle Maîtresse
 tile.bloodmagic.stone.ritual.imperfect.name=Pierre Rituelle Imparfaite
 
 tile.bloodmagic.altar.name=Autel de Sang
-tile.bloodmagic.alchemyArray.name=&r&fÉtalage d'Alchimie
+tile.bloodmagic.alchemyArray.name=Étalage d'Alchimie
 
 tile.bloodmagic.rune.blank.name=Rune de Sang
 tile.bloodmagic.rune.speed.name=Rune de Vitesse

--- a/src/main/resources/assets/bloodmagic/lang/ja_JP.lang
+++ b/src/main/resources/assets/bloodmagic/lang/ja_JP.lang
@@ -201,7 +201,7 @@ tile.bloodmagic.stone.ritual.imperfect.name=簡易儀式石
 tile.bloodmagic.stone.ritual.inverted.name=反転マスター儀式石
 
 tile.bloodmagic.altar.name=血の祭壇
-tile.bloodmagic.alchemyArray.name=&r&f錬金術魔法陣
+tile.bloodmagic.alchemyArray.name=錬金術魔法陣
 
 tile.bloodmagic.rune.blank.name=空のルーン
 tile.bloodmagic.rune.speed.name=速度のルーン

--- a/src/main/resources/assets/bloodmagic/lang/ru_RU.lang
+++ b/src/main/resources/assets/bloodmagic/lang/ru_RU.lang
@@ -200,7 +200,7 @@ tile.bloodmagic.stone.ritual.imperfect.name=Неполноценный риту�
 tile.bloodmagic.stone.ritual.inverted.name=Инвертированный ритуальный камень
 
 tile.bloodmagic.altar.name=Кровавый алтарь
-tile.bloodmagic.alchemyArray.name=&r&fАлхимическая матрица
+tile.bloodmagic.alchemyArray.name=Алхимическая матрица
 
 tile.bloodmagic.rune.blank.name=Чистая руна
 tile.bloodmagic.rune.speed.name=Руна скорости

--- a/src/main/resources/assets/bloodmagic/lang/zh_CN.lang
+++ b/src/main/resources/assets/bloodmagic/lang/zh_CN.lang
@@ -198,7 +198,7 @@ tile.bloodmagic.stone.ritual.imperfect.name=不完善的仪式石
 tile.bloodmagic.stone.ritual.inverted.name=反转的主仪式石
 
 tile.bloodmagic.altar.name=血之祭坛
-tile.bloodmagic.alchemyArray.name=&r&f炼金矩阵
+tile.bloodmagic.alchemyArray.name=炼金矩阵
 
 tile.bloodmagic.rune.blank.name=空白符文
 tile.bloodmagic.rune.speed.name=速度符文

--- a/src/main/resources/assets/bloodmagic/lang/zh_TW.lang
+++ b/src/main/resources/assets/bloodmagic/lang/zh_TW.lang
@@ -152,7 +152,7 @@ tile.bloodmagic.stone.ritual.master.name=魔導師儀式石
 tile.bloodmagic.stone.ritual.imperfect.name=次級儀式石
 
 tile.bloodmagic.altar.name=血祭壇
-tile.bloodmagic.alchemyArray.name=&r&f煉金矩陣
+tile.bloodmagic.alchemyArray.name=煉金矩陣
 
 tile.bloodmagic.rune.blank.name=空白符文石
 tile.bloodmagic.rune.speed.name=速度符文石


### PR DESCRIPTION
Use TextFormatting in code to remove the italics from alchemy array waila handler, rather than including it as part of the block's name.

This way if something else is requesting the names of block's they don't get the color formatting codes that are just there to get rid of the italics in Waila