### PR TITLE
Remove buffer writes from read method

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/recipe/serializer/AlchemyTableRecipeSerializer.java
+++ b/src/main/java/wayoftime/bloodmagic/common/recipe/serializer/AlchemyTableRecipeSerializer.java
@@ -82,12 +82,6 @@ public class AlchemyTableRecipeSerializer<RECIPE extends RecipeAlchemyTable>
 				input.add(i, Ingredient.read(buffer));
 			}
 
-			buffer.writeInt(input.size());
-			for (int i = 0; i < input.size(); i++)
-			{
-				input.get(i).write(buffer);
-			}
-
 			ItemStack output = buffer.readItemStack();
 			int syphon = buffer.readInt();
 			int ticks = buffer.readInt();


### PR DESCRIPTION
Upon attempting to join an SMP server, the client fails with the following exception. Removing the buffer writes fixes this.

```
java.lang.IndexOutOfBoundsException: writerIndex(96901) + minWritableBytes(4) exceeds maxCapacity(96901): UnpooledHeapByteBuf(ridx: 44453, widx: 96901, cap: 96901/96901)
	at io.netty.buffer.AbstractByteBuf.ensureWritable0(AbstractByteBuf.java:276) ~[netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.buffer.AbstractByteBuf.writeInt(AbstractByteBuf.java:998) ~[netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at net.minecraft.network.PacketBuffer.writeInt(PacketBuffer.java:950) ~[?:?] {re:classloading}
	at wayoftime.bloodmagic.common.recipe.serializer.AlchemyTableRecipeSerializer.read(AlchemyTableRecipeSerializer.java:86) [?:?] {re:classloading}
	at wayoftime.bloodmagic.common.recipe.serializer.AlchemyTableRecipeSerializer.read(AlchemyTableRecipeSerializer.java:24) [?:?] {re:classloading}
	at net.minecraft.network.play.server.SUpdateRecipesPacket.func_218772_c(SUpdateRecipesPacket.java:68) [?:?] {re:classloading}
	at net.minecraft.network.play.server.SUpdateRecipesPacket.readPacketData(SUpdateRecipesPacket.java:41) [?:?] {re:classloading}
	at net.minecraft.network.NettyPacketDecoder.decode(NettyPacketDecoder.java:30) [?:?] {re:classloading}
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:489) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:428) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:265) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:284) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:297) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:413) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:265) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1434) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:965) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:647) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysPlain(NioEventLoop.java:547) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:501) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:461) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:884) [netty-all-4.1.25.Final.jar:4.1.25.Final] {}
	at java.lang.Thread.run(Thread.java:834) [?:?] {}
```