### PR TITLE
Prevents insertions if there are any items in the Demon Crucible

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/tile/TileDemonCrucible.java
+++ b/src/main/java/WayofTime/bloodmagic/tile/TileDemonCrucible.java
@@ -204,7 +204,7 @@ public class TileDemonCrucible extends TileInventory implements ITickable, IDemo
 
     @Override
     public boolean canInsertItem(int index, ItemStack stack, EnumFacing direction) {
-        return !stack.isEmpty() && (stack.getItem() instanceof IDemonWillGem || stack.getItem() instanceof IDiscreteDemonWill);
+        return !stack.isEmpty() && inventory.get(0).isEmpty() && (stack.getItem() instanceof IDemonWillGem || stack.getItem() instanceof IDiscreteDemonWill);
     }
 
     @Override


### PR DESCRIPTION
Fixes issue #1418 

Specifically, when it would burn whatever is currently in the crucible, it would [set the stack count to 0](https://github.com/WayofTime/BloodMagic/blob/dea733a76eb3a91b27ed4ecf9722643400902a5a/src/main/java/WayofTime/bloodmagic/tile/TileDemonCrucible.java#L82). While it could have been fixed by changing that, there was the inconsistency between how many items could be inserted automatically - like through a hopper, and how many could be inserted by right clicking. 