### PR TITLE
Book: Updated Progression Tweaks

### DIFF
--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/sigil/divination.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/sigil/divination.json
@@ -3,12 +3,18 @@
   "icon": "bloodmagic:divinationsigil",
   "category": "bloodmagic:alchemy_array/sigil",
   "extra_recipe_mappings":[
-    ["bloodmagic:divinationsigil", 3]
+    ["bloodmagic:divinationsigil", 1]
   ],
   "pages": [
     {
       "type": "text",
       "text": "The $(item)Divination Sigil$() is probably the first of many sigils that you would like to craft in Blood Magic. In order to craft the sigil, you need to create an $(l:bloodmagic:alchemy_array/functional_arrays/arcane_ash)Alchemy Array$(/l) and use $(item)Redstone Dust$() and a $(item)Blank Slate$() as the base and catalyst items, respectively."
+    },
+    {
+      "type": "crafting_array",
+      "heading": "Divination Sigil",
+      "recipe": "bloodmagic:array/divinationsigil",
+      "text": " $(italic)Peer into the soul."
     },
     {
       "type": "image",
@@ -22,12 +28,6 @@
     {
       "type": "text",
       "text": "The Divination Sigil has two primary uses: $(br)$(li)When the player right-clicks in the air with the sigil, it will display the amount of LP that is in the owner's $(l:bloodmagic:altar/soul_network)Soul Network.$(/l)$(li)When clicking on a $(l:bloodmagic:altar/blood_altar)Blood Altar$(/l), it will tell the player the altar's current Tier, the amount of LP stored in the altar, as well as its current max capacity. Having a $(item)Divination Sigil$() on hand can also be helpful for other block applications, but that will be covered later."
-    },
-    {
-      "type": "crafting_array",
-      "heading": "Divination Sigil",
-      "recipe": "bloodmagic:array/divinationsigil",
-      "text": " $(italic)Peer into the soul."
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/sigil/grove.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/sigil/grove.json
@@ -3,13 +3,20 @@
   "icon": "bloodmagic:growthsigil",
   "category": "bloodmagic:alchemy_array/sigil",
   "extra_recipe_mappings":[
-    ["bloodmagic:reagentgrowth", 3],
-    ["bloodmagic:growthsigil", 3]
+    ["bloodmagic:reagentgrowth", 1],
+    ["bloodmagic:growthsigil", 1]
   ],
   "pages": [
     {
       "type": "text",
       "text": "The $(item)Sigil of the Green Grove$() is an item that has multiple uses. Crafted in an array with a $(item)Growth Reagent$(item) and a $(item)Reinforced Slate$(), the sigil can use the power of your stored life force to nourish and grow nearby plants."
+    },
+    {
+      "type": "crafting_2-step_sigil",
+      "alchemy_table.heading": "Growth Reagent",
+      "alchemy_table.recipe": "bloodmagic:alchemytable/reagent_growth",
+      "array.heading": "Sigil of the Green Grove",
+      "array.recipe": "bloodmagic:array/growthsigil"
     },
     {
       "type": "image",
@@ -25,13 +32,6 @@
     {
       "type": "text",
       "text": "If you right click on a block that is $(2)IGrowable$(), it will apply the bonemeal effect while consuming 150LP.$(br2)However, if you shift-right-click the sigil in the air, the sigil will light up to indicate that it is activated, and will consume 150LP every 10 seconds. Every block in a 7x7x5 high volume centered on the player will have a growth tick applied to it. Good for farming those taters!"
-    },
-    {
-      "type": "crafting_2-step_sigil",
-      "alchemy_table.heading": "Growth Reagent",
-      "alchemy_table.recipe": "bloodmagic:alchemytable/reagent_growth",
-      "array.heading": "Sigil of the Green Grove",
-      "array.recipe": "bloodmagic:array/growthsigil"
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/sigil/lava.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/sigil/lava.json
@@ -3,13 +3,21 @@
   "icon": "bloodmagic:lavasigil",
   "category": "bloodmagic:alchemy_array/sigil",
   "extra_recipe_mappings":[
-    ["bloodmagic:reagentlava", 2],
-    ["bloodmagic:lavasigil", 2]
+    ["bloodmagic:reagentlava", 1],
+    ["bloodmagic:lavasigil", 1]
   ],
   "pages": [
     {
       "type": "text",
       "text": "The sister sigil to the $(l:bloodmagic:alchemy_array/sigil/water)Water Sigil,$(/l) the $(item)Lava Sigil$() creates a source block of lava where you click on the ground for the cost of 1000LP. Crafted in an $(l:bloodmagic:alchemy_array/functional_arrays/arcane_ash)Alchemy Array$(/l) using a $(item)Lava Reagent$() and a $(item)Blank Slate,$() it'll drain 5 hearts from you if you don't have enough LP in your $(l:bloodmagic:altar/soul_network)Soul Network.$(/l)"
+    },
+    {
+      "type": "crafting_2-step_sigil",
+      "alchemy_table.heading": "Lava Reagent",
+      "alchemy_table.recipe": "bloodmagic:alchemytable/reagent_lava",
+      "array.heading": "Lava Sigil",
+      "array.recipe": "bloodmagic:array/lavasigil",
+      "array.text": "$(italic)HOT! DO NOT EAT"
     },
     {
       "type": "image",
@@ -20,14 +28,6 @@
       "title": "Lava Sigil Array",
       "border": true,
       "text": "The Lava Sigil, next to its crafting array, plus its primary use."
-    },
-    {
-      "type": "crafting_2-step_sigil",
-      "alchemy_table.heading": "Lava Reagent",
-      "alchemy_table.recipe": "bloodmagic:alchemytable/reagent_lava",
-      "array.heading": "Lava Sigil",
-      "array.recipe": "bloodmagic:array/lavasigil",
-      "array.text": "$(italic)HOT! DO NOT EAT"
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/sigil/mining.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/sigil/mining.json
@@ -3,13 +3,20 @@
   "icon": "bloodmagic:miningsigil",
   "category": "bloodmagic:alchemy_array/sigil",
   "extra_recipe_mappings":[
-    ["bloodmagic:reagentfastminer", 2],
-    ["bloodmagic:miningsigil", 2]
+    ["bloodmagic:reagentfastminer", 1],
+    ["bloodmagic:miningsigil", 1]
   ],
   "pages": [
     {
       "type": "text",
       "text": "The $(item)Sigil of the Fast Miner$() is a sigil that, when activated using shift-right-click, will consume 100LP every 10 seconds and apply the Haste potion effect. Thus, it increases your mining, digging, and cutting speeds. Crafted using the $(item)Mining Reagent$() and $(item)Reinforced Slate$() in an alchemy array."
+    },
+    {
+      "type": "crafting_2-step_sigil",
+      "alchemy_table.heading": "Mining Reagent",
+      "alchemy_table.recipe": "bloodmagic:alchemytable/reagent_fastminer",
+      "array.heading": "Sigil of the Fast Miner",
+      "array.recipe": "bloodmagic:array/fastminersigil"
     },
     {
       "type": "image",
@@ -20,13 +27,6 @@
       "title": "Fast Miner Sigil Array",
       "border": true,
       "text": "The Sigil of the Fast Miner's array, plus its primary uses."
-    },
-    {
-      "type": "crafting_2-step_sigil",
-      "alchemy_table.heading": "Mining Reagent",
-      "alchemy_table.recipe": "bloodmagic:alchemytable/reagent_fastminer",
-      "array.heading": "Sigil of the Fast Miner",
-      "array.recipe": "bloodmagic:array/fastminersigil"
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/sigil/water.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/sigil/water.json
@@ -3,13 +3,21 @@
   "icon": "bloodmagic:watersigil",
   "category": "bloodmagic:alchemy_array/sigil",
   "extra_recipe_mappings":[
-    ["bloodmagic:reagentwater", 2],
-    ["bloodmagic:watersigil", 2]
+    ["bloodmagic:reagentwater", 1],
+    ["bloodmagic:watersigil", 1]
   ],
   "pages": [
     {
       "type": "text",
       "text": "The $(item)Water Sigil$() is a rather simple sigil. By right clicking on a block, you can drain 100LP from your $(l:bloodmagic:altar/soul_network)Soul Network$(/l) to place a source block of water in the world. If there's not enough LP, it will instead drain the toll from your health. Crafted using a $(item)Water Reagent$() and a $(item)Blank Slate.$()"
+    },
+    {
+      "type": "crafting_2-step_sigil",
+      "alchemy_table.heading": "Water Reagent",
+      "alchemy_table.recipe": "bloodmagic:alchemytable/reagent_water",
+      "array.heading": "Water Sigil",
+      "array.recipe": "bloodmagic:array/watersigil",
+      "array.text": "$(italic)Infinite water, anyone?"
     },
     {
       "type": "image",
@@ -20,14 +28,6 @@
       "title": "Water Sigil Array",
       "border": true,
       "text": "The Water Sigil, next to its crafting array, plus its primary use."
-    },
-    {
-      "type": "crafting_2-step_sigil",
-      "alchemy_table.heading": "Water Reagent",
-      "alchemy_table.recipe": "bloodmagic:alchemytable/reagent_water",
-      "array.heading": "Water Sigil",
-      "array.recipe": "bloodmagic:array/watersigil",
-      "array.text": "$(italic)Infinite water, anyone?"
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/demon_will/soul_snare.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/demon_will/soul_snare.json
@@ -5,13 +5,14 @@
   "priority": "true",
   "pages": [
     {
-      "type": "text",
-      "text": "The very first thing you will want to do is craft a $(item)Soul Snare$(). This is your gateway into $(6)Blood Magic$(), as Soul Snares allow you to gather your first $(l:bloodmagic:demon_will/demon_will)Demon Will$(), which is a required ingredient for the $(l:bloodmagic:altar/blood_altar)Blood Altar$(/l), and will fuel your work within the $(l:bloodmagic:demon_will/soul_forge)Hellfire Forge$(/l)."
-    },
-    {
       "type": "crafting_altar",
       "heading": "Soul Snare",
-      "recipe": "bloodmagic:altar/soul_snare"
+      "recipe": "bloodmagic:altar/soul_snare",
+      "text": "$(item)Soul Snares$() are your gateway into the $(l:bloodmagic:demon_will/demon_will)Demon Will$() portion of $(6)Blood Magic$()."
+    },
+    {
+      "type": "text",
+      "text": "Using the Snare is simple enough - craft a good quantity of them, find a hostile mob, and throw Snares at them until white particles appear. Kill them quickly and you should get a $(l:bloodmagic:demon_will/demon_will)Demon Will$(). Before you ask, yes, the Looting enchantment will improve your odds. Once you've gathered a couple, you can get to work on crafting yourself a $(l:bloodmagic:demon_will/sentient_sword)Sentient Sword$() and a $(l:bloodmagic:demon_will/soul_gem)Tartaric Gem$() - these will make collecting $(l:bloodmagic:demon_will/demon_will)Demon Will$() much easier."
     },
     {
       "type": "image",
@@ -21,10 +22,6 @@
       "title": "Snare on Skeleton",
       "border": true,
       "text": "A skeleton with white particles after hit by a snare."
-    },
-    {
-      "type": "text",
-      "text": "Using the Snare is simple enough - craft a good quantity of them, find a hostile mob, and throw Snares at them until white particles appear. Kill them quickly and you should get a $(l:bloodmagic:demon_will/demon_will)Demon Will$(). Before you ask, yes, the Looting enchantment will improve your odds. Once you've gathered a couple, you can get to work on crafting yourself a $(l:bloodmagic:demon_will/sentient_sword)Sentient Sword$() and a $(l:bloodmagic:demon_will/soul_gem)Tartaric Gem$() - these will make collecting $(l:bloodmagic:demon_will/demon_will)Demon Will$() much easier."
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/utility/getting_started.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/utility/getting_started.json
@@ -6,19 +6,31 @@
   "pages": [
     {
       "type": "text",
-      "text": "$(6)Blood Magic$() has quite a tightly tiered progression system. As you start off with nothing but your precious $(l:bloodmagic:altar/blood_altar)Blood Altar$() you'll find much of the mod is closed off to you. Eventually, we hope to include a tutorial and some level of tiering in the book, but as the mod is still in early Alpha for 1.16, we have decided to list things out here as best we can."
+      "text": "$(6)Blood Magic 3$()'s progression is still being reworked, and the first few steps are significantly different from Blood Magic 2's.$(br2)We do plan on adding better guideance, such as entry unlocking, but we are waiting until the progression is locked down.  In the mean time, here is a quick overview on how to progress in this alpha version of $(6)Blood Magic 3$()."
     },
     {
       "type": "spotlight",
-      "item": "bloodmagic:sacrificialdagger",
-      "title": "Tier Zero",
-      "text": "As mentioned, $(6)Blood Magic$() begins, perhaps unsurprisingly, with the $(l:bloodmagic:altar/blood_altar)Blood Altar$(). Here, you can begin making $(l:bloodmagic:demon_will/soul_snare)Soul Snares$(). These are used to get $(l:bloodmagic:demon_will/demon_will)Demon Will$(), which among other things is used to power the $(l:bloodmagic:demon_will/soul_forge)Hellfire Forge$(/l) and fill $(l:bloodmagic:demon_will/soul_gem)Tartaric Gems$()."
+      "item": "bloodmagic:altar",
+      "title": "Blood Altar (Tier-1)",
+      "text": "The first step of $(6)Blood Magic$() is to build a $(l:bloodmagic:altar/blood_altar)Blood Altar$() and $(l:bloodmagic:altar/blood_altar#knife)Sacrificial Knife$(). Use these to generate $(blood)LP$() from Self-Sacrificing.$(br2)Use this $(blood)LP$() to craft a $(l:bloodmagic:altar/soul_network)Weak Blood Orb$(), several $(l:bloodmagic:altar/slates)Blank Slates$(), and a few $(l:bloodmagic:demon_will/soul_snare)Soul Snares$()."
     },
     {
       "type": "spotlight",
-      "item": "bloodmagic:soulsword",
-      "title": "Tier One",
-      "text": "Once you have a source of $(l:bloodmagic:demon_will/demon_will)Demon Will$(), a $(l:bloodmagic:demon_will/soul_forge)Hellfire Forge$(/l) and a $(l:bloodmagic:altar/blood_altar)Blood Altar$(/l), you can create the $(l:bloodmagic:demon_will/sentient_sword)Sentient Sword$() for easier $(raw)Will$() gathering, and start collecting LP for the crafting of $(l:bloodmagic:altar/slates)Slates$() and various $(item)Sigils$(). $(l:bloodmagic:demon_will/throwing_daggers)Throwing Daggers$() may be of interest. Aim to upgrade your $(l:bloodmagic:demon_will/soul_gem)Tartaric Gems$() and your Blood Altar, the latter through the creation of $(l:bloodmagic:altar/blood_altar#blank_rune)Blank Runes$()."
+      "item": "bloodmagic:alchemytable",
+      "title": "Alchemy Table (Tier-1)",
+      "text": "The $(l:bloodmagic:alchemy_table/alchemy_table)Alchemy Table$() uses $(blood)LP$() from a player's $(blood)Soul Network$() (drawn from the $(l:bloodmagic:altar/soul_network)bound Blood Orb$() in it) to craft various different objects, such as:$(li)$(l:bloodmagic:alchemy_array/functional_arrays/arcane_ash)Arcane Ashes$()$(li)$(item)Reagents for Sigils$()$(li)$(item)Anointments$()$(li)$(thing)2x Ore Processing$()$(li)and various other odds and ends."
+    },
+    {
+      "type": "spotlight",
+      "item": "bloodmagic:arcaneashes",
+      "title": "Alchemy Array (Tier-1)",
+      "text": "An $(thing)Alchemy Array$() is made by placing some $(l:bloodmagic:alchemy_array/functional_arrays/arcane_ash)Arcane Ashes$() on the ground.  The Alchemy Array can have 2 items right clicked into it, and will either craft an item (such as a $(l:bloodmagic:alchemy_array/sigil/divination)Divination Sigil$()) or perform some kind of function (such as $(l:bloodmagic:alchemy_array/functional_arrays/time_arrays)turning day into night$())."
+    },
+    {
+      "type": "spotlight",
+      "item": "bloodmagic:soulforge",
+      "title": "Hellfire Forge (Tier-1)",
+      "text": "The $(l:bloodmagic:demon_will/soul_forge)Hellfire Forge$() crafts using $(l:bloodmagic:demon_will/demon_will)Demon Will$(). You get your first $(raw)Will$() by using $(l:bloodmagic:demon_will/soul_snare)Soul Snares$(), though upgrading to a $(l:bloodmagic:demon_will/sentient_sword)Sentient Sword$() is recommended. The $(item)Hellfire Forge$() is used for stuff directly related to $(raw)Demon Will$() (like $(l:bloodmagic:demon_will/soul_gem)Tartaric Gems$() and $(l:bloodmagic:demon_will/sentient_tools)Sentient Tools$()), and consumables (like $(l:bloodmagic:demon_will/explosive_charges)Explosive Charges$() and $(l:bloodmagic:demon_will/throwing_daggers)Throwing Daggers$())."
     },
     {
       "type": "spotlight",


### PR DESCRIPTION
Updated Getting Started Entry
* Replaced First Page.
* Removed Tier-0 Page
* Split Tier-1 into the 4 crafting mechanics; Blood Altar, Alchemy table, Alchemy Array, and Hellfire Forge.

Updated Soul Snare Entry
* Removed the first page.  Added a brief description under the crafting page (which is now the first page)
* Moved the picture of the Skeleton to after the description.

Sigil Page Order Tweak
* Affects Divination, Water, Lava, Green Grove, and Fast Miner Sigils.
* Moved the crafting page so it's the second page.  This makes them consistent with the rest of the Sigil entries.  This moves their previous image pages (which may no longer be needed) to the third page.
* Updated Extra Recipe Mappings to account for this move.

Note: "First Page" = page index 0.