### PR TITLE
Tested everything again, noticed 2 oversights that didn't have any impact.

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/command/sub/SubCommandNetwork.java
+++ b/src/main/java/WayofTime/bloodmagic/command/sub/SubCommandNetwork.java
@@ -41,7 +41,7 @@ public class SubCommandNetwork extends CommandTreeBase {
 
     @Override
     public int getRequiredPermissionLevel() {
-        return 0;
+        return 2;
     }
 
     abstract class NetworkCommand extends CommandTreeBase {

--- a/src/main/java/WayofTime/bloodmagic/command/sub/SubCommandRitual.java
+++ b/src/main/java/WayofTime/bloodmagic/command/sub/SubCommandRitual.java
@@ -141,4 +141,9 @@ public class SubCommandRitual extends CommandTreeBase {
         }
 
     }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 2;
+    }
 }


### PR DESCRIPTION
Usable in both SSP (creative mode) and SMP (op).

Required permission level for commands is 2 (server's "op" permission level can be seen and changed in the server.properties).