### PR TITLE
Add Elytra Upgrade for Living Armor

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/BloodMagic.java
+++ b/src/main/java/wayoftime/bloodmagic/BloodMagic.java
@@ -1,11 +1,15 @@
 package wayoftime.bloodmagic;
 
+import java.util.Map;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.google.gson.Gson;
 
 import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.entity.PlayerRenderer;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.ItemGroup;
@@ -41,6 +45,7 @@ import wayoftime.bloodmagic.client.hud.Elements;
 import wayoftime.bloodmagic.client.key.BloodMagicKeyHandler;
 import wayoftime.bloodmagic.client.key.KeyBindings;
 import wayoftime.bloodmagic.client.model.MimicModelLoader;
+import wayoftime.bloodmagic.client.render.entity.layers.BloodElytraLayer;
 import wayoftime.bloodmagic.common.block.BloodMagicBlocks;
 import wayoftime.bloodmagic.common.data.GeneratorBaseRecipes;
 import wayoftime.bloodmagic.common.data.GeneratorBlockStates;
@@ -323,6 +328,12 @@ public class BloodMagic
 //		IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
 //		
 
+		Map<String, PlayerRenderer> skinMap = Minecraft.getInstance().getRenderManager().getSkinMap();
+		PlayerRenderer render;
+		render = skinMap.get("default");
+		render.addLayer(new BloodElytraLayer(render));
+		render = skinMap.get("slim");
+		render.addLayer(new BloodElytraLayer(render));
 	}
 
 	private void registerColors(final ColorHandlerEvent event)

--- a/src/main/java/wayoftime/bloodmagic/client/render/entity/layers/BloodElytraLayer.java
+++ b/src/main/java/wayoftime/bloodmagic/client/render/entity/layers/BloodElytraLayer.java
@@ -1,0 +1,37 @@
+package wayoftime.bloodmagic.client.render.entity.layers;
+
+import net.minecraft.client.renderer.entity.IEntityRenderer;
+import net.minecraft.client.renderer.entity.layers.ElytraLayer;
+import net.minecraft.client.renderer.entity.model.EntityModel;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import wayoftime.bloodmagic.common.item.ItemLivingArmor;
+import wayoftime.bloodmagic.core.LivingArmorRegistrar;
+import wayoftime.bloodmagic.core.living.LivingStats;
+import wayoftime.bloodmagic.core.living.LivingUtil;
+
+public class BloodElytraLayer<T extends LivingEntity, M extends EntityModel<T>> extends ElytraLayer<T, M>
+{
+	private static final ResourceLocation TEXTURE_BLOOD_ELYTRA = new ResourceLocation("bloodmagic", "textures/entities/bloodelytra.png");
+
+	public BloodElytraLayer(IEntityRenderer rendererIn)
+	{
+		super(rendererIn);
+	}
+
+	@Override
+	public boolean shouldRender(ItemStack stack, T entity)
+	{
+		if (stack.getItem() instanceof ItemLivingArmor && entity instanceof PlayerEntity && LivingUtil.hasFullSet((PlayerEntity) entity))
+			return LivingStats.fromPlayer((PlayerEntity) entity).getLevel(LivingArmorRegistrar.UPGRADE_ELYTRA.get().getKey()) > 0;
+		return false;
+	}
+
+	@Override
+	public ResourceLocation getElytraTexture(ItemStack stack, T entity)
+	{
+		return TEXTURE_BLOOD_ELYTRA;
+	}
+}

--- a/src/main/java/wayoftime/bloodmagic/common/item/ItemLivingArmor.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/ItemLivingArmor.java
@@ -12,6 +12,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.attributes.Attribute;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ArmorItem;
 import net.minecraft.item.Item;
@@ -23,11 +24,14 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.common.extensions.IForgeItem;
 import wayoftime.bloodmagic.BloodMagic;
+import wayoftime.bloodmagic.core.LivingArmorRegistrar;
 import wayoftime.bloodmagic.core.living.ILivingContainer;
 import wayoftime.bloodmagic.core.living.LivingStats;
+import wayoftime.bloodmagic.core.living.LivingUtil;
 
-public class ItemLivingArmor extends ArmorItem implements ILivingContainer, ExpandedArmor
+public class ItemLivingArmor extends ArmorItem implements ILivingContainer, ExpandedArmor, IForgeItem
 {
 
 	private static final int MAX_ABSORPTION = 100000;
@@ -190,5 +194,27 @@ public class ItemLivingArmor extends ArmorItem implements ILivingContainer, Expa
 	public void addInformation(ItemStack stack, World world, List<ITextComponent> tooltip, ITooltipFlag flag)
 	{
 		ILivingContainer.appendLivingTooltip(getLivingStats(stack), tooltip, true);
+	}
+
+	@Override
+	public boolean canElytraFly(ItemStack stack, LivingEntity entity)
+	{
+		return hasElytraUpgrade(stack, entity) && stack.getDamage() < stack.getMaxDamage() - 1;
+	}
+
+	@Override
+	public boolean elytraFlightTick(ItemStack stack, LivingEntity entity, int flightTicks)
+	{
+		if (!entity.world.isRemote && (flightTicks + 1) % 40 == 0)
+			stack.damageItem(1, entity, e -> e.sendBreakAnimation(net.minecraft.inventory.EquipmentSlotType.CHEST));
+		return true;
+	}
+
+	public boolean hasElytraUpgrade(ItemStack stack, LivingEntity entity)
+	{
+		if (stack.getItem() instanceof ItemLivingArmor && entity instanceof PlayerEntity && LivingUtil.hasFullSet((PlayerEntity) entity))
+			return LivingStats.fromPlayer((PlayerEntity) entity).getLevel(LivingArmorRegistrar.UPGRADE_ELYTRA.get().getKey()) > 0;
+		else
+			return false;
 	}
 }

--- a/src/main/java/wayoftime/bloodmagic/core/LivingArmorRegistrar.java
+++ b/src/main/java/wayoftime/bloodmagic/core/LivingArmorRegistrar.java
@@ -55,6 +55,7 @@ public class LivingArmorRegistrar
 		def.put("sprint_attack", BloodMagic.rl("sprint_attack"));
 		def.put("speed", BloodMagic.rl("speed"));
 		def.put("self_sacrifice", BloodMagic.rl("self_sacrifice"));
+		def.put("elytra", BloodMagic.rl("elytra"));
 		def.put("downgrade/quenched", BloodMagic.rl("downgrade/quenched"));
 		return def;
 	}).get();
@@ -118,6 +119,7 @@ public class LivingArmorRegistrar
 		attributeMap.put(Attributes.KNOCKBACK_RESISTANCE, new AttributeModifier(uuid, "KB Modifier", upgrade.getBonusValue("kb", level).doubleValue(), AttributeModifier.Operation.ADDITION));
 		attributeMap.put(Attributes.MAX_HEALTH, new AttributeModifier(uuid, "Health Modifier 2", upgrade.getBonusValue("hp", level).intValue(), AttributeModifier.Operation.ADDITION));
 	}));
+	public static final LivingUpgradeRegistryObject<LivingUpgrade> UPGRADE_ELYTRA = UPGRADES.register("elytra", () -> parseDefinition("elytra"));
 	public static final LivingUpgradeRegistryObject<LivingUpgrade> DOWNGRADE_QUENCHED = UPGRADES.register("downgrade/quenched", () -> parseDefinition("downgrade/quenched").asDowngrade());
 
 //	public static final LivingUpgrade UPGRADE_ARROW_PROTECT = parseDefinition("arrow_protect").withArmorProvider((player, stats, source, upgrade, level) -> {
@@ -150,6 +152,7 @@ public class LivingArmorRegistrar
 		registerUpgrade(UPGRADE_JUMP.get());
 		registerUpgrade(UPGRADE_KNOCKBACK_RESIST.get());
 		registerUpgrade(UPGRADE_FIRE_RESIST.get());
+		registerUpgrade(UPGRADE_ELYTRA.get());
 		registerUpgrade(DOWNGRADE_QUENCHED.get());
 //		Registry.register(UPGRADES, UPGRADE_ARROW_PROTECT.getKey(), UPGRADE_ARROW_PROTECT);
 //		Registry.register(UPGRADES, UPGRADE_ARROW_SHOT.getKey(), UPGRADE_ARROW_SHOT);

--- a/src/main/resources/data/bloodmagic/living_armor/elytra.json
+++ b/src/main/resources/data/bloodmagic/living_armor/elytra.json
@@ -1,0 +1,6 @@
+{
+  "id": "bloodmagic:elytra",
+  "levels": [
+    { "xp": 1, "cost": 15 }
+  ]
+}

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armor_upgrades/elytra.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armor_upgrades/elytra.json
@@ -1,0 +1,17 @@
+{
+  "name": "Elytra",
+  "icon": "minecraft:elytra",
+  "category": "bloodmagic:alchemy_array/living_equipment/armor_upgrades",
+  "pages": [
+    {
+      "type": "text",
+      "text": "Adds an Elytra to your Living Armor. Rather than being trained, the $(l:bloodmagic:alchemy_array/living_equipment/living_tomes)Upgrade Tome$() must be crafted. $(br2)This Elytra does drain durability from the Chestplate, but at half the speed of a normal Elytra. $(br2)It also looks pretty neat."
+    },
+    {
+      "type": "bloodmagic:crafting_upgrade_array",
+      "a.heading": "Elytra Tome",
+      "a.recipe": "bloodmagic:array/living_elytra_upgrade",
+      "b.upgrade": "bloodmagic:elytra"
+    }
+  ]
+}

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/templates/crafting_upgrade_array.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/templates/crafting_upgrade_array.json
@@ -1,0 +1,16 @@
+{
+  "include": [
+    {
+      "template": "crafting_array",
+      "as": "a",
+      "x": 0,
+      "y": 0
+    },
+    {
+      "template": "living_armour_upgrade_table",
+      "as": "b",
+      "x": 0,
+      "y": 65
+    }
+  ]
+}

--- a/src/main/resources/data/bloodmagic/recipes/array/living_elytra_upgrade.json
+++ b/src/main/resources/data/bloodmagic/recipes/array/living_elytra_upgrade.json
@@ -1,0 +1,14 @@
+{
+  "type": "bloodmagic:array",
+  "texture": "bloodmagic:textures/models/alchemyarrays/bindingarray.png",
+  "baseinput": {
+    "item": "bloodmagic:reagentbinding"
+  },
+  "addedinput": {
+    "item": "minecraft:elytra"
+  },
+  "output": {
+    "item": "bloodmagic:upgradetome",
+    "nbt": "{livingStats: {maxPoints: 15, upgrades: [{exp: 1.0d, key: \"bloodmagic:elytra\"}]}}"
+  }
+}


### PR DESCRIPTION
* Upgrade Tome crafted by using Arcane Ash to combine Binding Reagent and an Elytra.  Due to confusion with the data generator, this recipe is currently made by hand (not generated).
* The upgrade matches vanilla Elytra mechanics, though has the unique base texture from 1.12.
* When in use, durability is drained from the Chestplate, but at half the rate the vanilla Elytra does (1 point every 40 ticks rather than 20).
* There is only a single level for this upgrade, and it costs 15 Upgrade Points.
* Documentation in Patchouli is included, though Wrince may want to review it before release.