### PR TITLE
LA Downgrades: Book Code

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/compat/patchouli/RegisterPatchouliMultiblocks.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/patchouli/RegisterPatchouliMultiblocks.java
@@ -49,6 +49,7 @@ public class RegisterPatchouliMultiblocks
 		List<Ritual> rituals = BloodMagic.RITUAL_MANAGER.getSortedRituals();
 		for (Ritual ritual : rituals)
 		{
+			String ritualID = BloodMagic.RITUAL_MANAGER.getId(ritual);
 			Map<BlockPos, EnumRuneType> ritualMap = Maps.newHashMap();
 			List<RitualComponent> components = Lists.newArrayList();
 			ritual.gatherComponents(components::add);
@@ -62,9 +63,17 @@ public class RegisterPatchouliMultiblocks
 
 			String[][] pattern = makePattern(ritualMap, Collections.emptyMap());
 
+			// Manual Overrides (to add things like Chests).
+			// stringDumper(pattern) will dump the current String Array to the log.
+			if (ritualID.equals("downgrade"))
+			{
+				pattern[2][3] = "_FDC______"; // add Chest
+			}
+
 			// @formatter:off
 			IMultiblock multiblock = patAPI.makeMultiblock(
 					pattern,
+					'0', BloodMagicBlocks.MASTER_RITUAL_STONE.get(),
 					'B', BloodMagicBlocks.BLANK_RITUAL_STONE.get(),
 					'W', BloodMagicBlocks.WATER_RITUAL_STONE.get(),
 					'F', BloodMagicBlocks.FIRE_RITUAL_STONE.get(),
@@ -72,11 +81,11 @@ public class RegisterPatchouliMultiblocks
 					'A', BloodMagicBlocks.AIR_RITUAL_STONE.get(),
 					'D', BloodMagicBlocks.DUSK_RITUAL_STONE.get(),
 					'd', BloodMagicBlocks.DAWN_RITUAL_STONE.get(),
-					'0', BloodMagicBlocks.MASTER_RITUAL_STONE.get()
+					'C', Blocks.CHEST
 			); 
 			// @formatter:on
 
-			patAPI.registerMultiblock(new ResourceLocation(BloodMagic.MODID, BloodMagic.RITUAL_MANAGER.getId(ritual)), multiblock);
+			patAPI.registerMultiblock(new ResourceLocation(BloodMagic.MODID, ritualID), multiblock);
 		}
 
 		// Blood Altars
@@ -297,6 +306,20 @@ public class RegisterPatchouliMultiblocks
 		public TriPredicate<IBlockReader, BlockPos, BlockState> getStatePredicate()
 		{
 			return (w, p, s) -> valid.contains(s);
+		}
+	}
+
+	// A quick Dev utility to dump a multiblock's String Array to the log.
+	private void stringDumper(String[][] pattern)
+	{
+		System.out.println("Dev Test: Multiblock String Dumper");
+		for (int i = 0; i < pattern.length; i++)
+		{
+			for (int j = 0; j < pattern[i].length; j++)
+			{
+				System.out.println(String.format("pattern[%d][%d] = \"%s\";", i, j, pattern[i][j]));
+			}
+			System.out.println(""); // blank line to indicate a new Y level.
 		}
 	}
 }

--- a/src/main/java/wayoftime/bloodmagic/compat/patchouli/processors/LivingArmourDowngradeRecipeProcessor.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/patchouli/processors/LivingArmourDowngradeRecipeProcessor.java
@@ -1,0 +1,64 @@
+package wayoftime.bloodmagic.compat.patchouli.processors;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.util.ResourceLocation;
+import vazkii.patchouli.api.IComponentProcessor;
+import vazkii.patchouli.api.IVariable;
+import vazkii.patchouli.api.IVariableProvider;
+import wayoftime.bloodmagic.common.recipe.BloodMagicRecipeType;
+import wayoftime.bloodmagic.recipe.RecipeLivingDowngrade;
+
+/*
+ * Example Page:
+ * 
+ * {
+ *   "type": "crafting_downgrade",    // Corresponding Template.
+ *   "heading": "Title",    // (Optional) Title.
+ *   "recipe": "recipe_id",    // Recipe ID.
+ *   "text":  "Extra text."    //(Optional) Extra text to go under the entry.
+ * },
+ */
+
+public class LivingArmourDowngradeRecipeProcessor implements IComponentProcessor
+{
+	private RecipeLivingDowngrade recipe;
+
+	@Override
+	public void setup(IVariableProvider variables)
+	{
+		ResourceLocation id = new ResourceLocation(variables.get("recipe").asString());
+		Optional<? extends IRecipe<?>> recipeHandler = Minecraft.getInstance().world.getRecipeManager().getRecipe(id);
+		if (recipeHandler.isPresent())
+		{
+			IRecipe<?> recipe = recipeHandler.get();
+			if (recipe.getType().equals(BloodMagicRecipeType.LIVINGDOWNGRADE))
+			{
+				this.recipe = (RecipeLivingDowngrade) recipe;
+			}
+		}
+		if (this.recipe == null)
+		{
+			LogManager.getLogger().warn("Guidebook missing Blood Altar recipe{}", id);
+		}
+	}
+
+	@Override
+	public IVariable process(String key)
+	{
+		if (recipe == null)
+		{
+			return null;
+		}
+		if (key.equals("input"))
+			return IVariable.wrapList(Arrays.stream(recipe.getInput().getMatchingStacks()).map(IVariable::from).collect(Collectors.toList()));
+		else
+			return null;
+	}
+}

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/battle_hungry.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/battle_hungry.json
@@ -7,14 +7,10 @@
       "type": "text",
       "text": "Gives you hunger if you haven't attacked something recently. Higher levels give you a shorter cooldown window and make the hunger worse."
     },
-
     {
-      "type": "text",
-      "text": "TODO: Recipe page."
-    },
-    {
-      "type": "bloodmagic:living_armour_upgrade_table",
-      "upgrade": "bloodmagic:battle_hungry"
+      "type": "living_armour_downgrade",
+      "a.recipe": "bloodmagic:downgrade/battle_hungry",
+      "b.upgrade": "bloodmagic:battle_hungry"
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/crippled_arm.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/crippled_arm.json
@@ -7,14 +7,10 @@
       "type": "text",
       "text": "Effect: Prevents you from using your offhand item. This includes placing torches, raising your shield, etc."
     },
-
     {
-      "type": "text",
-      "text": "TODO: Recipe page."
-    },
-    {
-      "type": "bloodmagic:living_armour_upgrade_table",
-      "upgrade": "bloodmagic:crippled_arm"
+      "type": "living_armour_downgrade",
+      "a.recipe": "bloodmagic:downgrade/crippled_arm",
+      "b.upgrade": "bloodmagic:crippled_arm"
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/dig_slowdown.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/dig_slowdown.json
@@ -7,14 +7,10 @@
       "type": "text",
       "text": "Effect: Reduces your dig speed. Caps out at an 80% reduction."
     },
-
     {
-      "type": "text",
-      "text": "TODO: Recipe page."
-    },
-    {
-      "type": "bloodmagic:living_armour_upgrade_table",
-      "upgrade": "bloodmagic:dig_slowdown"
+      "type": "living_armour_downgrade",
+      "a.recipe": "bloodmagic:downgrade/dig_slowdown",
+      "b.upgrade": "bloodmagic:dig_slowdown"
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/melee_decrease.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/melee_decrease.json
@@ -7,14 +7,10 @@
       "type": "text",
       "text": "Reduces your melee damage. Caps out at an 80% reduction."
     },
-
     {
-      "type": "text",
-      "text": "TODO: Recipe page."
-    },
-    {
-      "type": "bloodmagic:living_armour_upgrade_table",
-      "upgrade": "bloodmagic:melee_decrease"
+      "type": "living_armour_downgrade",
+      "a.recipe": "bloodmagic:downgrade/melee_decrease",
+      "b.upgrade": "bloodmagic:melee_decrease"
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/quenched.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/quenched.json
@@ -7,14 +7,10 @@
       "type": "text",
       "text": "Prevents you from drinking any potions whilst wearing the armour."
     },
-
     {
-      "type": "text",
-      "text": "TODO: Recipe page."
-    },
-    {
-      "type": "bloodmagic:living_armour_upgrade_table",
-      "upgrade": "bloodmagic:quenched"
+      "type": "living_armour_downgrade",
+      "a.recipe": "bloodmagic:downgrade/quenched",
+      "b.upgrade": "bloodmagic:quenched"
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/slow_heal.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/slow_heal.json
@@ -7,14 +7,10 @@
       "type": "text",
       "text": "Reduces the effectiveness of all healing sources. Caps out at 80%, so a source that would normally heal 10 hearts will only heal 2."
     },
-
     {
-      "type": "text",
-      "text": "TODO: Recipe page."
-    },
-    {
-      "type": "bloodmagic:living_armour_upgrade_table",
-      "upgrade": "bloodmagic:slow_heal"
+      "type": "living_armour_downgrade",
+      "a.recipe": "bloodmagic:downgrade/slow_heal",
+      "b.upgrade": "bloodmagic:slow_heal"
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/speed_decrease.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/speed_decrease.json
@@ -7,14 +7,10 @@
       "type": "text",
       "text": "Effect: ??? $(br2)Maximum level: 5"
     },
-
     {
-      "type": "text",
-      "text": "TODO: Recipe page."
-    },
-    {
-      "type": "bloodmagic:living_armour_upgrade_table",
-      "upgrade": "bloodmagic:speed_decrease"
+      "type": "living_armour_downgrade",
+      "a.recipe": "bloodmagic:downgrade/speed_decrease",
+      "b.upgrade": "bloodmagic:speed_decrease"
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/storm_trooper.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/storm_trooper.json
@@ -7,14 +7,10 @@
       "type": "text",
       "text": "Makes you wildly inaccurate when shooting bows and crossbows."
     },
-
     {
-      "type": "text",
-      "text": "TODO: Recipe page."
-    },
-    {
-      "type": "bloodmagic:living_armour_upgrade_table",
-      "upgrade": "bloodmagic:storm_trooper"
+      "type": "living_armour_downgrade",
+      "a.recipe": "bloodmagic:downgrade/storm_trooper",
+      "b.upgrade": "bloodmagic:storm_trooper"
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/swim_decrease.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armour_downgrades/swim_decrease.json
@@ -7,14 +7,10 @@
       "type": "text",
       "text": "Reduces your swim speed significantly. Caps out at an 80% reduction."
     },
-
     {
-      "type": "text",
-      "text": "TODO: Recipe page."
-    },
-    {
-      "type": "bloodmagic:living_armour_upgrade_table",
-      "upgrade": "bloodmagic:swim_decrease"
+      "type": "living_armour_downgrade",
+      "a.recipe": "bloodmagic:downgrade/swim_decrease",
+      "b.upgrade": "bloodmagic:swim_decrease"
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/templates/crafting_living_armour_downgrade.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/templates/crafting_living_armour_downgrade.json
@@ -1,0 +1,40 @@
+{
+  "processor": "wayoftime.bloodmagic.compat.patchouli.processors.LivingArmourDowngradeRecipeProcessor",
+  "components": [
+    {
+      "type": "header",
+      "text": "#heading",
+      "x": -1,
+      "y": -6
+    },
+    {
+      "type": "image",
+      "image": "patchouli:textures/gui/crafting.png",
+      "x": 25,
+      "y": 4,
+      "u": 0,
+      "v": 102,
+      "texture_width": 128,
+      "texture_height": 256,
+      "width": 66,
+      "height": 26
+    },
+    {
+      "type": "item",
+      "item": "bloodmagic:upgradescraps",
+      "x": 90,
+      "y": 9
+    },
+    {
+      "type": "item",
+      "item": "#input",
+      "x": 50,
+      "y": 9
+    },
+    {
+      "type": "text",
+      "text": "#text",
+      "y": 30
+    }
+  ]
+}

--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/templates/living_armour_downgrade.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/en_us/templates/living_armour_downgrade.json
@@ -1,0 +1,16 @@
+{
+  "include": [
+    {
+      "template": "crafting_living_armour_downgrade",
+      "as": "a",
+      "x": 0,
+      "y": 0
+    },
+    {
+      "template": "living_armour_upgrade_table",
+      "as": "b",
+      "x": 0,
+      "y": 35
+    }
+  ]
+}


### PR DESCRIPTION
### Multiblocks
Added a Dev Utility to output a Patchouli Multiblock's String Array to the Log.  This method (`stringDumper(String[][])`) is left uncommented, but is not called by any code.

Added a Chest to the Living Armour Downgrade ritual to show its location.  I have been unable to add the Item Frame as it uses a (non-Block) Entity.

### Downgrades Documentation
Added a Processor to get the recipe item for Living Armour Downgrades.

Added a Template to use that processor.  This uses the Patchouli "Spotlight" page element.

Added another Template to nest the Downgrade and Living Armour Upgrade tables together on a single page.

Applied the nested template to all currently documented Living Armour Downgrades.