### PR TITLE
Fix the AE2 meteor not including sky stone or fluix blocks

### DIFF
--- a/src/main/resources/data/bloodmagic/recipes/meteor/ae2.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/ae2.json
@@ -12,11 +12,11 @@
       "minWeight": 0,
       "weightMap": [
         {
-          "tag": "appliedenergistics2:fluix_block",
+          "tag": "ae2:fluix_block",
           "weight": 100
         }
       ],
-      "fill": "appliedenergistics2:sky_stone_block"
+      "fill": "ae2:sky_stone_block"
     },
     {
       "radius": 7,
@@ -32,8 +32,8 @@
           "weight": 50
         }
       ],
-      "fill": "appliedenergistics2:sky_stone_block",
-      "shell": "appliedenergistics2:sky_stone_block"
+      "fill": "ae2:sky_stone_block",
+      "shell": "ae2:sky_stone_block"
     }
   ]
 }


### PR DESCRIPTION
At some point, it seems AE2's internal name was changed from `appliedenergistics2` to `ae2`, resulting in this meteor JSON not working properly. This PR fixes that.

(I have not actually tested building the mod with this change, but using the edited JSON in a datapack did work as intended.)