### PR TITLE
Fix Error if full equipping armor

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/item/ItemLivingArmor.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/ItemLivingArmor.java
@@ -221,7 +221,7 @@ public class ItemLivingArmor extends ArmorItem implements ILivingContainer, Expa
 	public boolean hasElytraUpgrade(ItemStack stack, LivingEntity entity)
 	{
 		if (stack.getItem() instanceof ItemLivingArmor && entity instanceof PlayerEntity && LivingUtil.hasFullSet((PlayerEntity) entity))
-			return LivingStats.fromPlayer((PlayerEntity) entity).getLevel(LivingArmorRegistrar.UPGRADE_ELYTRA.get().getKey()) > 0;
+			return LivingStats.fromPlayer((PlayerEntity) entity, true).getLevel(LivingArmorRegistrar.UPGRADE_ELYTRA.get().getKey()) > 0;
 		else
 			return false;
 	}


### PR DESCRIPTION
Fixes #1853 does the same as #1856, but maybe a little more 'elegant'. It seems the stats had yet to be created when this function tried to reach it; not sure if it should've already existed or it should be like this.