### PR TITLE
Fixes `/bloodmagic network` command permissions required for executing the command

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/command/sub/SubCommandNetwork.java
+++ b/src/main/java/WayofTime/bloodmagic/command/sub/SubCommandNetwork.java
@@ -50,6 +50,11 @@ public class SubCommandNetwork extends CommandTreeBase {
         public SoulNetwork network;
         public String uuid;
 
+        @Override
+        public int getRequiredPermissionLevel() {
+            return 2;
+        }
+
         public Integer commandHelperAmount(MinecraftServer server, ICommandSender sender, String[] args) {
             int amount;
             if (args.length == 0)


### PR DESCRIPTION
Inheriting from CommandTreeBase, the required permission level was 4.
All other BloodMagic commands had a required permission level of 2.
This resulted in network command not able to be executed from a Command Block, which have a permission level of 2.
#1612 