### PR TITLE
More Curios Support

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/compat/CuriosCompat.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/CuriosCompat.java
@@ -1,8 +1,8 @@
 package wayoftime.bloodmagic.compat;
 
+import net.minecraft.core.NonNullList;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.core.NonNullList;
 import net.minecraftforge.fml.InterModComms;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.items.IItemHandler;
@@ -22,6 +22,7 @@ public class CuriosCompat
 	{
 		InterModComms.sendTo("curios", SlotTypeMessage.REGISTER_TYPE, () -> SlotTypePreset.NECKLACE.getMessageBuilder().build());
 		InterModComms.sendTo("curios", SlotTypeMessage.REGISTER_TYPE, () -> SlotTypePreset.CHARM.getMessageBuilder().build());
+		InterModComms.sendTo("curios", SlotTypeMessage.REGISTER_TYPE, () -> SlotTypePreset.BRACELET.getMessageBuilder().build());
 		InterModComms.sendTo("curios", SlotTypeMessage.REGISTER_TYPE, () -> new SlotTypeMessage.Builder("living_armour_socket").size(0).icon(BloodMagic.rl("item/curios_empty_living_armour_socket")).build());
 	}
 

--- a/src/main/java/wayoftime/bloodmagic/core/util/PlayerUtil.java
+++ b/src/main/java/wayoftime/bloodmagic/core/util/PlayerUtil.java
@@ -11,24 +11,20 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import wayoftime.bloodmagic.common.item.ExpandedArmor;
 import wayoftime.bloodmagic.core.living.LivingUtil;
+import wayoftime.bloodmagic.util.helper.InventoryHelper;
 
 public class PlayerUtil
 {
 
 	public static ItemStack findItem(Player player, Predicate<ItemStack> requirements)
 	{
-
-		// Check offhand first
-		ItemStack offHand = player.getOffhandItem();
-		if (requirements.test(offHand))
-			return offHand;
-
-		// Check inventory next
-		for (int slot = 0; slot < player.getInventory().getContainerSize(); slot++)
+		// Check offhand first.
+		for (ItemStack stack : InventoryHelper.getAllInventories(player, InventoryHelper.OFFHAND_FIRST))
 		{
-			ItemStack foundStack = player.getInventory().getItem(slot);
-			if (!foundStack.isEmpty() && requirements.test(foundStack))
-				return foundStack;
+			if (!stack.isEmpty() && requirements.test(stack))
+			{
+				return stack;
+			}
 		}
 
 		return ItemStack.EMPTY;

--- a/src/main/java/wayoftime/bloodmagic/util/Utils.java
+++ b/src/main/java/wayoftime/bloodmagic/util/Utils.java
@@ -38,10 +38,10 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.wrapper.InvWrapper;
-import net.minecraftforge.items.wrapper.PlayerMainInvWrapper;
 import net.minecraftforge.items.wrapper.SidedInvWrapper;
 import wayoftime.bloodmagic.api.compat.IDemonWillViewer;
 import wayoftime.bloodmagic.common.tile.TileInventory;
+import wayoftime.bloodmagic.util.helper.InventoryHelper;
 import wayoftime.bloodmagic.util.helper.NBTHelper;
 
 public class Utils
@@ -570,11 +570,8 @@ public class Utils
 
 	public static boolean canPlayerSeeDemonWill(Player player)
 	{
-		IItemHandler inventory = new PlayerMainInvWrapper(player.getInventory());
-
-		for (int i = 0; i < inventory.getSlots(); i++)
+		for (ItemStack stack : InventoryHelper.getAllInventories(player))
 		{
-			ItemStack stack = inventory.getStackInSlot(i);
 			if (stack.isEmpty())
 			{
 				continue;
@@ -586,22 +583,13 @@ public class Utils
 			}
 		}
 
-		ItemStack offhandStack = player.getOffhandItem();
-		if (!offhandStack.isEmpty() && offhandStack.getItem() instanceof IDemonWillViewer && ((IDemonWillViewer) offhandStack.getItem()).canSeeDemonWillAura(player.getCommandSenderWorld(), offhandStack, player))
-		{
-			return true;
-		}
-
 		return false;
 	}
 
 	public static double getDemonWillResolution(Player player)
 	{
-		IItemHandler inventory = new PlayerMainInvWrapper(player.getInventory());
-
-		for (int i = 0; i < inventory.getSlots(); i++)
+		for (ItemStack stack : InventoryHelper.getAllInventories(player))
 		{
-			ItemStack stack = inventory.getStackInSlot(i);
 			if (stack.isEmpty())
 			{
 				continue;
@@ -611,12 +599,6 @@ public class Utils
 			{
 				return ((IDemonWillViewer) stack.getItem()).getDemonWillAuraResolution(player.getCommandSenderWorld(), stack, player);
 			}
-		}
-
-		ItemStack offhandStack = player.getOffhandItem();
-		if (!offhandStack.isEmpty() && offhandStack.getItem() instanceof IDemonWillViewer && ((IDemonWillViewer) offhandStack.getItem()).canSeeDemonWillAura(player.getCommandSenderWorld(), offhandStack, player))
-		{
-			return ((IDemonWillViewer) offhandStack.getItem()).getDemonWillAuraResolution(player.getCommandSenderWorld(), offhandStack, player);
 		}
 
 		return 100;

--- a/src/main/java/wayoftime/bloodmagic/util/helper/InventoryHelper.java
+++ b/src/main/java/wayoftime/bloodmagic/util/helper/InventoryHelper.java
@@ -1,29 +1,45 @@
 package wayoftime.bloodmagic.util.helper;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Function;
 
+import net.minecraft.core.NonNullList;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.core.NonNullList;
 import wayoftime.bloodmagic.impl.BloodMagicAPI;
 
 public class InventoryHelper
 {
+	public static final Comparator<Map.Entry<String, Function<Player, NonNullList<ItemStack>>>> OFFHAND_FIRST = (i1, i2) -> i1.getKey().equals("offHandInventory")
+			? -1
+			: 0;
 
 	/**
-	 * Gets all items from all registered inventories.
-	 * 
-	 * @param player - The player who's inventories to check.
-	 * @return - NonNullList<ItemStack> of all items in those inventories.
+	 * @param player     - Player who's inventories you want.
+	 * @param comparator - Sort order.
+	 * @return A NonNullList of all items in inventories registered using the BM
+	 *         API.
 	 */
-	public static NonNullList<ItemStack> getAllInventories(Player player)
+	public static NonNullList<ItemStack> getAllInventories(Player player, Comparator<Map.Entry<String, Function<Player, NonNullList<ItemStack>>>> comparator)
 	{
-		Map<String, Function<Player, NonNullList<ItemStack>>> inventoryProvider = BloodMagicAPI.INSTANCE.getInventoryProvider();
 		NonNullList<ItemStack> inventory = NonNullList.create();
+		List<Map.Entry<String, Function<Player, NonNullList<ItemStack>>>> inventoryProviders = new ArrayList<Entry<String, Function<Player, NonNullList<ItemStack>>>>(BloodMagicAPI.INSTANCE.getInventoryProvider().entrySet());
 
-		inventoryProvider.forEach((identifier, provider) -> inventory.addAll(provider.apply(player)));
+		if (comparator != null)
+			inventoryProviders.sort(comparator);
+
+		inventoryProviders.forEach(provider -> inventory.addAll(provider.getValue().apply(player)));
 
 		return inventory;
+	}
+
+	// no sort order method.
+	public static NonNullList<ItemStack> getAllInventories(Player player)
+	{
+		return getAllInventories(player, null);
 	}
 }

--- a/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/training_bracelet.json
+++ b/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/training_bracelet.json
@@ -25,6 +25,11 @@
     {
       "type": "patchouli:text",
       "text": "The bracelet can specify a limit for any given upgrade (assuming you have a copy of the $(item)Tome$() to hand). For example, you could tell it to limit Strong Legs to level 3 - once you reach this level, Strong Legs will no longer gain experience. It can also prevent or allow the training of all other skills that you haven't otherwise specified. If you want to allow all upgrades except one, you can add that one to the bracelet in 'allow others' mode and set its level cap to 0."
+    },
+    {
+      "type": "patchouli:text",
+      "flag": "mod:curios",
+      "text": "As you have the $(thing)Curios API$() installed, you can equip this $(item)Training Bracelet$() as a bracelet. If you want to wear more curios at once, consider using the $(l:bloodmagic:alchemy_array/living_equipment/armor_upgrades/curios_sockets)Socketed Upgrade$() for your $(l:bloodmagic:alchemy_array/living_equipment/living_basics)Living Armour$()."
     }
   ]
 }

--- a/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/sigil/suppression.json
+++ b/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/sigil/suppression.json
@@ -14,6 +14,11 @@
       "array.heading": "Sigil of Suppression",
       "array.recipe": "bloodmagic:array/suppressionsigil",
       "array.text": "$(italic)Better than a Void Sigil\u00AE!"
+    },
+    {
+      "type": "patchouli:text",
+      "flag": "mod:curios",
+      "text": "As you have the $(thing)Curios API$() installed, you can equip this $(item)Sigil$() as a charm. If you want to wear more curios at once, consider using a $(l:bloodmagic:alchemy_array/sigil/holding)Sigil of Holding$(), or the $(l:bloodmagic:alchemy_array/living_equipment/armor_upgrades/curios_sockets)Socketed Upgrade$() for your $(l:bloodmagic:alchemy_array/living_equipment/living_basics)Living Armour$()."
     }
   ]
 }

--- a/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/demon_will/will_manipulation/aura_gauge.json
+++ b/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/demon_will/will_manipulation/aura_gauge.json
@@ -24,6 +24,11 @@
     {
       "type": "patchouli:text",
       "text": "This gauge will appear in the top left of your screen. The coloured bars will give you a good estimate of how much of each $(l:bloodmagic:demon_will/will_manipulation/aspected_will)Will Aspect$() is in the current chunk. $(br2)You can hold [$(k:sneak)] to get a numerical value for each Aspect, between 1 and 100 $(raw)Will$() for each. 100 is the maximum amount of any one aspect of $(raw)Will$() that a chunk can have in it."
+    },
+    {
+      "type": "patchouli:text",
+      "flag": "mod:curios",
+      "text": "As you have the $(thing)Curios API$() installed, you can equip the $(item)Demon Will Aura Gauge$() as a charm. If you want to wear more curios at once, consider using the $(l:bloodmagic:alchemy_array/living_equipment/armor_upgrades/curios_sockets)Socketed Upgrade$() for your $(l:bloodmagic:alchemy_array/living_equipment/living_basics)Living Armour$()."
     }
   ]
 }

--- a/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/demon_will/will_manipulation/soul_gem.json
+++ b/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/demon_will/will_manipulation/soul_gem.json
@@ -47,7 +47,7 @@
     {
       "type": "patchouli:text",
       "flag": "mod:curios",
-      "text": "As you have the $(thing)Curios API$() installed, you can equip $(item)Tartaric Gems$() as a necklace. If you want to wear more curios at once, consider using a $(l:bloodmagic:alchemy_array/sigil/holding)Sigil of Holding$(), or the $(l:bloodmagic:alchemy_array/living_equipment/armor_upgrades/curios_sockets)Socketed Upgrade$() for your $(l:bloodmagic:alchemy_array/living_equipment/living_basics)Living Armour$()."
+      "text": "As you have the $(thing)Curios API$() installed, you can equip $(item)Tartaric Gems$() as a necklace. If you want to wear more curios at once, consider using the $(l:bloodmagic:alchemy_array/living_equipment/armor_upgrades/curios_sockets)Socketed Upgrade$() for your $(l:bloodmagic:alchemy_array/living_equipment/living_basics)Living Armour$()."
     }
   ]
 }

--- a/src/main/resources/data/curios/tags/items/bracelet.json
+++ b/src/main/resources/data/curios/tags/items/bracelet.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "bloodmagic:upgradetrainer"
+  ]
+}

--- a/src/main/resources/data/curios/tags/items/charm.json
+++ b/src/main/resources/data/curios/tags/items/charm.json
@@ -5,7 +5,9 @@
     "bloodmagic:growthsigil",
     "bloodmagic:sigilofmagnetism",
     "bloodmagic:icesigil",
+    "bloodmagic:sigilofsuppression",
     "bloodmagic:sigilofholding",
-    "bloodmagic:experiencebook"
+    "bloodmagic:experiencebook",
+    "bloodmagic:demonwillgauge"
   ]
 }

--- a/src/main/resources/data/curios/tags/items/living_armour_socket.json
+++ b/src/main/resources/data/curios/tags/items/living_armour_socket.json
@@ -5,11 +5,14 @@
     "bloodmagic:growthsigil",
     "bloodmagic:sigilofmagnetism",
     "bloodmagic:icesigil",
+    "bloodmagic:sigilofsuppression",
     "bloodmagic:sigilofholding",
     "bloodmagic:experiencebook",
     "bloodmagic:soulgempetty",
     "bloodmagic:soulgemlesser",
     "bloodmagic:soulgemcommon",
-    "bloodmagic:soulgemgreater"
+    "bloodmagic:soulgemgreater",
+    "bloodmagic:upgradetrainer",
+    "bloodmagic:demonwillgauge"
   ]
 }


### PR DESCRIPTION
Added Curios Support for the Living Armour Training Bracelet (Bracelet Slot), Demon Will Aura Gauge (Charm Slot), and Sigil of Suppression (Charm).  All can also go into the Living Armour Curio Socket slots too.

`CuriosCompat` - Added a Bracelet slot to the player's default Curios inventory.

`PlayerUtil.findItem` - Use `InventoryHelper` to search all inventories, starting with the Offhand slot first.

`InventoryHelper` - Allow Sorting (to check the Offhand slot first).  The method used was highly refined by TehNut.

`Utils` - Use `InventoryHelper` to also check the Curios slots too.

Added relevant Curios Item Tags.

Added documentation to Sanguine Scientiem.  Also tweaked Tartaric Gem entry to *not* mention the unrelated Sigil of Holding.