### PR TITLE
Fast Miner / Whirlwind

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/core/RegistrarBloodMagic.java
+++ b/src/main/java/WayofTime/bloodmagic/core/RegistrarBloodMagic.java
@@ -89,6 +89,7 @@ public class RegistrarBloodMagic
     {
         event.getRegistry().registerAll(
                 new PotionBloodMagic("Boost", false, 0xFFFFFF, 0, 0).setRegistryName("boost"),
+                new PotionBloodMagic("Whirlwind", false, 0xFFFFFF, 0, 0).setRegistryName("whirlwind"),
                 new PotionBloodMagic("Planar Binding", false, 0, 2, 0).setRegistryName("planar_binding"),
                 new PotionBloodMagic("Soul Snare", false, 0xFFFFFF, 3, 0).setRegistryName("soul_snare"),
                 new PotionBloodMagic("Soul Fray", true, 0xFFFFFF, 4, 0).setRegistryName("soul_fray"),

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilFastMiner.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilFastMiner.java
@@ -21,7 +21,7 @@ public class ItemSigilFastMiner extends ItemSigilToggleableBase {
     public void onSigilUpdate(ItemStack stack, World world, EntityPlayer player, int itemSlot, boolean isSelected) {
         if (PlayerHelper.isFakePlayer(player))
             return;
-        player.addPotionEffect(new PotionEffect(MobEffects.HASTE, 2, 0, true, false));
+        player.addPotionEffect(new PotionEffect(MobEffects.HASTE, 2, 1, true, false));
     }
 
     @Override


### PR DESCRIPTION
Added Whirlwind to the potion registry - fixing a bug where the fast miner sigil would also cause the whirlwind effect.

Increased the effect of the fast miner sigil to haste 2, to correspond with what the Sanguine Scientium states.