### PR TITLE
Register entities immediately within FMLClientSetupEvent

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/client/ClientEvents.java
+++ b/src/main/java/wayoftime/bloodmagic/client/ClientEvents.java
@@ -55,14 +55,14 @@ public class ClientEvents
 	@SuppressWarnings("deprecation")
 	public static void initClientEvents(FMLClientSetupEvent event)
 	{
+		RenderingRegistry.registerEntityRenderingHandler(BloodMagicEntityTypes.SNARE.getEntityType(), SoulSnareRenderer::new);
+		RenderingRegistry.registerEntityRenderingHandler(BloodMagicEntityTypes.BLOOD_LIGHT.getEntityType(), BloodLightRenderer::new);
+
 		DeferredWorkQueue.runLater(() -> {
 			RenderType rendertype = RenderType.getCutoutMipped();
 			RenderTypeLookup.setRenderLayer(BloodMagicBlocks.ALCHEMY_TABLE.get(), rendertype);
 
 			ClientEvents.registerContainerScreens();
-
-			RenderingRegistry.registerEntityRenderingHandler(BloodMagicEntityTypes.SNARE.getEntityType(), SoulSnareRenderer::new);
-			RenderingRegistry.registerEntityRenderingHandler(BloodMagicEntityTypes.BLOOD_LIGHT.getEntityType(), BloodLightRenderer::new);
 
 			registerToggleableProperties(BloodMagicItems.GREEN_GROVE_SIGIL.get());
 			registerToggleableProperties(BloodMagicItems.FAST_MINER_SIGIL.get());


### PR DESCRIPTION
Fixes a client crash when throwing snares, due to missing renderer.

Deferring registration does it after `EntityRendererManager` is already configured, which is too late.
