### PR TITLE
AlchemyTable rotation

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/item/block/ItemBlockAlchemyTable.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/block/ItemBlockAlchemyTable.java
@@ -29,7 +29,7 @@ public class ItemBlockAlchemyTable extends BlockItem
 	{
 //		PlayerEntity player = context.getPlayer()
 //		float yaw = player.rotationYaw;
-		Direction direction = context.getHorizontalDirection();
+		Direction direction = context.getHorizontalDirection().getClockWise();
 		Player player = context.getPlayer();
 
 		if (direction.getStepY() != 0)


### PR DESCRIPTION
Changes default rotation when trying to place the Alchemy Table. 
Makes placing the table more intuitive and easier against walls