### PR TITLE
Feature Redstone

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/altar/AltarUtil.java
+++ b/src/main/java/wayoftime/bloodmagic/altar/AltarUtil.java
@@ -12,8 +12,8 @@ import net.minecraft.block.material.Material;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import wayoftime.bloodmagic.impl.BloodMagicAPI;
 import wayoftime.bloodmagic.common.block.BlockBloodRune;
+import wayoftime.bloodmagic.impl.BloodMagicAPI;
 import wayoftime.bloodmagic.tile.TileAltar;
 
 public class AltarUtil
@@ -34,8 +34,7 @@ public class AltarUtil
 				BlockPos componentPos = pos.add(component.getOffset());
 				BlockState worldState = world.getBlockState(componentPos);
 
-				if (component.getComponent() == ComponentType.NOTAIR && worldState.getMaterial() != Material.AIR
-						&& !worldState.getMaterial().isLiquid())
+				if (component.getComponent() == ComponentType.NOTAIR && worldState.getMaterial() != Material.AIR && !worldState.getMaterial().isLiquid())
 					continue;
 
 				List<BlockState> validStates = BloodMagicAPI.INSTANCE.getComponentStates(component.getComponent());
@@ -80,8 +79,7 @@ public class AltarUtil
 			{
 				BlockPos componentPos = pos.add(component.getOffset());
 				BlockState worldState = world.getBlockState(componentPos);
-				if (component.getComponent() == ComponentType.NOTAIR && worldState.getMaterial() != Material.AIR
-						&& !worldState.getMaterial().isLiquid())
+				if (component.getComponent() == ComponentType.NOTAIR && worldState.getMaterial() != Material.AIR && !worldState.getMaterial().isLiquid())
 					continue;
 
 				List<BlockState> validStates = BloodMagicAPI.INSTANCE.getComponentStates(component.getComponent());

--- a/src/main/java/wayoftime/bloodmagic/altar/BloodAltar.java
+++ b/src/main/java/wayoftime/bloodmagic/altar/BloodAltar.java
@@ -3,6 +3,7 @@ package wayoftime.bloodmagic.altar;
 import com.google.common.base.Enums;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.block.RedstoneLampBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.particles.ParticleTypes;
@@ -290,16 +291,15 @@ public class BloodAltar// implements IFluidHandler
 		if (internalCounter % 100 == 0 && (this.isActive || this.cooldownAfterCrafting <= 0))
 			startCycle();
 
-		// add dedicated counter if the timing should be more precise
-		if (internalCounter % 100 == 0 && tileAltar.getOutputState())
-			tileAltar.setOutputState(false);
-
 		updateAltar();
 	}
 
 	private void updateAltar()
 	{
 //		System.out.println("Updating altar.");
+		if (tileAltar.getOutputState())
+			tileAltar.setOutputState(false);
+
 		if (!isActive)
 		{
 			if (cooldownAfterCrafting > 0)
@@ -381,7 +381,8 @@ public class BloodAltar// implements IFluidHandler
 					BloodMagicCraftedEvent.Altar event = new BloodMagicCraftedEvent.Altar(result, input.copy());
 					MinecraftForge.EVENT_BUS.post(event);
 					tileAltar.setInventorySlotContents(0, event.getOutput());
-					tileAltar.setOutputState(true);
+					if (tileAltar.getWorld().getBlockState(tileAltar.getPos().down()).getBlock() instanceof RedstoneLampBlock)
+						tileAltar.setOutputState(true);
 
 					progress = 0;
 

--- a/src/main/java/wayoftime/bloodmagic/altar/BloodAltar.java
+++ b/src/main/java/wayoftime/bloodmagic/altar/BloodAltar.java
@@ -756,6 +756,11 @@ public class BloodAltar// implements IFluidHandler
 		return currentTierDisplayed;
 	}
 
+	public int getAnalogSignalStrenght()
+	{
+		return getCurrentBlood() * 15 / getCapacity();
+	}
+
 	public static class VariableSizeFluidHandler implements IFluidHandler
 	{
 		BloodAltar altar;

--- a/src/main/java/wayoftime/bloodmagic/common/block/BlockAltar.java
+++ b/src/main/java/wayoftime/bloodmagic/common/block/BlockAltar.java
@@ -48,6 +48,19 @@ public class BlockAltar extends Block
 	}
 
 	@Override
+	public boolean hasComparatorInputOverride(BlockState state)
+	{
+		return true;
+	}
+
+	@Override
+	public int getComparatorInputOverride(BlockState state, World world, BlockPos pos)
+	{
+		TileAltar altar = (TileAltar) world.getTileEntity(pos);
+		return altar.getAnalogSignalStrength();
+	}
+
+	@Override
 	public ActionResultType onBlockActivated(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockRayTraceResult blockRayTraceResult)
 	{
 		TileAltar altar = (TileAltar) world.getTileEntity(pos);

--- a/src/main/java/wayoftime/bloodmagic/common/block/BlockAltar.java
+++ b/src/main/java/wayoftime/bloodmagic/common/block/BlockAltar.java
@@ -79,7 +79,7 @@ public class BlockAltar extends Block
 	@Override
 	public boolean canProvidePower(BlockState iBlockState)
 	{
-		return isRedstoneActive;
+		return true;
 	}
 
 	@Override

--- a/src/main/java/wayoftime/bloodmagic/common/block/BlockAltar.java
+++ b/src/main/java/wayoftime/bloodmagic/common/block/BlockAltar.java
@@ -25,7 +25,7 @@ import wayoftime.bloodmagic.util.Utils;
 public class BlockAltar extends Block
 {
 	protected static final VoxelShape BODY = Block.makeCuboidShape(0, 0, 0, 16, 12, 16);
-	private boolean isRedstoneActive = false;
+	public boolean isRedstoneActive = false;
 
 	public BlockAltar()
 	{
@@ -59,7 +59,7 @@ public class BlockAltar extends Block
 	@Override
 	public int getComparatorInputOverride(BlockState state, World world, BlockPos pos)
 	{
-		isRedstoneActive = false;
+		this.isRedstoneActive = false;
 		TileAltar altar = (TileAltar) world.getTileEntity(pos);
 		Block blockdown = world.getBlockState(pos.down()).getBlock();
 		int redstoneMode = 0;
@@ -70,7 +70,7 @@ public class BlockAltar extends Block
 		if (blockdown instanceof RedstoneLampBlock)
 		{
 			redstoneMode = 2;
-			isRedstoneActive = true;
+			this.isRedstoneActive = true;
 		}
 
 		return altar.getAnalogSignalStrength(redstoneMode);
@@ -79,7 +79,7 @@ public class BlockAltar extends Block
 	@Override
 	public boolean canProvidePower(BlockState iBlockState)
 	{
-		return true;
+		return isRedstoneActive;
 	}
 
 	@Override

--- a/src/main/java/wayoftime/bloodmagic/common/block/BlockAltar.java
+++ b/src/main/java/wayoftime/bloodmagic/common/block/BlockAltar.java
@@ -2,11 +2,13 @@ package wayoftime.bloodmagic.common.block;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.RedstoneLampBlock;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
@@ -23,6 +25,7 @@ import wayoftime.bloodmagic.util.Utils;
 public class BlockAltar extends Block
 {
 	protected static final VoxelShape BODY = Block.makeCuboidShape(0, 0, 0, 16, 12, 16);
+	private boolean isRedstoneActive = false;
 
 	public BlockAltar()
 	{
@@ -56,8 +59,48 @@ public class BlockAltar extends Block
 	@Override
 	public int getComparatorInputOverride(BlockState state, World world, BlockPos pos)
 	{
+		isRedstoneActive = false;
 		TileAltar altar = (TileAltar) world.getTileEntity(pos);
-		return altar.getAnalogSignalStrength();
+		Block blockdown = world.getBlockState(pos.down()).getBlock();
+		int redstoneMode = 0;
+
+		if (blockdown instanceof BloodstoneBlock)
+			redstoneMode = 1;
+
+		if (blockdown instanceof RedstoneLampBlock)
+		{
+			redstoneMode = 2;
+			isRedstoneActive = true;
+		}
+
+		return altar.getAnalogSignalStrength(redstoneMode);
+	}
+
+	@Override
+	public boolean canProvidePower(BlockState iBlockState)
+	{
+		return true;
+	}
+
+	@Override
+	public int getWeakPower(BlockState blockState, IBlockReader blockReader, BlockPos pos, Direction dir)
+	{
+		boolean isOutputOn = false;
+		TileEntity tileentity = blockReader.getTileEntity(pos);
+		if (tileentity instanceof TileAltar)
+		{
+			TileAltar altar = (TileAltar) tileentity;
+			isOutputOn = altar.getOutputState();
+		}
+
+		final int OUTPUT_POWER_WHEN_ON = 15;
+		return isOutputOn ? OUTPUT_POWER_WHEN_ON : 0;
+	}
+
+	@Override
+	public int getStrongPower(BlockState blockState, IBlockReader blockReader, BlockPos pos, Direction dir)
+	{
+		return 0;
 	}
 
 	@Override

--- a/src/main/java/wayoftime/bloodmagic/common/block/BloodMagicBlocks.java
+++ b/src/main/java/wayoftime/bloodmagic/common/block/BloodMagicBlocks.java
@@ -79,8 +79,8 @@ public class BloodMagicBlocks
 	public static final RegistryObject<Block> DUSK_RITUAL_STONE = BLOCKS.register("duskritualstone", () -> new BlockRitualStone(EnumRuneType.DUSK));
 	public static final RegistryObject<Block> DAWN_RITUAL_STONE = BLOCKS.register("lightritualstone", () -> new BlockRitualStone(EnumRuneType.DAWN));
 
-	public static final RegistryObject<Block> BLOODSTONE = BASICBLOCKS.register("largebloodstonebrick", () -> new Block(Properties.create(Material.ROCK).hardnessAndResistance(2.0F, 5.0F).sound(SoundType.STONE).harvestTool(ToolType.PICKAXE).harvestLevel(1)));
-	public static final RegistryObject<Block> BLOODSTONE_BRICK = BASICBLOCKS.register("bloodstonebrick", () -> new Block(Properties.create(Material.ROCK).hardnessAndResistance(2.0F, 5.0F).sound(SoundType.STONE).harvestTool(ToolType.PICKAXE).harvestLevel(1)));
+	public static final RegistryObject<Block> BLOODSTONE = BASICBLOCKS.register("largebloodstonebrick", () -> new BloodstoneBlock());
+	public static final RegistryObject<Block> BLOODSTONE_BRICK = BASICBLOCKS.register("bloodstonebrick", () -> new BloodstoneBlock());
 
 	public static final RegistryObject<Block> MASTER_RITUAL_STONE = BASICBLOCKS.register("masterritualstone", () -> new BlockMasterRitualStone(false));
 

--- a/src/main/java/wayoftime/bloodmagic/common/block/BloodstoneBlock.java
+++ b/src/main/java/wayoftime/bloodmagic/common/block/BloodstoneBlock.java
@@ -1,13 +1,22 @@
 package wayoftime.bloodmagic.common.block;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.SoundType;
+import net.minecraft.block.AbstractBlock.Properties;
 import net.minecraft.block.material.Material;
+import net.minecraftforge.common.ToolType;
 
 public class BloodstoneBlock extends Block
 {
 	public BloodstoneBlock() 
 	{
-		super(Properties.create(Material.ROCK));
+		super(Properties
+				.create(Material.ROCK)
+				.hardnessAndResistance(2.0F, 5.0F)
+				.sound(SoundType.STONE)
+				.harvestTool(ToolType.PICKAXE)
+				.harvestLevel(1));
+
 		// TODO Auto-generated constructor stub
 	}
 }

--- a/src/main/java/wayoftime/bloodmagic/tile/TileAltar.java
+++ b/src/main/java/wayoftime/bloodmagic/tile/TileAltar.java
@@ -47,9 +47,6 @@ public class TileAltar extends TileInventory implements IBloodAltar, ITickableTi
 	{
 		BlockAltar altar = (BlockAltar) this.getWorld().getBlockState(pos).getBlock();
 
-		if (state && !(altar.isRedstoneActive))
-			state = false;
-
 		this.isOutputOn = state;
 		this.world.notifyNeighborsOfStateChange(pos, altar);
 	}

--- a/src/main/java/wayoftime/bloodmagic/tile/TileAltar.java
+++ b/src/main/java/wayoftime/bloodmagic/tile/TileAltar.java
@@ -45,8 +45,13 @@ public class TileAltar extends TileInventory implements IBloodAltar, ITickableTi
 
 	public void setOutputState(boolean state)
 	{
+		BlockAltar altar = (BlockAltar) this.getWorld().getBlockState(pos).getBlock();
+
+		if (state && !(altar.isRedstoneActive))
+			state = false;
+
 		this.isOutputOn = state;
-		this.world.notifyNeighborsOfStateChange(pos, (BlockAltar) this.getWorld().getBlockState(pos).getBlock());
+		this.world.notifyNeighborsOfStateChange(pos, altar);
 	}
 
 	@Override

--- a/src/main/java/wayoftime/bloodmagic/tile/TileAltar.java
+++ b/src/main/java/wayoftime/bloodmagic/tile/TileAltar.java
@@ -210,6 +210,7 @@ public class TileAltar extends TileInventory implements IBloodAltar, ITickableTi
 	{
 		return bloodAltar.setCurrentTierDisplayed(altarTier);
 	}
+
 //
 //	@Override
 //	public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable Direction facing)
@@ -221,6 +222,10 @@ public class TileAltar extends TileInventory implements IBloodAltar, ITickableTi
 //
 //		return super.hasCapability(capability, facing);
 //	}
+	public int getAnalogSignalStrength()
+	{
+		return bloodAltar.getCurrentBlood() * 15 / bloodAltar.getCapacity();
+	}
 
 	@Override
 	protected void invalidateCaps()

--- a/src/main/java/wayoftime/bloodmagic/tile/TileAltar.java
+++ b/src/main/java/wayoftime/bloodmagic/tile/TileAltar.java
@@ -15,6 +15,7 @@ import net.minecraftforge.registries.ObjectHolder;
 import wayoftime.bloodmagic.altar.AltarTier;
 import wayoftime.bloodmagic.altar.BloodAltar;
 import wayoftime.bloodmagic.altar.IBloodAltar;
+import wayoftime.bloodmagic.common.block.BlockAltar;
 
 public class TileAltar extends TileInventory implements IBloodAltar, ITickableTileEntity
 {
@@ -23,16 +24,29 @@ public class TileAltar extends TileInventory implements IBloodAltar, ITickableTi
 	private BloodAltar bloodAltar;
 
 	private LazyOptional fluidOptional;
+	private boolean isOutputOn;
 
 	public TileAltar(TileEntityType<?> type)
 	{
 		super(type, 1, "altar");
 		this.bloodAltar = new BloodAltar(this);
+		this.isOutputOn = false;
 	}
 
 	public TileAltar()
 	{
 		this(TYPE);
+	}
+
+	public boolean getOutputState()
+	{
+		return this.isOutputOn;
+	}
+
+	public void setOutputState(boolean state)
+	{
+		this.isOutputOn = state;
+		this.world.notifyNeighborsOfStateChange(pos, (BlockAltar) this.getWorld().getBlockState(pos).getBlock());
 	}
 
 	@Override
@@ -222,9 +236,9 @@ public class TileAltar extends TileInventory implements IBloodAltar, ITickableTi
 //
 //		return super.hasCapability(capability, facing);
 //	}
-	public int getAnalogSignalStrength()
+	public int getAnalogSignalStrength(int redstoneMode)
 	{
-		return bloodAltar.getCurrentBlood() * 15 / bloodAltar.getCapacity();
+		return bloodAltar.getAnalogSignalStrenght(redstoneMode);
 	}
 
 	@Override


### PR DESCRIPTION
# Redstone Implementation
Implemented behavior of the altar to the redstone, as reported in the manual.

According to the block below the altar
| Block| Effect | 
| -------- | ---------- | 
| Default  | Comparator Reads LP | 
| Bloodstone| Comparator reads network LP of the Player's Orb inside the altar | 
| RedstoneLamp | Triggers a softPower (15) 1 tick signal when a crafting operation ends |

## Changes
- The Block checks the current redstone mode, Default and Bloodstone mode are managed in the `BloodAltar.java` class, RedstoneLamp in `TileBloodAltar.java`

- Moved Properties of Bloodstone (for brick and stone)  from `BloodMagicBlocks.java` to `BloodstoneBlock.java` as a standalone class, now used to check if the block below the altar is Bloodstone