### PR TITLE
Improved capacity formula

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/altar/BloodAltar.java
+++ b/src/main/java/wayoftime/bloodmagic/altar/BloodAltar.java
@@ -453,7 +453,9 @@ public class BloodAltar// implements IFluidHandler
 			this.efficiencyMultiplier = (float) Math.pow(0.85, upgrade.getLevel(BloodRuneType.EFFICIENCY));
 			this.sacrificeEfficiencyMultiplier = (float) (0.10 * upgrade.getLevel(BloodRuneType.SACRIFICE));
 			this.selfSacrificeEfficiencyMultiplier = (float) (0.10 * upgrade.getLevel(BloodRuneType.SELF_SACRIFICE));
-			this.capacityMultiplier = (float) ((1 + 0.20 * upgrade.getLevel(BloodRuneType.CAPACITY)) * Math.pow(1.075, upgrade.getLevel(BloodRuneType.AUGMENTED_CAPACITY)));
+			int cap = upgrade.getLevel(BloodRuneType.CAPACITY);
+			int cap_aug = upgrade.getLevel(BloodRuneType.AUGMENTED_CAPACITY);
+			this.capacityMultiplier = (float) ((1 + 0.20 * cap) * Math.pow(1.1, cap_aug * Math.pow(0.99, Math.abs(cap_aug - cap))));
 			this.dislocationMultiplier = (float) (Math.pow(1.2, upgrade.getLevel(BloodRuneType.DISPLACEMENT)));
 			this.orbCapacityMultiplier = (float) (1 + 0.02 * upgrade.getLevel(BloodRuneType.ORB));
 			this.chargingFrequency = Math.max(20 - accelerationUpgrades, 1);


### PR DESCRIPTION
```
def keraldi2(cap, cap_aug):
    cap_aug = cap_aug * (0.99 ** abs(cap_aug - cap))
    return round(2000 * (cap + 5) * 1.1 ** cap_aug)
```

results:
(cap, cap_aug, LP)
```
assignMax(keraldi2, 6)
(6, 0, 22000)
assignMax(keraldi2, 7)
(6, 1, 24087)
assignMax(keraldi2, 8)
(5, 3, 26469)
assignMax(keraldi2, 9)
(5, 4, 29171)
assignMax(keraldi2, 10)
(5, 5, 32210)
assignMax(keraldi2, 20)
(9, 11, 78238)
assignMax(keraldi2, 30)
(12, 18, 170980)
assignMax(keraldi2, 40)
(16, 24, 346678)
assignMax(keraldi2, 50)
(21, 29, 666277)
assignMax(keraldi2, 60)
(27, 33, 1236525)
assignMax(keraldi2, 70)
(34, 36, 2252048)
assignMax(keraldi2, 80)
(40, 40, 4073333)
assignMax(keraldi2, 90)
(45, 45, 7289048)
assignMax(keraldi2, 100)
(50, 50, 12912994)
```