### PR TITLE
Inter-mod gravity issue

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/potion/PotionEventHandlers.java
+++ b/src/main/java/WayofTime/bloodmagic/potion/PotionEventHandlers.java
@@ -92,10 +92,10 @@ public class PotionEventHandlers {
 //            }
 //        }
         List<EntityLivingBase> noGravityList = noGravityListMap.get(event.getEntityLiving().getEntityWorld());
-        if ((!(eventEntityLiving instanceof EntityPlayer) || !((EntityPlayer) eventEntityLiving).isSpectator()) && eventEntityLiving.isPotionActive(RegistrarBloodMagic.SUSPENDED)) {
+        if (eventEntityLiving.isPotionActive(RegistrarBloodMagic.SUSPENDED) && !eventEntityLiving.hasNoGravity()) {
             eventEntityLiving.setNoGravity(true);
             noGravityList.add(eventEntityLiving);
-        } else {
+        } else if (noGravityList.contains(eventEntityLiving)) {
             eventEntityLiving.setNoGravity(false);
             noGravityList.remove(eventEntityLiving);
         }


### PR DESCRIPTION
#1544 
Ritual of grounding logic for corrosive demon will was applying gravity to every entity on update.

Changed the logic so it would only apply no gravity to those that already have gravity, and would add gravity to entities that were on the noGravityList but are no longer have the suspended potion effect.