### PR TITLE
Various minor fixes for the guidebook

### DIFF
--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/arcane_ash.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/arcane_ash.json
@@ -9,9 +9,9 @@
       "text": "$(item)Arcane Ashes$() is an item that is pivotal in the creation of Alchemy Arrays. $(item)Arcane Ashes$() can be crafted in the $(l:demon_will/soul_forge)Hellfire Forge$(/l) using some early game items."
     },
     {
-      "type": "crafting_soulforge",
+      "type": "crafting_alchemy_table",
       "heading": "Arcane Ashes",
-      "recipe": "bloodmagic:soulforge/arcaneashes"
+      "recipe": "bloodmagic:alchemytable/arcane_ash"
     },
     {
       "type": "text",

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/spike_array.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/spike_array.json
@@ -9,6 +9,7 @@
     },
     {
       "type": "functional_array",
+      "heading": "Spike Array",
       "recipe": "bloodmagic:array/spike",
       "image": "spikearray.png"
     }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/demon_will/explosive_charges.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/demon_will/explosive_charges.json
@@ -4,7 +4,7 @@
   "category": "demon_will",
   "extra_recipe_mappings":[
     ["bloodmagic:shaped_charge", 1],
-    ["bloodmagic:deforester_charge", 3]
+    ["bloodmagic:deforester_charge", 2]
 	],
   "pages":[
     {
@@ -13,12 +13,14 @@
     },
     {
       "type": "crafting_soulforge",
+      "heading": "Shaped Charge",
       "recipe": "bloodmagic:soulforge/shaped_charge",
 	  "anchor":"shaped_charge",
 	  "text": "The $(item)Shaped Charge$() will destroy a 5x5x5 cube facing whichever side of a block it lands on, dropping all blocks as though mined with a pickaxe. It even works on Obsidian, and provides a most satisfying $(o)KABOOM$() whilst doing so."
     },
     {
       "type": "crafting_soulforge",
+      "heading": "Deforester Charge",
       "recipe": "bloodmagic:soulforge/deforester_charge",
 	  "anchor":"deforester_charge",
 	  "text": "The $(item)Deforester Charge$() is for felling trees. It can be used on logs or leaves, and will fell all but the mightiest of trees, breaking up to 2 stacks of logs at a time (and neatly stripping away any leaves it encounters in the process!) Even the giant trees of the Jungle will fall in a matter of seconds."

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/living_equipment/living_basics.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/living_equipment/living_basics.json
@@ -10,9 +10,9 @@
       "text": "To create $(item)Living Equipment$(), you will first need $(item)Iron Armor$() (or $(item)Iron Armour$(), if you prefer), some $(l:alchemy_array/arcane_ash)Arcane Ash$(), and some $(item)Binding Reagent$(). You'll also need at least a $(l:demon_will/soul_gem)Common Tartaric Gem$() in order to hold the $(item)Demon Will$() required."
     },
     {
-      "type": "crafting_soulforge",
+      "type": "crafting_alchemy_table",
       "heading": "Binding Reagent",
-      "recipe": "bloodmagic:soulforge/reagent_binding",
+      "recipe": "bloodmagic:alchemytable/reagent_binding",
       "text": "It clings to me tightly..."
     },
     {


### PR DESCRIPTION
* Updated Arcane Ash entry to use the new Alchemy Table recipe.
* Updated Living Armor Basics to use the new Alchemy Table recipe for Binding reagent.
* Added a heading over Spike Array recipe.
* Added headings over the two Explosive Charges recipes.
* Corrected Extra Recipe Mapping for Deforester Charge.  From what I see in the log, that is the last one that was erroring.  I haven't checked to see if all of them line up correctly.