### PR TITLE
Fix memory leak when unloading worlds

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/util/handler/event/GenericHandler.java
+++ b/src/main/java/WayofTime/bloodmagic/util/handler/event/GenericHandler.java
@@ -561,6 +561,8 @@ public class GenericHandler {
         filledHandMapMap.remove(world);
         attackTaskMapMap.remove(world);
         targetTaskMapMap.remove(world);
+        forceSpawnMap.remove(world);
+        preventSpawnMap.remove(world);
         PotionEventHandlers.flightListMap.remove(world);
         PotionEventHandlers.noGravityListMap.remove(world);
     }


### PR DESCRIPTION
fixes https://github.com/WayofTime/BloodMagic/issues/1685

When forceSpawnMap and preventSpawnMap were added, the code to free the World instance on world unload wasn't added. It might be prudent to rework this section so the same issue doesn't happen again if new maps are added.