### PR TITLE
Add CraftTweaker Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,9 @@ dependencies {
     
     compileOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}:api")
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
+
+    compile fg.deobf("com.blamejared.crafttweaker:CraftTweaker-1.16.4:7.1.0.71")
+
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"
     // compile "some.group:artifact:version"

--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ dependencies {
     compileOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}:api")
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
 
-    compile fg.deobf("com.blamejared.crafttweaker:CraftTweaker-1.16.4:7.1.0.71")
+    compileOnly fg.deobf("com.blamejared.crafttweaker:CraftTweaker-1.16.4:7.1.0.84")
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/src/main/java/wayoftime/bloodmagic/common/recipe/BloodMagicRecipeType.java
+++ b/src/main/java/wayoftime/bloodmagic/common/recipe/BloodMagicRecipeType.java
@@ -1,6 +1,7 @@
 package wayoftime.bloodmagic.common.recipe;
 
 import net.minecraft.item.crafting.IRecipeType;
+import wayoftime.bloodmagic.BloodMagic;
 import wayoftime.bloodmagic.recipe.RecipeARC;
 import wayoftime.bloodmagic.recipe.RecipeAlchemyArray;
 import wayoftime.bloodmagic.recipe.RecipeAlchemyTable;
@@ -9,9 +10,9 @@ import wayoftime.bloodmagic.recipe.RecipeTartaricForge;
 
 public class BloodMagicRecipeType
 {
-	public static final IRecipeType<RecipeBloodAltar> ALTAR = IRecipeType.register("altar");
-	public static final IRecipeType<RecipeAlchemyArray> ARRAY = IRecipeType.register("array");
-	public static final IRecipeType<RecipeTartaricForge> TARTARICFORGE = IRecipeType.register("soulforge");
-	public static final IRecipeType<RecipeARC> ARC = IRecipeType.register("arc");
-	public static final IRecipeType<RecipeAlchemyTable> ALCHEMYTABLE = IRecipeType.register("alchemytable");
+	public static final IRecipeType<RecipeBloodAltar> ALTAR = IRecipeType.register(BloodMagic.MODID + ":altar");
+	public static final IRecipeType<RecipeAlchemyArray> ARRAY = IRecipeType.register(BloodMagic.MODID + ":array");
+	public static final IRecipeType<RecipeTartaricForge> TARTARICFORGE = IRecipeType.register(BloodMagic.MODID + ":soulforge");
+	public static final IRecipeType<RecipeARC> ARC = IRecipeType.register(BloodMagic.MODID + ":arc");
+	public static final IRecipeType<RecipeAlchemyTable> ALCHEMYTABLE = IRecipeType.register(BloodMagic.MODID + ":alchemytable");
 }

--- a/src/main/java/wayoftime/bloodmagic/compat/crt/ARCManager.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/crt/ARCManager.java
@@ -1,0 +1,74 @@
+package wayoftime.bloodmagic.compat.crt;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.fluid.IFluidStack;
+import com.blamejared.crafttweaker.api.item.IIngredient;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionRemoveOutputRecipe;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionRemoveRecipeByOutput;
+import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.impl.item.MCWeightedItemStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.util.ResourceLocation;
+import org.apache.commons.lang3.tuple.Pair;
+import org.openzen.zencode.java.ZenCodeType;
+import wayoftime.bloodmagic.common.recipe.BloodMagicRecipeType;
+import wayoftime.bloodmagic.recipe.RecipeARC;
+import wayoftime.bloodmagic.recipe.helper.FluidStackIngredient;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ZenRegister
+@ZenCodeType.Name("mods.bloodmagic.ARC")
+public class ARCManager implements IRecipeManager {
+    
+    @ZenCodeType.Method
+    public void addRecipe(String name, IItemStack output, IFluidStack outputFluid, IIngredient input, IFluidStack inputFluid, IIngredient arcTool, boolean consumeIngredient, @ZenCodeType.Optional MCWeightedItemStack[] addedItems) {
+        name = fixRecipeName(name);
+        ResourceLocation location = new ResourceLocation("crafttweaker", name);
+        List<Pair<ItemStack, Double>> addedItemsList = new ArrayList<>();
+        if(addedItems != null) {
+            addedItemsList = Arrays.stream(addedItems).map(mcWeightedItemStack -> Pair.of(mcWeightedItemStack.getItemStack().getInternal(), mcWeightedItemStack.getWeight())).collect(Collectors.toList());
+        }
+        RecipeARC recipeARC = new RecipeARC(location, input.asVanillaIngredient(), arcTool.asVanillaIngredient(), inputFluid.getInternal().isEmpty() ? null : FluidStackIngredient.from(inputFluid.getInternal()), output.getInternal(), addedItemsList, outputFluid.getInternal(), consumeIngredient);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipeARC, ""));
+    }
+    
+    @Override
+    public void removeRecipe(IItemStack output) {
+        
+        CraftTweakerAPI.apply(new ActionRemoveRecipeByOutput(this, output) {
+            @Override
+            public void apply() {
+                List<ResourceLocation> toRemove = new ArrayList<>();
+                for(ResourceLocation location : getManager().getRecipes().keySet()) {
+                    IRecipe<?> recipe = getManager().getRecipes().get(location);
+                    if(recipe instanceof RecipeARC) {
+                        RecipeARC recipeARC = (RecipeARC) recipe;
+                        List<ItemStack> allListedOutputs = recipeARC.getAllListedOutputs();
+                        // no other way to get the main output, and there may not even be a main output
+                        if(allListedOutputs.size() > 0) {
+                            if(output.matches(new MCItemStackMutable(allListedOutputs.get(0)))) {
+                                toRemove.add(location);
+                            }
+                        }
+                    }
+                }
+                toRemove.forEach(getManager().getRecipes()::remove);
+            }
+        });
+    }
+    
+    @Override
+    public IRecipeType<RecipeARC> getRecipeType() {
+        return BloodMagicRecipeType.ARC;
+    }
+}

--- a/src/main/java/wayoftime/bloodmagic/compat/crt/AlchemyArrayManager.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/crt/AlchemyArrayManager.java
@@ -1,0 +1,63 @@
+package wayoftime.bloodmagic.compat.crt;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.item.IIngredient;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionRemoveRecipeByOutput;
+import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.util.ResourceLocation;
+import org.openzen.zencode.java.ZenCodeType;
+import wayoftime.bloodmagic.common.recipe.BloodMagicRecipeType;
+import wayoftime.bloodmagic.recipe.RecipeAlchemyArray;
+import wayoftime.bloodmagic.recipe.RecipeAlchemyTable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ZenRegister
+@ZenCodeType.Name("mods.bloodmagic.AlchemyArray")
+public class AlchemyArrayManager implements IRecipeManager {
+    
+    @ZenCodeType.Method
+    public void addRecipe(String name, IItemStack output, IIngredient baseInput, IIngredient addedInput, ResourceLocation texture) {
+        name = fixRecipeName(name);
+        ResourceLocation location = new ResourceLocation("crafttweaker", name);
+        RecipeAlchemyArray recipe = new RecipeAlchemyArray(location, texture, baseInput.asVanillaIngredient(), addedInput.asVanillaIngredient(), output.getInternal());
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+    }
+    
+    @Override
+    public void removeRecipe(IItemStack output) {
+        
+        CraftTweakerAPI.apply(new ActionRemoveRecipeByOutput(this, output) {
+            @Override
+            public void apply() {
+                List<ResourceLocation> toRemove = new ArrayList<>();
+                for(ResourceLocation location : getManager().getRecipes().keySet()) {
+                    IRecipe<?> recipe = getManager().getRecipes().get(location);
+                    if(recipe instanceof RecipeAlchemyArray) {
+                        RecipeAlchemyArray recipeAT = (RecipeAlchemyArray) recipe;
+                        ItemStack recipeOutput = recipeAT.getOutput();
+                        if(output.matches(new MCItemStackMutable(recipeOutput))) {
+                            toRemove.add(location);
+                        }
+                    }
+                }
+                toRemove.forEach(getManager().getRecipes()::remove);
+            }
+        });
+    }
+    
+    @Override
+    public IRecipeType<RecipeAlchemyArray> getRecipeType() {
+        return BloodMagicRecipeType.ARRAY;
+    }
+}

--- a/src/main/java/wayoftime/bloodmagic/compat/crt/AlchemyTableManager.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/crt/AlchemyTableManager.java
@@ -1,0 +1,63 @@
+package wayoftime.bloodmagic.compat.crt;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.item.IIngredient;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionRemoveRecipeByOutput;
+import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.util.ResourceLocation;
+import org.openzen.zencode.java.ZenCodeType;
+import wayoftime.bloodmagic.common.recipe.BloodMagicRecipeType;
+import wayoftime.bloodmagic.recipe.RecipeAlchemyTable;
+import wayoftime.bloodmagic.recipe.RecipeTartaricForge;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ZenRegister
+@ZenCodeType.Name("mods.bloodmagic.AlchemyTable")
+public class AlchemyTableManager implements IRecipeManager {
+    
+    @ZenCodeType.Method
+    public void addRecipe(String name, IItemStack output, IIngredient[] input, int syphon, int ticks, int minimumTier) {
+        name = fixRecipeName(name);
+        ResourceLocation location = new ResourceLocation("crafttweaker", name);
+        RecipeAlchemyTable recipe = new RecipeAlchemyTable(location, Arrays.stream(input).map(IIngredient::asVanillaIngredient).collect(Collectors.toList()), output.getInternal(), syphon, ticks, minimumTier);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+    }
+    
+    @Override
+    public void removeRecipe(IItemStack output) {
+        
+        CraftTweakerAPI.apply(new ActionRemoveRecipeByOutput(this, output) {
+            @Override
+            public void apply() {
+                List<ResourceLocation> toRemove = new ArrayList<>();
+                for(ResourceLocation location : getManager().getRecipes().keySet()) {
+                    IRecipe<?> recipe = getManager().getRecipes().get(location);
+                    if(recipe instanceof RecipeAlchemyTable) {
+                        RecipeAlchemyTable recipeAT = (RecipeAlchemyTable) recipe;
+                        ItemStack recipeOutput = recipeAT.getOutput();
+                        if(output.matches(new MCItemStackMutable(recipeOutput))) {
+                            toRemove.add(location);
+                        }
+                    }
+                }
+                toRemove.forEach(getManager().getRecipes()::remove);
+            }
+        });
+    }
+    
+    @Override
+    public IRecipeType<RecipeAlchemyTable> getRecipeType() {
+        return BloodMagicRecipeType.ALCHEMYTABLE;
+    }
+}

--- a/src/main/java/wayoftime/bloodmagic/compat/crt/BloodAltarManager.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/crt/BloodAltarManager.java
@@ -1,0 +1,67 @@
+package wayoftime.bloodmagic.compat.crt;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.fluid.IFluidStack;
+import com.blamejared.crafttweaker.api.item.IIngredient;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionRemoveRecipeByOutput;
+import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.impl.item.MCWeightedItemStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.util.ResourceLocation;
+import org.apache.commons.lang3.tuple.Pair;
+import org.openzen.zencode.java.ZenCodeType;
+import wayoftime.bloodmagic.common.recipe.BloodMagicRecipeType;
+import wayoftime.bloodmagic.recipe.RecipeARC;
+import wayoftime.bloodmagic.recipe.RecipeBloodAltar;
+import wayoftime.bloodmagic.recipe.helper.FluidStackIngredient;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ZenRegister
+@ZenCodeType.Name("mods.bloodmagic.BloodAltar")
+public class BloodAltarManager implements IRecipeManager {
+    
+    @ZenCodeType.Method
+    public void addRecipe(String name, IItemStack output, IIngredient input, int minimumTier, int syphon, int consumeRate, int drainRate) {
+        name = fixRecipeName(name);
+        ResourceLocation location = new ResourceLocation("crafttweaker", name);
+        RecipeBloodAltar recipeARC = new RecipeBloodAltar(location, input.asVanillaIngredient(), output.getInternal(), minimumTier, syphon, consumeRate, drainRate);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipeARC, ""));
+    }
+    
+    @Override
+    public void removeRecipe(IItemStack output) {
+        
+        CraftTweakerAPI.apply(new ActionRemoveRecipeByOutput(this, output) {
+            @Override
+            public void apply() {
+                List<ResourceLocation> toRemove = new ArrayList<>();
+                for(ResourceLocation location : getManager().getRecipes().keySet()) {
+                    IRecipe<?> recipe = getManager().getRecipes().get(location);
+                    if(recipe instanceof RecipeBloodAltar) {
+                        RecipeBloodAltar recipeBloodAltar = (RecipeBloodAltar) recipe;
+                        ItemStack recOut = recipeBloodAltar.getOutput();
+                        if(output.matches(new MCItemStackMutable(recOut))) {
+                            toRemove.add(location);
+                        }
+                    }
+                }
+                toRemove.forEach(getManager().getRecipes()::remove);
+            }
+        });
+    }
+    
+    @Override
+    public IRecipeType<RecipeBloodAltar> getRecipeType() {
+        return BloodMagicRecipeType.ALTAR;
+    }
+}

--- a/src/main/java/wayoftime/bloodmagic/compat/crt/TartaricForgeManager.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/crt/TartaricForgeManager.java
@@ -1,0 +1,68 @@
+package wayoftime.bloodmagic.compat.crt;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.fluid.IFluidStack;
+import com.blamejared.crafttweaker.api.item.IIngredient;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionRemoveRecipeByOutput;
+import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.impl.item.MCWeightedItemStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.util.ResourceLocation;
+import org.apache.commons.lang3.tuple.Pair;
+import org.openzen.zencode.java.ZenCodeType;
+import wayoftime.bloodmagic.common.recipe.BloodMagicRecipeType;
+import wayoftime.bloodmagic.recipe.RecipeARC;
+import wayoftime.bloodmagic.recipe.RecipeTartaricForge;
+import wayoftime.bloodmagic.recipe.helper.FluidStackIngredient;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+@ZenRegister
+@ZenCodeType.Name("mods.bloodmagic.TartaricForge")
+public class TartaricForgeManager implements IRecipeManager {
+    
+    @ZenCodeType.Method
+    public void addRecipe(String name, IItemStack output, IIngredient[] input, double minimumSouls, double soulDrain) {
+        name = fixRecipeName(name);
+        ResourceLocation location = new ResourceLocation("crafttweaker", name);
+        RecipeTartaricForge recipe = new RecipeTartaricForge(location, Arrays.stream(input).map(IIngredient::asVanillaIngredient).collect(Collectors.toList()), output.getInternal(), minimumSouls, soulDrain);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+    }
+    
+    @Override
+    public void removeRecipe(IItemStack output) {
+        
+        CraftTweakerAPI.apply(new ActionRemoveRecipeByOutput(this, output) {
+            @Override
+            public void apply() {
+                List<ResourceLocation> toRemove = new ArrayList<>();
+                for(ResourceLocation location : getManager().getRecipes().keySet()) {
+                    IRecipe<?> recipe = getManager().getRecipes().get(location);
+                    if(recipe instanceof RecipeTartaricForge) {
+                        RecipeTartaricForge recipeTF = (RecipeTartaricForge) recipe;
+                        ItemStack recipeOutput = recipeTF.getOutput();
+                        if(output.matches(new MCItemStackMutable(recipeOutput))) {
+                            toRemove.add(location);
+                        }
+                    }
+                }
+                toRemove.forEach(getManager().getRecipes()::remove);
+            }
+        });
+    }
+    
+    @Override
+    public IRecipeType<RecipeTartaricForge> getRecipeType() {
+        return BloodMagicRecipeType.TARTARICFORGE;
+    }
+}


### PR DESCRIPTION
As requested by @WayofTime  on Discord, CraftTweaker support :smiley: 

Docs will be PR'd to the CraftTweaker Docs repo, and will be hosted on https://docs.blamejared.com

This is the script I used to test it, it should cover everything that can be done in JSON with it

Also I put CraftTweaker has a compileOnly because we don't really have an :api and I don't think you guys really want waste the CPU cycles loading more mods when deving, happy to change it though

```zenscript
<recipetype:bloodmagic:arc>.addRecipe("arc_recipe_test_all", <item:minecraft:glass>, <fluid:minecraft:lava>, <item:minecraft:diamond>, <fluid:minecraft:water>, <item:bloodmagic:basiccuttingfluid>.anyDamage(), false, [<item:minecraft:apple> % 50]);
<recipetype:bloodmagic:arc>.addRecipe("arc_recipe_test_no_extras", <item:minecraft:diamond>, <fluid:minecraft:lava>, <item:minecraft:dirt>, <fluid:minecraft:water>, <item:bloodmagic:basiccuttingfluid>.anyDamage(), false);
<recipetype:bloodmagic:arc>.addRecipe("arc_recipe_test_no_fluid_output", <item:minecraft:diamond>, <fluid:minecraft:lava>, <item:minecraft:glass>, <fluid:minecraft:empty>, <item:bloodmagic:basiccuttingfluid>.anyDamage(), false);
<recipetype:bloodmagic:arc>.addRecipe("arc_recipe_test_no_fluid_input", <item:minecraft:diamond>, <fluid:minecraft:empty>, <item:minecraft:apple>, <fluid:minecraft:water>, <item:bloodmagic:basiccuttingfluid>.anyDamage(), false);

<recipetype:bloodmagic:arc>.addRecipe("arc_recipe_test_all_consume", <item:minecraft:stick>, <fluid:minecraft:lava>, <item:minecraft:water_bucket>, <fluid:minecraft:water>, <item:bloodmagic:basiccuttingfluid>.anyDamage(), true, [<item:minecraft:apple> % 50]);
<recipetype:bloodmagic:arc>.addRecipe("arc_recipe_test_no_extras_consume", <item:minecraft:arrow>, <fluid:minecraft:lava>,<item:minecraft:pufferfish_bucket>, <fluid:minecraft:water>, <item:bloodmagic:basiccuttingfluid>.anyDamage(), true);
<recipetype:bloodmagic:arc>.addRecipe("arc_recipe_test_no_fluid_output_consume", <item:minecraft:shield>, <fluid:minecraft:lava>, <item:minecraft:lava_bucket>, <fluid:minecraft:empty>, <item:bloodmagic:basiccuttingfluid>.anyDamage(), true);
<recipetype:bloodmagic:arc>.addRecipe("arc_recipe_test_no_fluid_input_consume", <item:minecraft:stone>, <fluid:minecraft:empty>, <item:minecraft:water_bucket>, <fluid:minecraft:water>, <item:bloodmagic:basiccuttingfluid>.anyDamage(), true);

<recipetype:bloodmagic:arc>.removeRecipe(<item:bloodmagic:weakbloodshard>);

<recipetype:bloodmagic:altar>.addRecipe("altar_test", <item:minecraft:diamond>, <item:minecraft:coal>, 0, 500, 1, 1);
<recipetype:bloodmagic:altar>.removeRecipe(<item:bloodmagic:reinforcedslate>);

<recipetype:bloodmagic:soulforge>.addRecipe("soulforge_test", <item:minecraft:diamond>, [<item:minecraft:coal>], 0, 500);
<recipetype:bloodmagic:soulforge>.removeRecipe(<item:bloodmagic:soulaxe>);

<recipetype:bloodmagic:alchemytable>.addRecipe("alchemytable_test", <item:minecraft:diamond>, [<item:minecraft:coal>], 0, 100, 0);
<recipetype:bloodmagic:alchemytable>.removeRecipe(<item:minecraft:clay_ball>);

<recipetype:bloodmagic:array>.addRecipe("array_test", <item:minecraft:diamond>, <item:minecraft:coal>, <item:minecraft:dirt>, <resource:textures/item/diamond.png>);
<recipetype:bloodmagic:array>.removeRecipe(<item:bloodmagic:divinationsigil>);

```
