### PR TITLE
Removed unnecessary altar tier checks in attempt to fix #1646

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/altar/BloodAltar.java
+++ b/src/main/java/WayofTime/bloodmagic/altar/BloodAltar.java
@@ -353,7 +353,7 @@ public class BloodAltar implements IFluidHandler {
                 return;
 
             if (fluid != null && fluid.amount >= 1) {
-                int liquidDrained = Math.min((int) (altarTier.ordinal() >= 2 ? orb.getFillRate() * (1 + consumptionMultiplier) : orb.getFillRate()), fluid.amount);
+                int liquidDrained = Math.min((int) (orb.getFillRate() * (1 + consumptionMultiplier)), fluid.amount);
                 int drain = NetworkHelper.getSoulNetwork(binding).add(SoulTicket.block(world, pos, liquidDrained), (int) (orb.getCapacity() * this.orbCapacityMultiplier));
                 fluid.amount = fluid.amount - drain;
 

--- a/src/main/java/WayofTime/bloodmagic/altar/BloodAltar.java
+++ b/src/main/java/WayofTime/bloodmagic/altar/BloodAltar.java
@@ -291,7 +291,7 @@ public class BloodAltar implements IFluidHandler {
                 hasOperated = true;
             }
             if (fluid != null && fluid.amount >= 1) {
-                int liquidDrained = Math.min((int) (altarTier.ordinal() >= 2 ? consumptionRate * (1 + consumptionMultiplier) : consumptionRate), fluid.amount);
+                int liquidDrained = Math.min((int) (consumptionRate * (1 + consumptionMultiplier)), fluid.amount);
 
                 if (liquidDrained > (liquidRequired * stackSize - progress))
                     liquidDrained = liquidRequired * stackSize - progress;


### PR DESCRIPTION
I removed any checks like `altarTier.ordinal() >= 2` while checking for altar liquid drain when filling a blood orb or using the altar to transform an item. This fixes the issue noted in #1646.
I believe this shouldn't have any other adverse effects because a tier 1 altar cannot have speed upgrades, and the code further already enforces the tier restrictions for speed upgrades in `BloodAltar.java:382` and `BloodAltar.java:398`. Consumption multiplier is already 0 if the tier isn't high enough because `BloodAltar.checkTier` enforces as such.