### PR TITLE
Level 4 StormTrooper downgrade to correctly cost -65 upgrade points (was 65)

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/livingArmour/downgrade/LivingArmourUpgradeStormTrooper.java
+++ b/src/main/java/WayofTime/bloodmagic/livingArmour/downgrade/LivingArmourUpgradeStormTrooper.java
@@ -8,7 +8,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
 public class LivingArmourUpgradeStormTrooper extends LivingArmourUpgrade {
-    public static final int[] costs = new int[]{-10, -25, -40, 65, -90};
+    public static final int[] costs = new int[]{-10, -25, -40, -65, -90};
     public static final float[] inaccuracy = new float[]{0.04f, 0.08f, 0.12f, 0.16f, 0.2f};
 
     public LivingArmourUpgradeStormTrooper(int level) {


### PR DESCRIPTION
#1630
#1168 