### PR TITLE
Added getHeight() to AreaDescriptor, Jumping power modifyable

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/ritual/AreaDescriptor.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/AreaDescriptor.java
@@ -41,6 +41,8 @@ public abstract class AreaDescriptor implements Iterator<BlockPos> {
 
     public abstract int getVolume();
 
+    public abstract int getHeight();
+
     public abstract boolean isWithinRange(int verticalLimit, int horizontalLimit);
 
     /**
@@ -113,6 +115,11 @@ public abstract class AreaDescriptor implements Iterator<BlockPos> {
         public AxisAlignedBB getAABB(BlockPos pos) {
             AxisAlignedBB tempAABB = new AxisAlignedBB(minimumOffset, maximumOffset);
             return tempAABB.offset(pos.getX(), pos.getY(), pos.getZ());
+        }
+
+        @Override
+        public int getHeight() {
+            return this.maximumOffset.getY() - this.minimumOffset.getY();
         }
 
         /**
@@ -270,6 +277,13 @@ public abstract class AreaDescriptor implements Iterator<BlockPos> {
             blockPosCache = new ArrayList<>();
         }
 
+
+        @Override
+        public int getHeight() {
+            return this.radius * 2;
+        }
+
+
         @Override
         public List<BlockPos> getContainedPositions(BlockPos pos) {
             if (!cache || !pos.equals(cachedPosition) || blockPosCache.isEmpty()) {
@@ -402,6 +416,12 @@ public abstract class AreaDescriptor implements Iterator<BlockPos> {
             this.size = size;
             this.blockPosCache = new ArrayList<>();
         }
+
+        @Override
+        public int getHeight() {
+            return this.size * 2 + 1;
+        }
+
 
         @Override
         public List<BlockPos> getContainedPositions(BlockPos pos) {

--- a/src/main/java/WayofTime/bloodmagic/ritual/types/RitualJumping.java
+++ b/src/main/java/WayofTime/bloodmagic/ritual/types/RitualJumping.java
@@ -14,11 +14,14 @@ import java.util.function.Consumer;
 @RitualRegister("jumping")
 public class RitualJumping extends Ritual {
     public static final String JUMP_RANGE = "jumpRange";
+    public static final String JUMP_POWER = "jumpPower";
 
     public RitualJumping() {
         super("ritualJump", 0, 5000, "ritual." + BloodMagic.MODID + ".jumpRitual");
         addBlockRange(JUMP_RANGE, new AreaDescriptor.Rectangle(new BlockPos(-1, 1, -1), 3, 1, 3));
         setMaximumVolumeAndDistanceOfRange(JUMP_RANGE, 0, 5, 5);
+        addBlockRange(JUMP_POWER, new AreaDescriptor.Rectangle(new BlockPos(0, 0, 0), 0, 5, 0));
+        setMaximumVolumeAndDistanceOfRange(JUMP_POWER, 0, 0, 100);
     }
 
     @Override
@@ -41,7 +44,7 @@ public class RitualJumping extends Ritual {
                 break;
             }
 
-            double motionY = 1.5;
+            double motionY = masterRitualStone.getBlockRange(JUMP_POWER).getHeight() * 0.3;
 
             entity.fallDistance = 0;
             if (entity.isSneaking()) {
@@ -66,7 +69,7 @@ public class RitualJumping extends Ritual {
 
     @Override
     public int getRefreshCost() {
-        return 5;
+        return getBlockRange(JUMP_POWER).getHeight();
     }
 
     @Override


### PR DESCRIPTION
#1476

AreaDescriptors implement getHeight() to get the total height of the area.
RitualJumping (Ritual of the High Jump) has a second AreaDescriptor, JUMP_POWER, that can be altered to increase/decrease jumping power (motionY will be modified by 0.3*getHeight())