### PR TITLE
Book: Alchemy Table Entry Rewrite

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/compat/patchouli/processors/AlchemyTableProcessor.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/patchouli/processors/AlchemyTableProcessor.java
@@ -66,6 +66,8 @@ public class AlchemyTableProcessor implements IComponentProcessor
 			return IVariable.wrap(recipe.getSyphon());
 		case "time":
 			return IVariable.wrap(recipe.getTicks());
+		case "tier":
+			return IVariable.wrap(recipe.getMinimumTier());
 		case "orb":
 			switch (recipe.getMinimumTier())
 			{

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_table/alchemy_table.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_table/alchemy_table.json
@@ -3,17 +3,18 @@
   "icon": "bloodmagic:alchemytable",
   "category": "bloodmagic:alchemy_table",
   "extra_recipe_mappings":[
-    ["bloodmagic:plantoil", 8],
-    ["bloodmagic:coalsand", 9]
+    ["bloodmagic:plantoil", 10],
+    ["bloodmagic:coalsand",11]
   ],
   "pages": [
     {
       "type": "text",
-      "text": "The Alchemy Table takes a little LP and a few ingredients to do some wondrous things!$(br2)A lot of its content is NYI. $(br2)Mouse over the LP arrow for more info."
+      "text": "The $(item)Alchemy Table$() crafts items using $(blood)LP$() from a $(l:bloodmagic:altar/soul_network)Soul Network$(/l). The $(thing)Soul Network$() used and Tier of recipes available are determined by the $(item)Blood Orb$() inserted on the right side of the GUI. $(br2)The $(item)Alchemy Table$() is used to craft a handful of $(6)Blood Magic$() components, and provides alternate recipes for some vanilla items as well."
     },
     {
       "type": "crafting",
-      "recipe": "bloodmagic:alchemy_table"
+      "recipe": "bloodmagic:alchemy_table",
+      "text": "When looking at $(item)Alchemy Table$() recipes in this book (or $(thing)JEI$()), please hover over the arrow with an \"LP\" label to view Time, $(blood)LP$() drain, and Tier information."
     },
     {
       "type": "image",
@@ -38,7 +39,7 @@
       "heading": "Basic Cutting Fluid",
 	  "anchor": "cutting_fluid",
       "recipe": "bloodmagic:alchemytable/basic_cutting_fluid",
-      "text": "Basic Cutting Fluid is used for 2x Ore Processing.  It is also used in the $(l:bloodmagic:utility/alchemical_reaction_chamber)Alchemical Reaction Chamber$(/l) and the $(l:bloodmagic:rituals/ritual_list/ritual_crushing)Ritual of the Crusher$() for the same purpose." 
+      "text": "Basic Cutting Fluid is used for 2x Ore Processing.  It is also used in the $(l:bloodmagic:utility/alchemical_reaction_chamber)Alchemical Reaction Chamber$(/l) for the same purpose." 
     },
     {
       "type": "2x_crafting_alchemy_table",
@@ -46,10 +47,6 @@
       "a.recipe": "bloodmagic:alchemytable/sand_iron",
       "b.heading": "Gold Sand",
       "b.recipe": "bloodmagic:alchemytable/sand_gold"
-    },
-    {
-      "type": "text",
-      "text": "The Alchemy Table provides several ways to get vanilla items."
     },
     {
       "type": "3x_crafting_alchemy_table",

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_table/alchemy_table.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_table/alchemy_table.json
@@ -14,7 +14,7 @@
     {
       "type": "crafting",
       "recipe": "bloodmagic:alchemy_table",
-      "text": "When looking at $(item)Alchemy Table$() recipes in this book (or $(thing)JEI$()), please hover over the arrow with an \"LP\" label to view Time, $(blood)LP$() drain, and Tier information."
+      "text": "When looking at $(item)Alchemy Table$() recipes in this book (or in $(thing)JEI$()), please hover over the arrow with an \"LP\" label to view Time, $(blood)LP$() drain, and Tier information."
     },
     {
       "type": "image",
@@ -23,11 +23,11 @@
       ],
       "title": "Alchemy Table GUI",
       "border": true,
-      "text": "The Alchemy Table can be inserted into or extracted from. This is how it's configured."
+      "text": "The Alchemy Table can be inserted into or extracted from using these buttons."
     },
     {
       "type": "text",
-      "text": "The $(item)Alchemy Table$() has a number of buttons on its right hand side. These are, in order, $(underline)D$()own, $(underline)U$()p, $(underline)N$()orth, $(underline)S$()outh, $(underline)W$()est, and $(underline)e$()ast. To use them, first click on any slot in the Alchemy Table. (Here, we have selected the central 'finished item' slot, for demonstration.) Next, click on one of these six buttons to toggle whether or not the $(item)Alchemy Table$() should allow $(item)Hoppers$(), pipes, or other such external interference from this face. To return to the table's normal function,"
+      "text": "The $(item)Alchemy Table$() has a number of buttons on its right hand side. These are, in order, $(bold)D$()own, $(bold)U$()p, $(bold)N$()orth, $(bold)S$()outh, $(bold)W$()est, and $(bold)E$()ast. To use them, first click on any slot in the Alchemy Table. (Here, we have selected the central 'finished item' slot, for demonstration.) Next, click on one of these six buttons to toggle whether or not the $(item)Alchemy Table$() should allow $(item)Hoppers$(), pipes, or other such external interference from this face. To return to the table's normal function,"
     },
     {
       "type": "text",

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/demon_will/crystallized_will.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/demon_will/crystallized_will.json
@@ -36,11 +36,11 @@
       "type": "crafting_soulforge",
       "heading": "Demon Crystallizer",
       "recipe": "bloodmagic:soulforge/demon_crystallizer",
-      "text": "This will slowly consume $(l:bloodmagic:demon_will/demon_will)Demon Will$() from the atmosphere to produce $(item)Will Crystals$(). The first spire costs about 100 will to form, and all subsequent spires cost 40 each, but can be burned for 50 in the $(item)Demon Crucible$(). The largest $(item)Crystal Cluster$() can be up to 7 spires."
+      "text": "This will slowly consume $(l:bloodmagic:demon_will/demon_will)Demon Will$() from the atmosphere to produce $(item)Will Crystals$(). The first spire costs about 100 $(raw)Will$() to form, and all subsequent spires cost 40 each, but can be burned for 50 in the $(item)Demon Crucible$(). The largest $(item)Crystal Cluster$() can be up to 7 spires."
     },
     {
       "type": "text",
-      "text": "If you have at least 1,000 total Will in your inventory (Across any number of $(l:bloodmagic:demon_will/soul_gem)Tartaric Gems$()), you can harvest these crystals by right-clicking the spire with an empty hand. This will remove all but the central spire. $(br2)However, if you have not got this much will, $(italic)really$() need that central spire, or are just in a hurry, you can harvest the whole lot with a pickaxe."
+      "text": "If you have more than 1,024 total $(raw)Will$() in your inventory (Across any number of $(l:bloodmagic:demon_will/soul_gem)Tartaric Gems$()), you can harvest these crystals by right-clicking the spire with an empty hand. This will remove all but the central spire. $(br2)However, if you do not have enough $(raw)will$(), $(italic)really$() need that central spire, or are just in a hurry, you can harvest the whole lot with a pickaxe."
     },
     {
       "type": "relations",

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/templates/crafting_alchemy_table.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/templates/crafting_alchemy_table.json
@@ -87,7 +87,7 @@
     },
     {
       "type": "tooltip",
-      "tooltip": ["Cost: #syphon# LP", "Duration: #time# Ticks"],
+      "tooltip": ["Cost: #syphon# LP", "Duration: #time# Ticks", "Tier: #tier#+"],
       "x": 69,
       "y": 8,
       "width": 16,


### PR DESCRIPTION
* Rewrote the first page of the Alchemy Table entry to make it much clearer on how it works.
* Removed an incorrect statement about the Ritual of the Crusher (it does not use Cutting Fluid; it provides a similar effect using a Will augment, which I did not mention).
* Removed a (now duplicated info) page.
* Corrected Extra Recipe Mappings page references.
* Added Tier information to the Alchemy Table Recipe's tooltip.