### PR TITLE
Various routing node improvements/fixes

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/item/routing/ItemRouterFilter.java
+++ b/src/main/java/WayofTime/bloodmagic/item/routing/ItemRouterFilter.java
@@ -58,11 +58,11 @@ public class ItemRouterFilter extends Item implements IItemFilterProvider, IVari
 
     @Override
     public IItemFilter getInputItemFilter(ItemStack filterStack, TileEntity tile, IItemHandler handler) {
-        IItemFilter testFilter = new TestItemFilter();
+        IItemFilter testFilter = new PreciseItemFilter();
 
         switch (filterStack.getMetadata()) {
             case 0:
-                testFilter = new TestItemFilter();
+                testFilter = new PreciseItemFilter();
                 break;
             case 1:
                 testFilter = new IgnoreNBTItemFilter();
@@ -101,7 +101,7 @@ public class ItemRouterFilter extends Item implements IItemFilterProvider, IVari
 
         switch (filterStack.getMetadata()) {
             case 0:
-                testFilter = new TestItemFilter();
+                testFilter = new PreciseItemFilter();
                 break;
             case 1:
                 testFilter = new IgnoreNBTItemFilter();

--- a/src/main/java/WayofTime/bloodmagic/routing/IItemFilter.java
+++ b/src/main/java/WayofTime/bloodmagic/routing/IItemFilter.java
@@ -10,23 +10,30 @@ public interface IItemFilter extends IRoutingFilter {
     void initializeFilter(List<ItemStack> filteredList, TileEntity tile, IItemHandler itemHandler, boolean isFilterOutput);
 
     /**
-     * This method is only called when the output inventory this filter is
-     * managing receives an ItemStack. Should only really be called by the Input
-     * filter via it's transfer method.
-     *
-     * @param inputStack - The stack to filter
-     * @return - The remainder of the stack after it has been absorbed into the
-     * inventory.
-     */
-    ItemStack transferStackThroughOutputFilter(ItemStack inputStack);
-
-    /**
-     * This method is only called on an input filter to transfer ItemStacks from
-     * the input inventory to the output inventory.
+     * Tries to transfer items from this filter to outputFilter.
+     * Potentially modifies outputFilter and this filter.
+     * @param outputFilter the filter to transfer items to
+     * @param maxTransfer the max amount of items to transfer
+     * @return the amount of items actually transferred.
      */
     int transferThroughInputFilter(IItemFilter outputFilter, int maxTransfer);
 
-    boolean doesStackMatchFilter(ItemStack testStack);
+    /**
+     * Offers an inventory slot to this output filter. The output filter will
+     * try to extract the stack and return how many items it actually extracted.
+     * @param inv The inventory that has the offered ItemStack.
+     *  inv may be modified by calling inv.extractItem(slot, ..., false)
+     * @param slot The slot of inv to check.
+     * @param maxTransfer The max amount of items that can be taken.
+     * @return The number of items that were actually extracted and taken.
+     */
+    int offerStack(IItemHandler inv, int slot, int maxTransfer);
 
-    boolean doStacksMatch(ItemStack filterStack, ItemStack testStack);
+    /**
+     * Returns true if this is an input filter that can accept no more items
+     * or if this is an output filter that can output no items.
+     * Filters may return false even if they have no work.
+     * @return true if this filter can be skipped
+     */
+    boolean canSkip();
 }

--- a/src/main/java/WayofTime/bloodmagic/routing/IgnoreNBTItemFilter.java
+++ b/src/main/java/WayofTime/bloodmagic/routing/IgnoreNBTItemFilter.java
@@ -2,7 +2,7 @@ package WayofTime.bloodmagic.routing;
 
 import net.minecraft.item.ItemStack;
 
-public class IgnoreNBTItemFilter extends TestItemFilter {
+public class IgnoreNBTItemFilter extends PreciseItemFilter {
     @Override
     public boolean doesStackMatchFilter(ItemStack testStack) {
         for (ItemStack filterStack : requestList) {

--- a/src/main/java/WayofTime/bloodmagic/routing/ModIdItemFilter.java
+++ b/src/main/java/WayofTime/bloodmagic/routing/ModIdItemFilter.java
@@ -2,7 +2,7 @@ package WayofTime.bloodmagic.routing;
 
 import net.minecraft.item.ItemStack;
 
-public class ModIdItemFilter extends TestItemFilter {
+public class ModIdItemFilter extends PreciseItemFilter {
 
     @Override
     public boolean doStacksMatch(ItemStack filterStack, ItemStack testStack) {

--- a/src/main/java/WayofTime/bloodmagic/routing/OreDictItemFilter.java
+++ b/src/main/java/WayofTime/bloodmagic/routing/OreDictItemFilter.java
@@ -3,7 +3,7 @@ package WayofTime.bloodmagic.routing;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
-public class OreDictItemFilter extends TestItemFilter {
+public class OreDictItemFilter extends PreciseItemFilter {
     @Override
     public boolean doesStackMatchFilter(ItemStack testStack) {
         for (ItemStack filterStack : requestList) {

--- a/src/main/java/WayofTime/bloodmagic/routing/PreciseItemFilter.java
+++ b/src/main/java/WayofTime/bloodmagic/routing/PreciseItemFilter.java
@@ -17,7 +17,7 @@ import java.util.List;
  *
  * @author WayofTime
  */
-public class TestItemFilter implements IItemFilter {
+public class PreciseItemFilter implements IItemFilter {
     /*
      * This list acts as the way the filter keeps track of its contents. For the
      * case of an output filter, it holds a list of ItemStacks that needs to be

--- a/src/main/java/WayofTime/bloodmagic/routing/RoutingFluidFilter.java
+++ b/src/main/java/WayofTime/bloodmagic/routing/RoutingFluidFilter.java
@@ -89,7 +89,8 @@ public class RoutingFluidFilter implements IFluidFilter {
         }
 
         FluidStack copyStack = fluidStack.copy();
-        int filledAmount = fluidHandler.fill(fluidStack, true);
+        copyStack.amount = allowedAmount;
+        int filledAmount = fluidHandler.fill(copyStack, true);
         copyStack.amount = fluidStack.amount - filledAmount;
 
         Iterator<FluidStack> itr = requestList.iterator();

--- a/src/main/java/WayofTime/bloodmagic/routing/RoutingFluidFilter.java
+++ b/src/main/java/WayofTime/bloodmagic/routing/RoutingFluidFilter.java
@@ -130,7 +130,6 @@ public class RoutingFluidFilter implements IFluidFilter {
                     drainStack.amount = drained;
 
                     fluidHandler.drain(drainStack, true);
-                    maxTransfer -= drained;
                 }
 
                 Iterator<FluidStack> itr = requestList.iterator();
@@ -148,7 +147,7 @@ public class RoutingFluidFilter implements IFluidFilter {
                 BlockPos pos = accessedTile.getPos();
                 world.notifyBlockUpdate(pos, world.getBlockState(pos), world.getBlockState(pos), 3);
 
-                return maxTransfer;
+                return drained;
             }
         }
 

--- a/src/main/java/WayofTime/bloodmagic/tile/routing/TileMasterRoutingNode.java
+++ b/src/main/java/WayofTime/bloodmagic/tile/routing/TileMasterRoutingNode.java
@@ -32,10 +32,7 @@ public class TileMasterRoutingNode extends TileInventory implements IMasterRouti
     @Override
     public void update() {
         if (!getWorld().isRemote) {
-//            currentInput = getWorld().isBlockIndirectlyGettingPowered(pos);
             currentInput = getWorld().getStrongPower(pos);
-
-//            System.out.println(currentInput);
         }
 
         if (getWorld().isRemote || getWorld().getTotalWorldTime() % tickRate != 0) //Temporary tick rate solver
@@ -58,7 +55,7 @@ public class TileMasterRoutingNode extends TileInventory implements IMasterRouti
                         }
 
                         IItemFilter filter = outputNode.getOutputFilterForSide(facing);
-                        if (filter != null) {
+                        if (filter != null && !filter.canSkip()) {
                             int priority = outputNode.getPriority(facing);
                             if (outputMap.containsKey(priority)) {
                                 outputMap.get(priority).add(filter);
@@ -110,7 +107,7 @@ public class TileMasterRoutingNode extends TileInventory implements IMasterRouti
                         }
 
                         IItemFilter filter = inputNode.getInputFilterForSide(facing);
-                        if (filter != null) {
+                        if (filter != null && !filter.canSkip()) {
                             int priority = inputNode.getPriority(facing);
                             if (inputMap.containsKey(priority)) {
                                 inputMap.get(priority).add(filter);


### PR DESCRIPTION
Hi, here are 3 routing nodes bug fixes and one performance optimization:

- Make Fluid output filters respect allowedAmount
Fluid output filters would try to extract the amount given to them by the input filter, ignoring their own limits. This caused odd behavior where inputs limited to amounts such as 50 mb would insert 1000mb in the tank.
- Fix input item routing filters not properly filtering
All the input item filters derived from PreciseItemFilter had odd behavior since empty item stacks are treated like air in many comparisons.
- Fix fluid routing with multiple nodes (fix #1657)
see related issue
- Improve item routing perf by reducing ItemStack copies
Changes the item filter code to make less ItemStack copies and do less simulated ItemStack extractions, improving performance in large routing systems. Also adds a canSkip heuristic to prune filters that won't be used.
- Rename TestItemFilter -> PreciseItemFilter
I know the contributing guidelines say not to do unnecessary file renames, but I feel this one is useful since it better matches the ingame item name. Also, I think the old name was meant to be temporary ;). I can remove this commit though.

The commit messages have more information as well! I tested the routing out on a sample world w/one input and one output of each type (including default filters) and several tanks. It seems to work