### PR TITLE
Controlled Charges no longer destroy bedrock.

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/tile/TileVeinMineCharge.java
+++ b/src/main/java/wayoftime/bloodmagic/tile/TileVeinMineCharge.java
@@ -275,7 +275,7 @@ public class TileVeinMineCharge extends TileExplosiveCharge
 
 	public boolean isValidStartingBlock(BlockState originalBlockState)
 	{
-		return true;
+		return originalBlockState.getBlockHardness(world, pos) != -1.0F;
 	}
 
 	public boolean checkDiagonals()


### PR DESCRIPTION
Fixes #1789 by checking if the starting block's hardness is -1.0F when it checks if the starting block is valid, rather than assume it is valid.