### PR TITLE
fixed typo - language file has ritual.notValid

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/tile/TileMasterRitualStone.java
+++ b/src/main/java/wayoftime/bloodmagic/tile/TileMasterRitualStone.java
@@ -234,7 +234,7 @@ public class TileMasterRitualStone extends TileTicking implements IMasterRitualS
 		} else
 		{
 			if (activator != null)
-				activator.sendStatusMessage(new TranslationTextComponent("chat.bloodmagic.ritual.notvalid"), true);
+				activator.sendStatusMessage(new TranslationTextComponent("chat.bloodmagic.ritual.notValid"), true);
 		}
 
 		return false;


### PR DESCRIPTION
this should make the ritual give the correct error message.