### PR TITLE
Fix non [a-z0-9/._-] character in path of location

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerPlantable.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerPlantable.java
@@ -42,9 +42,9 @@ public class HarvestHandlerPlantable implements IHarvestHandler
 		HarvestRegistry.registerStandardCrop(Blocks.BEETROOTS, 3);
 		HarvestRegistry.registerStandardCrop(Blocks.NETHER_WART, 3);
 
-		addThirdPartyCrop("actuallyadditions", "blockFlax", 7);
-		addThirdPartyCrop("actuallyadditions", "blockCanola", 7);
-		addThirdPartyCrop("actuallyadditions", "blockRice", 7);
+		addThirdPartyCrop("actuallyadditions", "flax_block", 7);
+		addThirdPartyCrop("actuallyadditions", "canola_block", 7);
+		addThirdPartyCrop("actuallyadditions", "rice_block", 7);
 
 		addThirdPartyCrop("extrautils2", "redorchid", 6);
 		addThirdPartyCrop("extrautils2", "enderlily", 7);


### PR DESCRIPTION
Fixes a net.minecraft.util.ResourceLocationException that happens when the mod is loaded with Actually Additions due to the third party crop integration using an old block ID with deprecated casing.