### PR TITLE
Fix Blood Elytra from crashing if the Living Armor Stats aren't…

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/item/ItemLivingArmor.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/ItemLivingArmor.java
@@ -29,7 +29,6 @@ import wayoftime.bloodmagic.BloodMagic;
 import wayoftime.bloodmagic.core.LivingArmorRegistrar;
 import wayoftime.bloodmagic.core.living.ILivingContainer;
 import wayoftime.bloodmagic.core.living.LivingStats;
-import wayoftime.bloodmagic.core.living.LivingUtil;
 
 public class ItemLivingArmor extends ArmorItem implements ILivingContainer, ExpandedArmor, IForgeItem
 {
@@ -220,9 +219,14 @@ public class ItemLivingArmor extends ArmorItem implements ILivingContainer, Expa
 
 	public boolean hasElytraUpgrade(ItemStack stack, LivingEntity entity)
 	{
-		if (stack.getItem() instanceof ItemLivingArmor && entity instanceof PlayerEntity && LivingUtil.hasFullSet((PlayerEntity) entity))
-			return LivingStats.fromPlayer((PlayerEntity) entity).getLevel(LivingArmorRegistrar.UPGRADE_ELYTRA.get().getKey()) > 0;
-		else
-			return false;
+		if (entity instanceof PlayerEntity)
+		{
+			LivingStats playerLivingStats = LivingStats.fromPlayer((PlayerEntity) entity);
+			if (playerLivingStats != null)
+			{
+				return playerLivingStats.getLevel(LivingArmorRegistrar.UPGRADE_ELYTRA.get().getKey()) > 0;
+			}
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
…Initialized when hasElytraUpgrade is checked

Also slightly streamlined the checks.

This should fix the issue with Caelus checking canElytraFly as soon as a fresh Living Armor Chestplate is equipped.

#1855, #1853