### PR TITLE
Sentient Sword sigil effects

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/core/RegistrarBloodMagic.java
+++ b/src/main/java/WayofTime/bloodmagic/core/RegistrarBloodMagic.java
@@ -62,6 +62,7 @@ public class RegistrarBloodMagic {
     public static final Potion HEAVY_HEART = MobEffects.HASTE;
     public static final Potion SUSPENDED = MobEffects.HASTE;
     public static final Potion FEATHERED = MobEffects.HASTE;
+    public static final Potion FIRE_VULNERABILITY = MobEffects.FIRE_RESISTANCE;
 
     public static IForgeRegistry<BloodOrb> BLOOD_ORBS = null;
 
@@ -101,7 +102,8 @@ public class RegistrarBloodMagic {
                 new PotionBloodMagic("Grounded", true, 0x000000, 1, 0).setRegistryName("grounded"),
                 new PotionBloodMagic("Suspended", false, 0x000000, 1, 0).setRegistryName("suspended"),
                 new PotionBloodMagic("Heavy Heart", true, 0x000000, 1, 0).setRegistryName("heavy_heart"),
-                new PotionBloodMagic("Feathered", false, 0x000000, 0, 0).setRegistryName("feathered")
+                new PotionBloodMagic("Feathered", false, 0x000000, 0, 0).setRegistryName("feathered"),
+                new PotionBloodMagic("Fire Vuln.", true, 0xAA5500, 0, 0).setRegistryName("fire_vulnerability")
         );
     }
 

--- a/src/main/java/WayofTime/bloodmagic/iface/ISentientSwordEffectProvider.java
+++ b/src/main/java/WayofTime/bloodmagic/iface/ISentientSwordEffectProvider.java
@@ -5,7 +5,17 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
 public interface ISentientSwordEffectProvider {
-    boolean applyOnHitEffect(EnumDemonWillType type, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target);
-
-    boolean providesEffectForWill(EnumDemonWillType type);
+    /**
+     * Attempts to apply the effect of off-handing sigils
+     * have fire breathing.
+     * @param type
+     * @param swordStack the sword swung
+     * @param providerStack the stack providing the effect
+     * @param attacker
+     * @param target
+     * @return true if the effect was successful; false otherwise. Failures include events 
+     * such as attempting to drown a player, but they have water breathing, or burn when they
+     * have fire protection
+     */
+    boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target);
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigil.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigil.java
@@ -10,7 +10,7 @@ import net.minecraft.item.ItemStack;
  * Base class for all (static) sigils.
  */
 public class ItemSigil extends ItemBindableBase implements ISigil {
-    private int lpUsed;
+    protected int lpUsed;
 
     public ItemSigil(int lpUsed) {
         super();

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilAir.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilAir.java
@@ -59,13 +59,8 @@ public class ItemSigilAir extends ItemSigilBase implements ISentientSwordEffectP
     }
 
     @Override
-    public boolean applyOnHitEffect(EnumDemonWillType type, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target) {
+    public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target) {
         target.addPotionEffect(new PotionEffect(MobEffects.LEVITATION, 200, 0));
         return true;
-    }
-
-    @Override
-    public boolean providesEffectForWill(EnumDemonWillType type) {
-        return false;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilAir.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilAir.java
@@ -7,11 +7,16 @@ import WayofTime.bloodmagic.iface.ISigil;
 import WayofTime.bloodmagic.soul.EnumDemonWillType;
 import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.*;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
@@ -63,8 +68,9 @@ public class ItemSigilAir extends ItemSigilBase implements ISentientSwordEffectP
         int LPUsage = getLpUsed() * willLevel;
 
         if (NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
-            target.addVelocity(-.2 * attacker.motionX, 0.1, -.2 * attacker.motionZ);
-            target.fallDistance += 3 + willLevel;
+            int knockbackLevel = EnchantmentHelper.getKnockbackModifier(attacker);
+            target.addVelocity(-0.2 * attacker.motionX, 0.075 * (willLevel + knockbackLevel), -0.2 * attacker.motionZ);
+            target.addPotionEffect(new PotionEffect(RegistrarBloodMagic.HEAVY_HEART, 30 * (willLevel + knockbackLevel), 1));
             return true;
         }
         return false;

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilAir.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilAir.java
@@ -9,10 +9,8 @@ import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.MobEffects;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
-import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.*;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -60,7 +58,15 @@ public class ItemSigilAir extends ItemSigilBase implements ISentientSwordEffectP
 
     @Override
     public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target) {
-        target.addPotionEffect(new PotionEffect(MobEffects.LEVITATION, 200, 0));
-        return true;
+	//to ensure it will not return 0
+        willLevel += 1;
+        int LPUsage = getLpUsed() * willLevel;
+
+        if (NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
+            target.addVelocity(-.2 * attacker.motionX, 0.1, -.2 * attacker.motionZ);
+            target.fallDistance += 3 + willLevel;
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilElementalAffinity.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilElementalAffinity.java
@@ -1,13 +1,20 @@
 package WayofTime.bloodmagic.item.sigil;
 
+import WayofTime.bloodmagic.core.data.SoulTicket;
+import WayofTime.bloodmagic.iface.ISentientSwordEffectProvider;
+import WayofTime.bloodmagic.soul.EnumDemonWillType;
+import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.MobEffects;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.world.World;
 
-public class ItemSigilElementalAffinity extends ItemSigilToggleableBase {
+public class ItemSigilElementalAffinity extends ItemSigilToggleableBase implements ISentientSwordEffectProvider {
     public ItemSigilElementalAffinity() {
         super("elemental_affinity", 200);
     }
@@ -21,5 +28,54 @@ public class ItemSigilElementalAffinity extends ItemSigilToggleableBase {
         player.extinguish();
         player.addPotionEffect(new PotionEffect(MobEffects.FIRE_RESISTANCE, 2, 1, true, false));
         player.addPotionEffect(new PotionEffect(MobEffects.WATER_BREATHING, 2, 0, true, false));
+    }
+
+    @Override
+    public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target)
+    {
+        boolean highWill = willLevel >= 3;
+        int LPUsage = getLpUsed();
+        if (highWill)
+            LPUsage *= 2;
+        
+        if (!NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
+            return false;
+        }
+        
+        // Disable their elemental affinity sigil, remove any fire resistance, water breathing
+        if (target instanceof EntityPlayer) {
+            Item current;
+            
+            // If attacker has a lot of will, attempt to disable all elemental affinity sigils in target's inventory
+            // otherwise disable just 1
+            boolean found = false;
+            // disable any in their main inventory
+            for (ItemStack stack: ((EntityPlayer) target).inventory.mainInventory) {
+                current = stack.getItem();
+                if (current instanceof ItemSigilElementalAffinity) {
+                    if (((ItemSigilElementalAffinity) current).getActivated(stack)) {
+                        ((ItemSigilElementalAffinity) current).setActivatedState(stack, false);
+                        if (!highWill) {
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            
+            if (!found || highWill) {
+                // check their off hand
+                for (ItemStack stack: ((EntityPlayer) target).inventory.offHandInventory) {
+                    current = stack.getItem();
+                    if (current instanceof ItemSigilElementalAffinity) {
+                        ((ItemSigilElementalAffinity) current).setActivatedState(stack, false);
+                    }
+                }
+            }
+            
+        }
+        target.removePotionEffect(MobEffects.FIRE_RESISTANCE);
+        target.removePotionEffect(MobEffects.WATER_BREATHING);
+        return true;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilElementalAffinity.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilElementalAffinity.java
@@ -1,5 +1,6 @@
 package WayofTime.bloodmagic.item.sigil;
 
+import WayofTime.bloodmagic.core.RegistrarBloodMagic;
 import WayofTime.bloodmagic.core.data.SoulTicket;
 import WayofTime.bloodmagic.iface.ISentientSwordEffectProvider;
 import WayofTime.bloodmagic.soul.EnumDemonWillType;
@@ -10,9 +11,10 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.MobEffects;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.world.World;
+
+import java.util.Random;
 
 public class ItemSigilElementalAffinity extends ItemSigilToggleableBase implements ISentientSwordEffectProvider {
     public ItemSigilElementalAffinity() {
@@ -34,6 +36,7 @@ public class ItemSigilElementalAffinity extends ItemSigilToggleableBase implemen
     public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target)
     {
         boolean highWill = willLevel >= 3;
+        boolean found = false;
         int LPUsage = getLpUsed();
         if (highWill)
             LPUsage *= 2;
@@ -48,7 +51,6 @@ public class ItemSigilElementalAffinity extends ItemSigilToggleableBase implemen
             
             // If attacker has a lot of will, attempt to disable all elemental affinity sigils in target's inventory
             // otherwise disable just 1
-            boolean found = false;
             // disable any in their main inventory
             for (ItemStack stack: ((EntityPlayer) target).inventory.mainInventory) {
                 current = stack.getItem();
@@ -69,13 +71,31 @@ public class ItemSigilElementalAffinity extends ItemSigilToggleableBase implemen
                     current = stack.getItem();
                     if (current instanceof ItemSigilElementalAffinity) {
                         ((ItemSigilElementalAffinity) current).setActivatedState(stack, false);
+                        found = true;
                     }
                 }
             }
-            
         }
-        target.removePotionEffect(MobEffects.FIRE_RESISTANCE);
-        target.removePotionEffect(MobEffects.WATER_BREATHING);
+        if (found || !(target instanceof EntityPlayer)) {
+            target.removePotionEffect(MobEffects.FIRE_RESISTANCE);
+            target.removePotionEffect(MobEffects.WATER_BREATHING);
+        }
+        if (!found) {
+            World world = target.getEntityWorld();
+            Random random = new Random();
+            int number = random.nextInt(4);
+            System.out.println(number);
+            if (number == 0) {
+                target.addPotionEffect(new PotionEffect(MobEffects.LEVITATION, 20, willLevel));
+            } else if (number == 1) {
+                target.addPotionEffect(new PotionEffect(RegistrarBloodMagic.DEAFNESS, 20 * willLevel, 0));
+            } else if (number == 2) {
+                target.rotationPitch = world.rand.nextFloat() * 360;
+                target.rotationYaw = world.rand.nextFloat() * 180 - 90;
+            } else if (number == 3) {
+                target.addPotionEffect(new PotionEffect(RegistrarBloodMagic.FIRE_VULNERABILITY, 20 * willLevel, 2 * willLevel));
+            }
+        }
         return true;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilLava.java
@@ -1,12 +1,16 @@
 package WayofTime.bloodmagic.item.sigil;
 
 import WayofTime.bloodmagic.core.data.SoulTicket;
+import WayofTime.bloodmagic.iface.ISentientSwordEffectProvider;
 import WayofTime.bloodmagic.iface.ISigil;
+import WayofTime.bloodmagic.soul.EnumDemonWillType;
 import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
@@ -17,7 +21,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
 
-public class ItemSigilLava extends ItemSigilFluidBase {
+public class ItemSigilLava extends ItemSigilFluidBase implements ISentientSwordEffectProvider {
 
     public ItemSigilLava() {
         super("lava", 1000, new FluidStack(FluidRegistry.LAVA, 1000));
@@ -67,5 +71,17 @@ public class ItemSigilLava extends ItemSigilFluidBase {
             }
         }
         return super.onItemRightClick(world, player, hand);
+    }
+
+    
+    @Override
+    public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target)
+    {
+        target.hurtResistantTime = 0;
+        int LPUsage = getLpUsed() * (willLevel + 1);
+        if (NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
+            return target.attackEntityFrom(DamageSource.LAVA, willLevel + 1);
+        }
+        return false;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilVoid.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilVoid.java
@@ -3,12 +3,16 @@ package WayofTime.bloodmagic.item.sigil;
 import WayofTime.bloodmagic.core.data.Binding;
 import WayofTime.bloodmagic.core.data.SoulNetwork;
 import WayofTime.bloodmagic.core.data.SoulTicket;
+import WayofTime.bloodmagic.iface.ISentientSwordEffectProvider;
 import WayofTime.bloodmagic.iface.ISigil;
+import WayofTime.bloodmagic.soul.EnumDemonWillType;
 import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
@@ -17,7 +21,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
-public class ItemSigilVoid extends ItemSigilFluidBase {
+public class ItemSigilVoid extends ItemSigilFluidBase implements ISentientSwordEffectProvider {
     public ItemSigilVoid() {
         super("void", 50, null);
     }
@@ -92,6 +96,19 @@ public class ItemSigilVoid extends ItemSigilFluidBase {
 
         network.syphon(SoulTicket.item(sigil, getLpUsed()));
         return Math.min(capacity, resource.amount);
+    }
+
+    
+    @Override
+    public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack, EntityLivingBase attacker, EntityLivingBase target)
+    {
+        target.hurtResistantTime = 0;
+        int LPUsage = getLpUsed() * (willLevel + 1);
+        if (NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
+            return target.attackEntityFrom(DamageSource.OUT_OF_WORLD, (willLevel + 1) / 2);
+        }
+    
+        return false;
     }
 }
 

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
@@ -81,18 +81,16 @@ public class ItemSigilWater extends ItemSigilFluidBase implements ISentientSword
         return super.onItemRightClick(world, player, hand);
     }
 
-    
-    
     @Override
     public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack,
 	    EntityLivingBase attacker, EntityLivingBase target) {
 	
-	target.hurtResistantTime = 0;
-	int LPUsage = getLpUsed() * (willLevel + 1);
-	if (NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
-	    return target.attackEntityFrom(DamageSource.DROWN, willLevel + 1);
-	}
+        target.hurtResistantTime = 0;
+        int LPUsage = getLpUsed() * (willLevel + 1);
+        if (NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
+            return target.attackEntityFrom(DamageSource.DROWN, willLevel + 1);
+        }
 	
-	return false;
+        return false;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
+++ b/src/main/java/WayofTime/bloodmagic/item/sigil/ItemSigilWater.java
@@ -1,14 +1,18 @@
 package WayofTime.bloodmagic.item.sigil;
 
 import WayofTime.bloodmagic.core.data.SoulTicket;
+import WayofTime.bloodmagic.iface.ISentientSwordEffectProvider;
 import WayofTime.bloodmagic.iface.ISigil;
+import WayofTime.bloodmagic.soul.EnumDemonWillType;
 import WayofTime.bloodmagic.util.helper.NetworkHelper;
 import WayofTime.bloodmagic.util.helper.PlayerHelper;
 import net.minecraft.block.BlockCauldron;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
@@ -18,7 +22,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
-public class ItemSigilWater extends ItemSigilFluidBase {
+public class ItemSigilWater extends ItemSigilFluidBase implements ISentientSwordEffectProvider {
     public ItemSigilWater() {
         super("water", 100, new FluidStack(FluidRegistry.WATER, 1000));
     }
@@ -75,5 +79,20 @@ public class ItemSigilWater extends ItemSigilFluidBase {
         }
 
         return super.onItemRightClick(world, player, hand);
+    }
+
+    
+    
+    @Override
+    public boolean applyOnHitEffect(EnumDemonWillType type, int willLevel, ItemStack swordStack, ItemStack providerStack,
+	    EntityLivingBase attacker, EntityLivingBase target) {
+	
+	target.hurtResistantTime = 0;
+	int LPUsage = getLpUsed() * (willLevel + 1);
+	if (NetworkHelper.getSoulNetwork(getBinding(providerStack)).syphonAndDamage((EntityPlayer) attacker, SoulTicket.item(providerStack, attacker.getEntityWorld(), attacker, LPUsage)).isSuccess()) {
+	    return target.attackEntityFrom(DamageSource.DROWN, willLevel + 1);
+	}
+	
+	return false;
     }
 }

--- a/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientAxe.java
+++ b/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientAxe.java
@@ -202,9 +202,7 @@ public class ItemSentientAxe extends ItemAxe implements IDemonWillWeapon, IMeshP
                 ItemStack offStack = attackerPlayer.getItemStackFromSlot(EntityEquipmentSlot.OFFHAND);
                 if (offStack.getItem() instanceof ISentientSwordEffectProvider) {
                     ISentientSwordEffectProvider provider = (ISentientSwordEffectProvider) offStack.getItem();
-                    if (provider.providesEffectForWill(type)) {
-                        provider.applyOnHitEffect(type, stack, offStack, attacker, target);
-                    }
+                    provider.applyOnHitEffect(type, willBracket, stack, offStack, attacker, target);
                 }
             }
 

--- a/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientPickaxe.java
+++ b/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientPickaxe.java
@@ -202,9 +202,7 @@ public class ItemSentientPickaxe extends ItemPickaxe implements IDemonWillWeapon
                 ItemStack offStack = attackerPlayer.getItemStackFromSlot(EntityEquipmentSlot.OFFHAND);
                 if (offStack.getItem() instanceof ISentientSwordEffectProvider) {
                     ISentientSwordEffectProvider provider = (ISentientSwordEffectProvider) offStack.getItem();
-                    if (provider.providesEffectForWill(type)) {
-                        provider.applyOnHitEffect(type, stack, offStack, attacker, target);
-                    }
+                    provider.applyOnHitEffect(type, willBracket, stack, offStack, attacker, target);
                 }
             }
 

--- a/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientShovel.java
+++ b/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientShovel.java
@@ -202,9 +202,7 @@ public class ItemSentientShovel extends ItemSpade implements IDemonWillWeapon, I
                 ItemStack offStack = attackerPlayer.getItemStackFromSlot(EntityEquipmentSlot.OFFHAND);
                 if (offStack.getItem() instanceof ISentientSwordEffectProvider) {
                     ISentientSwordEffectProvider provider = (ISentientSwordEffectProvider) offStack.getItem();
-                    if (provider.providesEffectForWill(type)) {
-                        provider.applyOnHitEffect(type, stack, offStack, attacker, target);
-                    }
+                    provider.applyOnHitEffect(type, willBracket, stack, offStack, attacker, target);
                 }
             }
 

--- a/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientSword.java
+++ b/src/main/java/WayofTime/bloodmagic/item/soul/ItemSentientSword.java
@@ -184,9 +184,7 @@ public class ItemSentientSword extends ItemSword implements IDemonWillWeapon, IM
                 ItemStack offStack = attackerPlayer.getItemStackFromSlot(EntityEquipmentSlot.OFFHAND);
                 if (offStack.getItem() instanceof ISentientSwordEffectProvider) {
                     ISentientSwordEffectProvider provider = (ISentientSwordEffectProvider) offStack.getItem();
-                    if (provider.providesEffectForWill(type)) {
-                        provider.applyOnHitEffect(type, stack, offStack, attacker, target);
-                    }
+                    provider.applyOnHitEffect(type, willBracket, stack, offStack, attacker, target);
                 }
             }
 

--- a/src/main/java/WayofTime/bloodmagic/potion/PotionEventHandlers.java
+++ b/src/main/java/WayofTime/bloodmagic/potion/PotionEventHandlers.java
@@ -187,5 +187,11 @@ public class PotionEventHandlers {
         if (event.getSource() == DamageSource.FALL)
             if (event.getEntityLiving().isPotionActive(RegistrarBloodMagic.FEATHERED))
                 event.setCanceled(true);
+
+        if (event.getSource().isFireDamage()) {
+            PotionEffect fireVuln = event.getEntityLiving().getActivePotionEffect(RegistrarBloodMagic.FIRE_VULNERABILITY);
+            if (fireVuln != null)
+                event.setAmount(event.getAmount() * (1 + 0.25F * (1 + fireVuln.getAmplifier())));
+        }
     }
 }


### PR DESCRIPTION
Added effect providers (on hit effects) with sigils in the offhand and a sentient tool (sword) in the main hand.
More effects may be added incrementally in the future.

Added Elemental Sigil on hit effects:
Air Sigil:
 - throws target in the air based on will and knockback level
 - applies heavy heart (increases fall damage)

Water Sigil:
 - deals drowning damage based on will

Lava Sigil:
 - deals fire damage based on will

Void Sigil:
 - deals out of world damage based on will, half as much as water/lava

Elemental Affinity:
 - disables Sigils of Elemental Affinity and removes water breathing/fire resistance
 - if there's no Sigil of Elemental Affinity active on the target, one of 4 effects is applied on attack
    - Levitation (strength based on will)
    - Desorientation (akin to Desorientation LA downgrade)
    - Deafness
    - Fire Vulnerability (strength based on will)

New potion effect: Fire Vulnerability
  - increases fire damage taken by 25% per level