### PR TITLE
Made teleposers a bit more foolproof

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/tile/TileTeleposer.java
+++ b/src/main/java/WayofTime/bloodmagic/tile/TileTeleposer.java
@@ -49,7 +49,7 @@ public class TileTeleposer extends TileInventory implements ITickable {
 
     @Override
     public void update() {
-        if (!getWorld().isRemote) {
+        if (!getWorld().isRemote && canInitiateTeleport()) {
             int currentInput = getWorld().getStrongPower(pos);
 
             if (previousInput == 0 && currentInput != 0) {


### PR DESCRIPTION
Fixed an issue where a teleposer that somehow got filled with nasty items would crash on tick because the teleposer throws a fit at that nasty item.

#1591