### PR TITLE
update book.json for to simplify the work of translators

### DIFF
--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/book.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/book.json
@@ -1,7 +1,7 @@
 {
   "name": "guide.bloodmagic.name",
-  "subtitle": "Alchemical Wizardry",
-  "landing_text": "Welcome to $(6)Blood Magic$()! $(br2)$(l:bloodmagic:utility/nyi)A lot of stuff$() isn't yet implemented, so please excuse our dust. $(br2)Click $(l:bloodmagic:utility/getting_started)HERE$() to get started. If you find any bugs, please report them on our $(l:https://github.com/WayofTime/BloodMagic/issues)Github$().",
+  "subtitle": "guide.bloodmagic.subtitle",
+  "landing_text": "guide.bloodmagic.landing",
   "book_texture": "patchouli:textures/gui/book_red.png",
   "filler_texture": "bloodmagic:textures/gui/patchouli_book/page_filler.png",
   "creative_tab": "bloodmagictab",


### PR DESCRIPTION
lines "guide.bloodmagic.name", "guide.bloodmagic.subtitle", "guide.bloodmagic.landing" use in the lang.json file

for example 
"guide.bloodmagic.name": "Sanguine Scientiem",
 "guide.bloodmagic.subtitle": "Alchemical Wizardry",
 "guide.bloodmagic.landing": "Welcome to $(6)Blood Magic$()! $(br2)$(l:bloodmagic:utility/nyi)A lot of stuff$() isn't yet implemented, so please excuse our dust. $(br2)Click $(l:bloodmagic:utility/getting_started)HERE$() to get started. If you find any bugs, please report them on our $(l:https://github.com/WayofTime/BloodMagic/issues)Github$().)",