### PR TITLE
readd CraftTweaker support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ dependencies {
     compileOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}:api")
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
 
-//    compileOnly fg.deobf("com.blamejared.crafttweaker:CraftTweaker-1.18.2:9.1.154")
+    implementation fg.deobf("com.blamejared.crafttweaker:CraftTweaker-forge-1.18.2:9.1.+")
     
     runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}")
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api")

--- a/src/main/java/wayoftime/bloodmagic/compat/crt/ARCManager.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/crt/ARCManager.java
@@ -1,0 +1,74 @@
+package wayoftime.bloodmagic.compat.crt;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.action.recipe.ActionAddRecipe;
+import com.blamejared.crafttweaker.api.action.recipe.ActionRemoveRecipeByOutput;
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker.api.fluid.IFluidStack;
+import com.blamejared.crafttweaker.api.ingredient.IIngredient;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.api.recipe.manager.base.IRecipeManager;
+import com.blamejared.crafttweaker.api.util.random.Percentaged;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeType;
+import org.apache.commons.lang3.tuple.Pair;
+import org.openzen.zencode.java.ZenCodeType;
+import wayoftime.bloodmagic.common.recipe.BloodMagicRecipeType;
+import wayoftime.bloodmagic.recipe.RecipeARC;
+import wayoftime.bloodmagic.recipe.helper.FluidStackIngredient;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ZenRegister
+@ZenCodeType.Name("mods.bloodmagic.ARC")
+public class ARCManager implements IRecipeManager<RecipeARC> {
+    
+    @ZenCodeType.Method
+    public void addRecipe(String name, IItemStack output, IFluidStack outputFluid, IIngredient input, IFluidStack inputFluid, IIngredient arcTool, boolean consumeIngredient, @ZenCodeType.Optional Percentaged<IItemStack>[] addedItems) {
+        name = fixRecipeName(name);
+        ResourceLocation location = new ResourceLocation("crafttweaker", name);
+        List<Pair<ItemStack, Pair<Double, Double>>> addedItemsList = new ArrayList<>();
+        if(addedItems != null) {
+            addedItemsList = Arrays.stream(addedItems).map(mcWeightedItemStack -> Pair.of(mcWeightedItemStack.getData().getInternal(), Pair.of(mcWeightedItemStack.getPercentage(), mcWeightedItemStack.getPercentage()))).collect(Collectors.toList());
+        }
+        RecipeARC recipeARC = new RecipeARC(location, input.asVanillaIngredient(), 0, arcTool.asVanillaIngredient(), inputFluid.getInternal().isEmpty() ? null : FluidStackIngredient.from(inputFluid.getInternal()), output.getInternal(), addedItemsList, outputFluid.getInternal(), consumeIngredient);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipeARC, ""));
+    }
+    
+    @Override
+    public void remove(IIngredient output) {
+        
+        CraftTweakerAPI.apply(new ActionRemoveRecipeByOutput(this, output) {
+            @Override
+            public void apply() {
+                List<ResourceLocation> toRemove = new ArrayList<>();
+                for (int i = 0; i < getManager().getAllRecipes().size(); i++) {
+                    ResourceLocation location = ARCManager.this.getRecipes().values().stream().toList().get(i).getId();
+                    Recipe<?> recipe = getManager().getRecipeList().get(location);
+                    if(recipe instanceof RecipeARC) {
+                        RecipeARC recipeARC = (RecipeARC) recipe;
+                        List<ItemStack> allListedOutputs = recipeARC.getAllListedOutputs();
+                        // no other way to get the main output, and there may not even be a main output
+                        if(allListedOutputs.size() > 0) {
+                            if(output.matches(new MCItemStackMutable(allListedOutputs.get(0)))) {
+                                toRemove.add(location);
+                            }
+                        }
+                    }
+                }
+                toRemove.forEach(getManager().getRecipes()::remove);
+            }
+        });
+    }
+    
+    @Override
+    public RecipeType<RecipeARC> getRecipeType() {
+        return BloodMagicRecipeType.ARC.get();
+    }
+}

--- a/src/main/java/wayoftime/bloodmagic/compat/crt/AlchemyArrayManager.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/crt/AlchemyArrayManager.java
@@ -1,0 +1,59 @@
+package wayoftime.bloodmagic.compat.crt;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.action.recipe.ActionAddRecipe;
+import com.blamejared.crafttweaker.api.action.recipe.ActionRemoveRecipeByOutput;
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker.api.ingredient.IIngredient;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.api.recipe.manager.base.IRecipeManager;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeType;
+import org.openzen.zencode.java.ZenCodeType;
+import wayoftime.bloodmagic.common.recipe.BloodMagicRecipeType;
+import wayoftime.bloodmagic.recipe.RecipeAlchemyArray;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ZenRegister
+@ZenCodeType.Name("mods.bloodmagic.AlchemyArray")
+public class AlchemyArrayManager implements IRecipeManager<RecipeAlchemyArray> {
+    
+    @ZenCodeType.Method
+    public void addRecipe(String name, IItemStack output, IIngredient baseInput, IIngredient addedInput, ResourceLocation texture) {
+        name = fixRecipeName(name);
+        ResourceLocation location = new ResourceLocation("crafttweaker", name);
+        RecipeAlchemyArray recipe = new RecipeAlchemyArray(location, texture, baseInput.asVanillaIngredient(), addedInput.asVanillaIngredient(), output.getInternal());
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+    }
+    
+    @Override
+    public void remove(IIngredient output) {
+        
+        CraftTweakerAPI.apply(new ActionRemoveRecipeByOutput(this, output) {
+            @Override
+            public void apply() {
+                List<ResourceLocation> toRemove = new ArrayList<>();
+                for (int i = 0; i < getManager().getRecipes().size(); i++) {
+                    ResourceLocation location = AlchemyArrayManager.this.getRecipes().values().stream().toList().get(i).getId();
+                    Recipe<?> recipe = getManager().getRecipeList().get(location);
+                    if(recipe instanceof RecipeAlchemyArray) {
+                        RecipeAlchemyArray recipeAT = (RecipeAlchemyArray) recipe;
+                        ItemStack recipeOutput = recipeAT.getOutput();
+                        if(output.matches(new MCItemStackMutable(recipeOutput))) {
+                            toRemove.add(location);
+                        }
+                    }
+                }
+                toRemove.forEach(getManager().getRecipes()::remove);
+            }
+        });
+    }
+    
+    @Override
+    public RecipeType<RecipeAlchemyArray> getRecipeType() { return BloodMagicRecipeType.ARRAY.get(); }
+}

--- a/src/main/java/wayoftime/bloodmagic/compat/crt/AlchemyTableManager.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/crt/AlchemyTableManager.java
@@ -1,0 +1,62 @@
+package wayoftime.bloodmagic.compat.crt;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.action.recipe.ActionAddRecipe;
+import com.blamejared.crafttweaker.api.action.recipe.ActionRemoveRecipeByOutput;
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker.api.ingredient.IIngredient;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.api.recipe.manager.base.IRecipeManager;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeType;
+import org.openzen.zencode.java.ZenCodeType;
+import wayoftime.bloodmagic.common.recipe.BloodMagicRecipeType;
+import wayoftime.bloodmagic.recipe.RecipeAlchemyTable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ZenRegister
+@ZenCodeType.Name("mods.bloodmagic.AlchemyTable")
+public class AlchemyTableManager implements IRecipeManager<RecipeAlchemyTable> {
+    
+    @ZenCodeType.Method
+    public void addRecipe(String name, IItemStack output, IIngredient[] input, int syphon, int ticks, int minimumTier) {
+        name = fixRecipeName(name);
+        ResourceLocation location = new ResourceLocation("crafttweaker", name);
+        RecipeAlchemyTable recipe = new RecipeAlchemyTable(location, Arrays.stream(input).map(IIngredient::asVanillaIngredient).collect(Collectors.toList()), output.getInternal(), syphon, ticks, minimumTier);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+    }
+    
+    @Override
+    public void remove(IIngredient output) {
+        
+        CraftTweakerAPI.apply(new ActionRemoveRecipeByOutput(this, output) {
+            @Override
+            public void apply() {
+                List<ResourceLocation> toRemove = new ArrayList<>();
+                for (int i = 0; i < getManager().getRecipes().size(); i++) {
+                    ResourceLocation location = AlchemyTableManager.this.getRecipes().values().stream().toList().get(i).getId();
+                    Recipe<?> recipe = getManager().getRecipeList().get(location);
+                    if(recipe instanceof RecipeAlchemyTable recipeAT) {
+                        ItemStack recipeOutput = recipeAT.getOutput();
+                        if(output.matches(new MCItemStackMutable(recipeOutput))) {
+                            toRemove.add(location);
+                        }
+                    }
+                }
+                toRemove.forEach(getManager().getRecipes()::remove);
+            }
+        });
+    }
+    
+    @Override
+    public RecipeType<RecipeAlchemyTable> getRecipeType() {
+        return BloodMagicRecipeType.ALCHEMYTABLE.get();
+    }
+}

--- a/src/main/java/wayoftime/bloodmagic/compat/crt/BloodAltarManager.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/crt/BloodAltarManager.java
@@ -1,0 +1,61 @@
+package wayoftime.bloodmagic.compat.crt;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.action.recipe.ActionAddRecipe;
+import com.blamejared.crafttweaker.api.action.recipe.ActionRemoveRecipeByOutput;
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker.api.ingredient.IIngredient;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.api.recipe.manager.base.IRecipeManager;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeType;
+import org.openzen.zencode.java.ZenCodeType;
+import wayoftime.bloodmagic.common.recipe.BloodMagicRecipeType;
+import wayoftime.bloodmagic.recipe.RecipeBloodAltar;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ZenRegister
+@ZenCodeType.Name("mods.bloodmagic.BloodAltar")
+public class BloodAltarManager implements IRecipeManager<RecipeBloodAltar> {
+    
+    @ZenCodeType.Method
+    public void addRecipe(String name, IItemStack output, IIngredient input, int minimumTier, int syphon, int consumeRate, int drainRate) {
+        name = fixRecipeName(name);
+        ResourceLocation location = new ResourceLocation("crafttweaker", name);
+        RecipeBloodAltar recipeARC = new RecipeBloodAltar(location, input.asVanillaIngredient(), output.getInternal(), minimumTier, syphon, consumeRate, drainRate);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipeARC, ""));
+    }
+    
+    @Override
+    public void remove(IIngredient output) {
+        
+        CraftTweakerAPI.apply(new ActionRemoveRecipeByOutput(this, output) {
+            @Override
+            public void apply() {
+                List<ResourceLocation> toRemove = new ArrayList<>();
+                for (int i = 0; i < getManager().getRecipes().size(); i++) {
+                    ResourceLocation location = BloodAltarManager.this.getRecipes().values().stream().toList().get(i).getId();
+                    Recipe<?> recipe = getManager().getRecipeList().get(location);
+                    if(recipe instanceof RecipeBloodAltar) {
+                        RecipeBloodAltar recipeBloodAltar = (RecipeBloodAltar) recipe;
+                        ItemStack recOut = recipeBloodAltar.getOutput();
+                        if(output.matches(new MCItemStackMutable(recOut))) {
+                            toRemove.add(location);
+                        }
+                    }
+                }
+                toRemove.forEach(getManager().getRecipes()::remove);
+            }
+        });
+    }
+    
+    @Override
+    public RecipeType<RecipeBloodAltar> getRecipeType() {
+        return BloodMagicRecipeType.ALTAR.get();
+    }
+}

--- a/src/main/java/wayoftime/bloodmagic/compat/crt/TartaricForgeManager.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/crt/TartaricForgeManager.java
@@ -1,0 +1,63 @@
+package wayoftime.bloodmagic.compat.crt;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.action.recipe.ActionAddRecipe;
+import com.blamejared.crafttweaker.api.action.recipe.ActionRemoveRecipeByOutput;
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker.api.ingredient.IIngredient;
+import com.blamejared.crafttweaker.api.item.IItemStack;
+import com.blamejared.crafttweaker.api.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.api.recipe.manager.base.IRecipeManager;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeType;
+import org.openzen.zencode.java.ZenCodeType;
+import wayoftime.bloodmagic.common.recipe.BloodMagicRecipeType;
+import wayoftime.bloodmagic.recipe.RecipeTartaricForge;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ZenRegister
+@ZenCodeType.Name("mods.bloodmagic.TartaricForge")
+public class TartaricForgeManager implements IRecipeManager<RecipeTartaricForge> {
+    
+    @ZenCodeType.Method
+    public void addRecipe(String name, IItemStack output, IIngredient[] input, double minimumSouls, double soulDrain) {
+        name = fixRecipeName(name);
+        ResourceLocation location = new ResourceLocation("crafttweaker", name);
+        RecipeTartaricForge recipe = new RecipeTartaricForge(location, Arrays.stream(input).map(IIngredient::asVanillaIngredient).collect(Collectors.toList()), output.getInternal(), minimumSouls, soulDrain);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, ""));
+    }
+    
+    @Override
+    public void remove(IIngredient output) {
+        
+        CraftTweakerAPI.apply(new ActionRemoveRecipeByOutput(this, output) {
+            @Override
+            public void apply() {
+                List<ResourceLocation> toRemove = new ArrayList<>();
+                for (int i = 0; i < getManager().getRecipes().size(); i++) {
+                    ResourceLocation location = TartaricForgeManager.this.getRecipes().values().stream().toList().get(i).getId();
+                    Recipe<?> recipe = getManager().getRecipeList().get(location);
+                    if(recipe instanceof RecipeTartaricForge) {
+                        RecipeTartaricForge recipeTF = (RecipeTartaricForge) recipe;
+                        ItemStack recipeOutput = recipeTF.getOutput();
+                        if(output.matches(new MCItemStackMutable(recipeOutput))) {
+                            toRemove.add(location);
+                        }
+                    }
+                }
+                toRemove.forEach(getManager().getRecipes()::remove);
+            }
+        });
+    }
+    
+    @Override
+    public RecipeType<RecipeTartaricForge> getRecipeType() {
+        return BloodMagicRecipeType.TARTARICFORGE.get();
+    }
+}


### PR DESCRIPTION
As Crafttweaker support hasn't been updated to 1.18, I readded this support from 1.16 to work with 1.18.

- no changes for adding recipe via crafttweaker between 1.16 and 1.18
- changes for removing recipe via crafttweaker to match 1.18 changes from crafttweaker (uses remove instead of removeRecipe) 