### PR TITLE
Another one bites the changelog!

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,20 @@
 ------------------------------------------------------
+Version 2.4.?
+------------------------------------------------------
+
+Not merged yet:
+
+    - Fixed "Gate of the Fold" and altered its functionality to accomodate multiple portals with the same key (#1553)
+    - Added on hit effects for sentient tools (sword) for elemental sigils (#1650)
+    - Fixed FluidSigils only filling fractions of a bucket and not being able to place liquids after having filled fractions of a bucket once (#1585)
+    - Added creative item handling and new creative/test items (#1556)
+    	- Orb of Testing (Cap, Fill, Empty, Get)
+	    - Creative Activation Crystal (Prevents LP, Will drain, Nausea)
+	    - Ritual Diviner (Places instantly, ignores blocks)
+	    - Draft of Angelus (increases upgrade points to 10,000 if used with >200 points and creative)
+	    - Tartaric Gems
+
+------------------------------------------------------
 Version 2.4.2
 ------------------------------------------------------
 Now with no guarantees for working textures!


### PR DESCRIPTION
Not merged yet:

    - Fixed "Gate of the Fold" and altered its functionality to accomodate multiple portals with the same key (#1553)
    - Added on hit effects for sentient tools (sword) for elemental sigils (#1650)
    - Fixed FluidSigils only filling fractions of a bucket and not being able to place liquids after having filled fractions of a bucket once (#1585)
    - Added creative item handling and new creative/test items (#1556)
    	- Orb of Testing (Cap, Fill, Empty, Get)
	    - Creative Activation Crystal (Prevents LP, Will drain, Nausea)
	    - Ritual Diviner (Places instantly, ignores blocks)
	    - Draft of Angelus (increases upgrade points to 10,000 if used with >200 points and creative)
	    - Tartaric Gems