### PR TITLE
ISentientSwordEffectProvider Implementation

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/iface/ISentientSwordEffectProvider.java
+++ b/src/main/java/WayofTime/bloodmagic/iface/ISentientSwordEffectProvider.java
@@ -5,7 +5,17 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public interface ISentientSwordEffectProvider {
-    boolean applyOnHitEffect(EnumDemonWillType type, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target);
-
-    boolean providesEffectForWill(EnumDemonWillType type);
+    /**
+     * Attempts to apply the effect of off-handing sigils
+     * have fire breathing.
+     * @param type
+     * @param swordStack the sword swung
+     * @param providerStack the stack providing the effect
+     * @param attacker
+     * @param target
+     * @return true if the effect was successful; false otherwise. Failures include events 
+     * such as attempting to drown a player, but they have water breathing, or burn when they
+     * have fire protection
+     */
+    boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target);
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigil.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigil.java
@@ -10,7 +10,7 @@ import net.minecraft.item.ItemStack;
  * Base class for all (static) sigils.
  */
 public class ItemSigil extends ItemBindableBase implements ISigil {
-    private int lpUsed;
+    protected int lpUsed;
 
     public ItemSigil(int lpUsed) {
         super();

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilAir.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilAir.java
@@ -59,13 +59,8 @@ public class ItemSigilAir extends ItemSigilBase implements ISentientSwordEffectP
     }
 
     @Override
-    public boolean applyOnHitEffect(EnumDemonWillType type, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target) {
+    public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target) {
         target.addPotionEffect(new PotionEffect(MobEffects.LEVITATION, 200, 0));
         return true;
-    }
-
-    @Override
-    public boolean providesEffectForWill(EnumDemonWillType type) {
-        return false;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilAir.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilAir.java
@@ -9,10 +9,8 @@ import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.MobEffects;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
-import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.*;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -60,7 +58,15 @@ public class ItemSigilAir extends ItemSigilBase implements ISentientSwordEffectP
 
     @Override
     public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target) {
-        target.addPotionEffect(new PotionEffect(MobEffects.LEVITATION, 200, 0));
-        return true;
+	//to ensure it will not return 0
+        willLevel += 1;
+        int LPUsage = getLpUsed() * willLevel;
+
+        if (NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
+            target.addVelocity(-.2 * attacker.motionX, 0.1, -.2 * attacker.motionZ);
+            target.fallDistance += 3 + willLevel;
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilElementalAffinity.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilElementalAffinity.java
@@ -1,13 +1,20 @@
 package WayofTime.bloodmagic.item.sigil;
 
+import WayofTime.bloodmagic.core.data.SoulTicket;
+import WayofTime.bloodmagic.iface.ISentientSwordEffectProvider;
+import WayofTime.bloodmagic.soul.EnumDemonWillType;
+import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.MobEffects;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.world.World;
 
-public class ItemSigilElementalAffinity extends ItemSigilToggleableBase {
+public class ItemSigilElementalAffinity extends ItemSigilToggleableBase implements ISentientSwordEffectProvider {
     public ItemSigilElementalAffinity() {
         super("elemental_affinity", 200);
     }
@@ -21,5 +28,54 @@ public class ItemSigilElementalAffinity extends ItemSigilToggleableBase {
         player.extinguish();
         player.addPotionEffect(new PotionEffect(MobEffects.FIRE_RESISTANCE, 2, 1, true, false));
         player.addPotionEffect(new PotionEffect(MobEffects.WATER_BREATHING, 2, 0, true, false));
+    }
+
+    @Override
+    public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target)
+    {
+        boolean highWill = willLevel >= 3;
+        int LPUsage = getLpUsed();
+        if (highWill)
+            LPUsage *= 2;
+        
+        if (!NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
+            return false;
+        }
+        
+        // Disable their elemental affinity sigil, remove any fire resistance, water breathing
+        if (target instanceof EntityPlayer) {
+            Item current;
+            
+            // If attacker has a lot of will, attempt to disable all elemental affinity sigils in target's inventory
+            // otherwise disable just 1
+            boolean found = false;
+            // disable any in their main inventory
+            for (ItemStack stack: ((EntityPlayer) target).inventory.mainInventory) {
+                current = stack.getItem();
+                if (current instanceof ItemSigilElementalAffinity) {
+                    if (((ItemSigilElementalAffinity) current).getActivated(stack)) {
+                        ((ItemSigilElementalAffinity) current).setActivatedState(stack, false);
+                        if (!highWill) {
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            
+            if (!found || highWill) {
+                // check their off hand
+                for (ItemStack stack: ((EntityPlayer) target).inventory.offHandInventory) {
+                    current = stack.getItem();
+                    if (current instanceof ItemSigilElementalAffinity) {
+                        ((ItemSigilElementalAffinity) current).setActivatedState(stack, false);
+                    }
+                }
+            }
+            
+        }
+        target.removePotionEffect(MobEffects.FIRE_RESISTANCE);
+        target.removePotionEffect(MobEffects.WATER_BREATHING);
+        return true;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
@@ -1,12 +1,16 @@
 package WayofTime.bloodmagic.item.sigil;
 
 import WayofTime.bloodmagic.core.data.SoulTicket;
+import WayofTime.bloodmagic.iface.ISentientSwordEffectProvider;
 import WayofTime.bloodmagic.iface.ISigil;
+import WayofTime.bloodmagic.soul.EnumDemonWillType;
 import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
@@ -17,7 +21,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
 
-public class ItemSigilLava extends ItemSigilFluidBase {
+public class ItemSigilLava extends ItemSigilFluidBase implements ISentientSwordEffectProvider {
 
     public ItemSigilLava() {
         super("lava", 1000, new FluidStack(FluidRegistry.LAVA, 1000));
@@ -67,5 +71,17 @@ public class ItemSigilLava extends ItemSigilFluidBase {
             }
         }
         return super.onItemRightClick(world, player, hand);
+    }
+
+    
+    @Override
+    public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target)
+    {
+        target.hurtResistantTime = 0;
+        int LPUsage = getLpUsed() * (willLevel + 1);
+        if (NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
+            return target.attackEntityFrom(DamageSource.LAVA, willLevel + 1);
+        }
+        return false;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilVoid.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilVoid.java
@@ -3,12 +3,16 @@ package WayofTime.bloodmagic.item.sigil;
 import WayofTime.bloodmagic.core.data.Binding;
 import WayofTime.bloodmagic.core.data.SoulNetwork;
 import WayofTime.bloodmagic.core.data.SoulTicket;
+import WayofTime.bloodmagic.iface.ISentientSwordEffectProvider;
 import WayofTime.bloodmagic.iface.ISigil;
+import WayofTime.bloodmagic.soul.EnumDemonWillType;
 import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
@@ -17,7 +21,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
-public class ItemSigilVoid extends ItemSigilFluidBase {
+public class ItemSigilVoid extends ItemSigilFluidBase implements ISentientSwordEffectProvider {
     public ItemSigilVoid() {
         super("void", 50, null);
     }
@@ -92,6 +96,19 @@ public class ItemSigilVoid extends ItemSigilFluidBase {
 
         network.syphon(SoulTicket.item(sigil, getLpUsed()));
         return Math.min(capacity, resource.amount);
+    }
+
+    
+    @Override
+    public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target)
+    {
+        target.hurtResistantTime = 0;
+        int LPUsage = getLpUsed() * (willLevel + 1);
+        if (NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
+            return target.attackEntityFrom(DamageSource.OUT_OF_WORLD, (willLevel + 1) / 2);
+        }
+    
+        return false;
     }
 }
 

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
@@ -81,18 +81,16 @@ public class ItemSigilWater extends ItemSigilFluidBase implements ISentientSword
         return super.onItemRightClick(world, player, hand);
     }
 
-    
-    
     @Override
     public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack,
 	    EntityLivingBase attacker, EntityLivingBase target) {
 	
-	target.hurtResistantTime = 0;
-	int LPUsage = getLpUsed() * (willLevel + 1);
-	if (NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
-	    return target.attackEntityFrom(DamageSource.DROWN, willLevel + 1);
-	}
+        target.hurtResistantTime = 0;
+        int LPUsage = getLpUsed() * (willLevel + 1);
+        if (NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
+            return target.attackEntityFrom(DamageSource.DROWN, willLevel + 1);
+        }
 	
-	return false;
+        return false;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
@@ -1,14 +1,18 @@
 package WayofTime.bloodmagic.item.sigil;
 
 import WayofTime.bloodmagic.core.data.SoulTicket;
+import WayofTime.bloodmagic.iface.ISentientSwordEffectProvider;
 import WayofTime.bloodmagic.iface.ISigil;
+import WayofTime.bloodmagic.soul.EnumDemonWillType;
 import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
 import net.minecraft.block.BlockCauldron;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
@@ -18,7 +22,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
-public class ItemSigilWater extends ItemSigilFluidBase {
+public class ItemSigilWater extends ItemSigilFluidBase implements ISentientSwordEffectProvider {
     public ItemSigilWater() {
         super("water", 100, new FluidStack(FluidRegistry.WATER, 1000));
     }
@@ -75,5 +79,20 @@ public class ItemSigilWater extends ItemSigilFluidBase {
         }
 
         return super.onItemRightClick(world, player, hand);
+    }
+
+    
+    
+    @Override
+    public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack,
+	    EntityLivingBase attacker, EntityLivingBase target) {
+	
+	target.hurtResistantTime = 0;
+	int LPUsage = getLpUsed() * (willLevel + 1);
+	if (NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
+	    return target.attackEntityFrom(DamageSource.DROWN, willLevel + 1);
+	}
+	
+	return false;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientAxe.java
+++ b/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientAxe.java
@@ -202,9 +202,7 @@ public class ItemSentientAxe extends ItemAxe implements IDemonWillWeapon, IMeshP
                 ItemStack offStack = attackerPlayer.getItemStackFromSlot(EntityEquipmentSlot.OFFHAND);
                 if (offStack.getItem() instanceof ISentientSwordEffectProvider) {
                     ISentientSwordEffectProvider provider = (ISentientSwordEffectProvider) offStack.getItem();
-                    if (provider.providesEffectForWill(type)) {
-                        provider.applyOnHitEffect(type, stack, offStack, attacker, target);
-                    }
+                    provider.applyOnHitEffect(type, willBracket, stack, offStack, attacker, target);
                 }
             }
 

--- a/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientPickaxe.java
+++ b/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientPickaxe.java
@@ -202,9 +202,7 @@ public class ItemSentientPickaxe extends ItemPickaxe implements IDemonWillWeapon
                 ItemStack offStack = attackerPlayer.getItemStackFromSlot(EntityEquipmentSlot.OFFHAND);
                 if (offStack.getItem() instanceof ISentientSwordEffectProvider) {
                     ISentientSwordEffectProvider provider = (ISentientSwordEffectProvider) offStack.getItem();
-                    if (provider.providesEffectForWill(type)) {
-                        provider.applyOnHitEffect(type, stack, offStack, attacker, target);
-                    }
+                    provider.applyOnHitEffect(type, willBracket, stack, offStack, attacker, target);
                 }
             }
 

--- a/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientShovel.java
+++ b/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientShovel.java
@@ -202,9 +202,7 @@ public class ItemSentientShovel extends ItemSpade implements IDemonWillWeapon, I
                 ItemStack offStack = attackerPlayer.getItemStackFromSlot(EntityEquipmentSlot.OFFHAND);
                 if (offStack.getItem() instanceof ISentientSwordEffectProvider) {
                     ISentientSwordEffectProvider provider = (ISentientSwordEffectProvider) offStack.getItem();
-                    if (provider.providesEffectForWill(type)) {
-                        provider.applyOnHitEffect(type, stack, offStack, attacker, target);
-                    }
+                    provider.applyOnHitEffect(type, willBracket, stack, offStack, attacker, target);
                 }
             }
 

--- a/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientSword.java
+++ b/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientSword.java
@@ -184,9 +184,7 @@ public class ItemSentientSword extends ItemSword implements IDemonWillWeapon, IM
                 ItemStack offStack = attackerPlayer.getItemStackFromSlot(EntityEquipmentSlot.OFFHAND);
                 if (offStack.getItem() instanceof ISentientSwordEffectProvider) {
                     ISentientSwordEffectProvider provider = (ISentientSwordEffectProvider) offStack.getItem();
-                    if (provider.providesEffectForWill(type)) {
-                        provider.applyOnHitEffect(type, stack, offStack, attacker, target);
-                    }
+                    provider.applyOnHitEffect(type, willBracket, stack, offStack, attacker, target);
                 }
             }
 


### PR DESCRIPTION
#1396 
Changed the interface to provide the will level too, so that the sigils could provide stronger effects depending on how much will is in the player's inventory.

Simplified the logic for weapons calling these methods. Instead of calling a separate to first check whether there was enough LP in the player's network, the applyEffectOnHit method will now return true if it applied the effect. 

Water and lava sigils provide drowning and lava damage, respectively, that increases with will level. LP drain also increases with will level.

Air sigil sends the target a few blocks up into the air, and increases the fallDistance counter relative to will level. 

Void sigil deals OUT_OF_WORLD damage to the player, but at half the amount of the water and lava sigils.

Elemental Affinity Sigil removes fire resistance and water breathing. If the target is a player, it will search their inventory and disable 1 elemental affinity sigil if the attacker has a will level < 3, or all of them if the attacker has a will level >= 3.