### PR TITLE
added curios support for divination/seer sigil

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/api/IBloodMagicAPI.java
+++ b/src/main/java/wayoftime/bloodmagic/api/IBloodMagicAPI.java
@@ -7,11 +7,11 @@ import javax.annotation.Nonnull;
 
 import org.apache.logging.log4j.LogManager;
 
-import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.core.NonNullList;
+import net.minecraft.util.LazyLoadedValue;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.util.LazyLoadedValue;
-import net.minecraft.core.NonNullList;
+import net.minecraft.world.level.block.state.BlockState;
 
 /**
  * The main interface between a plugin and Blood Magic's internals.
@@ -136,6 +136,16 @@ public interface IBloodMagicAPI
 	 *                            a NonNullList of ItemStacks.
 	 */
 	default void registerInventoryProvider(String inventoryIdentifier, Function<Player, NonNullList<ItemStack>> provider)
+	{
+	}
+
+	/**
+	 * Registers an already registered inventory to be considered active (eg.
+	 * Main/Offhand, Curios)
+	 * 
+	 * @param inventoryIdentifier String identifier for the inventory.
+	 */
+	default void registerActiveInventoryProvider(String inventoryIdentifier)
 	{
 	}
 

--- a/src/main/java/wayoftime/bloodmagic/client/hud/element/ElementDivinedInformation.java
+++ b/src/main/java/wayoftime/bloodmagic/client/hud/element/ElementDivinedInformation.java
@@ -3,10 +3,14 @@ package wayoftime.bloodmagic.client.hud.element;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.InteractionHand;
+import net.minecraftforge.items.IItemHandler;
+import top.theillusivec4.curios.api.CuriosApi;
+import wayoftime.bloodmagic.BloodMagic;
 import wayoftime.bloodmagic.common.item.BloodMagicItems;
 import wayoftime.bloodmagic.common.item.sigil.ItemSigilHolding;
 
@@ -25,39 +29,31 @@ public abstract class ElementDivinedInformation<T extends BlockEntity> extends E
 	public boolean shouldRender(Minecraft minecraft)
 	{
 		Player player = Minecraft.getInstance().player;
-		ItemStack sigilStack = player.getItemInHand(InteractionHand.MAIN_HAND);
+
+		NonNullList<ItemStack> inventory = NonNullList.create();
+		if (BloodMagic.curiosLoaded)
+		{
+			IItemHandler curioSlots = CuriosApi.getCuriosHelper().getEquippedCurios(player).resolve().get();
+			for (int i = 0; i < curioSlots.getSlots(); i++)
+			{
+				inventory.add(curioSlots.getStackInSlot(i));
+			}
+		}
+
+		inventory.add(player.getItemInHand(InteractionHand.MAIN_HAND));
+		inventory.add(player.getItemInHand(InteractionHand.OFF_HAND));
+
 		boolean flag = false;
-		if (simple)
+		for (int i = 0; i < inventory.size(); i++)
 		{
-			if (sigilStack.getItem() == BloodMagicItems.DIVINATION_SIGIL.get() || sigilStack.getItem() == BloodMagicItems.SEER_SIGIL.get())
+			ItemStack sigilStack = inventory.get(i);
+			if ((sigilStack.getItem() == BloodMagicItems.DIVINATION_SIGIL.get() && simple) || sigilStack.getItem() == BloodMagicItems.SEER_SIGIL.get())
 				flag = true;
 			else
-				flag = isFlagSigilHolding(sigilStack, true);
+				flag = isFlagSigilHolding(sigilStack, simple);
 
-			if (!flag)
-			{
-				sigilStack = player.getItemInHand(InteractionHand.OFF_HAND);
-				if (sigilStack.getItem() == BloodMagicItems.DIVINATION_SIGIL.get() || sigilStack.getItem() == BloodMagicItems.SEER_SIGIL.get())
-					flag = true;
-				else
-					flag = isFlagSigilHolding(sigilStack, true);
-			}
-
-		} else
-		{
-			if (sigilStack.getItem() == BloodMagicItems.SEER_SIGIL.get())
-				flag = true;
-			else
-				flag = isFlagSigilHolding(sigilStack, false);
-
-			if (!flag)
-			{
-				sigilStack = player.getItemInHand(InteractionHand.OFF_HAND);
-				if (sigilStack.getItem() == BloodMagicItems.SEER_SIGIL.get())
-					flag = true;
-				else
-					flag = isFlagSigilHolding(sigilStack, false);
-			}
+			if (flag)
+				break;
 		}
 
 		return super.shouldRender(minecraft) && flag;

--- a/src/main/java/wayoftime/bloodmagic/client/hud/element/ElementDivinedInformation.java
+++ b/src/main/java/wayoftime/bloodmagic/client/hud/element/ElementDivinedInformation.java
@@ -4,15 +4,12 @@ import java.util.List;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.NonNullList;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraftforge.items.IItemHandler;
-import top.theillusivec4.curios.api.CuriosApi;
-import wayoftime.bloodmagic.BloodMagic;
 import wayoftime.bloodmagic.common.item.BloodMagicItems;
 import wayoftime.bloodmagic.common.item.sigil.ItemSigilHolding;
+import wayoftime.bloodmagic.util.helper.InventoryHelper;
 
 public abstract class ElementDivinedInformation<T extends BlockEntity> extends ElementTileInformation<T>
 {
@@ -30,18 +27,7 @@ public abstract class ElementDivinedInformation<T extends BlockEntity> extends E
 	{
 		Player player = Minecraft.getInstance().player;
 
-		NonNullList<ItemStack> inventory = NonNullList.create();
-		if (BloodMagic.curiosLoaded)
-		{
-			IItemHandler curioSlots = CuriosApi.getCuriosHelper().getEquippedCurios(player).resolve().get();
-			for (int i = 0; i < curioSlots.getSlots(); i++)
-			{
-				inventory.add(curioSlots.getStackInSlot(i));
-			}
-		}
-
-		inventory.add(player.getItemInHand(InteractionHand.MAIN_HAND));
-		inventory.add(player.getItemInHand(InteractionHand.OFF_HAND));
+		NonNullList<ItemStack> inventory = InventoryHelper.getActiveInventories(player);
 
 		boolean flag = false;
 		for (int i = 0; i < inventory.size(); i++)

--- a/src/main/java/wayoftime/bloodmagic/client/hud/element/ElementDivinedInformation.java
+++ b/src/main/java/wayoftime/bloodmagic/client/hud/element/ElementDivinedInformation.java
@@ -30,9 +30,8 @@ public abstract class ElementDivinedInformation<T extends BlockEntity> extends E
 		NonNullList<ItemStack> inventory = InventoryHelper.getActiveInventories(player);
 
 		boolean flag = false;
-		for (int i = 0; i < inventory.size(); i++)
+		for (ItemStack sigilStack : inventory)
 		{
-			ItemStack sigilStack = inventory.get(i);
 			if ((sigilStack.getItem() == BloodMagicItems.DIVINATION_SIGIL.get() && simple) || sigilStack.getItem() == BloodMagicItems.SEER_SIGIL.get())
 				flag = true;
 			else
@@ -53,7 +52,7 @@ public abstract class ElementDivinedInformation<T extends BlockEntity> extends E
 			int currentSlot = ItemSigilHolding.getCurrentItemOrdinal(sigilStack);
 			if (internalInv != null && !internalInv.get(currentSlot).isEmpty())
 			{
-				return (internalInv.get(currentSlot).getItem() == BloodMagicItems.SEER_SIGIL.get() && !simple) || (internalInv.get(currentSlot).getItem() == BloodMagicItems.DIVINATION_SIGIL.get() && simple);
+				return (internalInv.get(currentSlot).getItem() == BloodMagicItems.SEER_SIGIL.get()) || (internalInv.get(currentSlot).getItem() == BloodMagicItems.DIVINATION_SIGIL.get() && simple);
 			}
 		}
 		return false;

--- a/src/main/java/wayoftime/bloodmagic/compat/CuriosCompat.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/CuriosCompat.java
@@ -1,8 +1,8 @@
 package wayoftime.bloodmagic.compat;
 
+import net.minecraft.core.NonNullList;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.core.NonNullList;
 import net.minecraftforge.fml.InterModComms;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.items.IItemHandler;
@@ -28,6 +28,7 @@ public class CuriosCompat
 	public void registerInventory()
 	{
 		BloodMagicAPI.INSTANCE.registerInventoryProvider("curiosInventory", player -> getCuriosInventory(player));
+		BloodMagicAPI.INSTANCE.registerActiveInventoryProvider("curiosInventory");
 	}
 
 	public NonNullList<ItemStack> getCuriosInventory(Player player)

--- a/src/main/java/wayoftime/bloodmagic/impl/BloodMagicAPI.java
+++ b/src/main/java/wayoftime/bloodmagic/impl/BloodMagicAPI.java
@@ -1,5 +1,6 @@
 package wayoftime.bloodmagic.impl;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +43,7 @@ public class BloodMagicAPI implements IBloodMagicAPI
 	private final BloodMagicValueManager valueManager;
 	private final Multimap<ComponentType, BlockState> altarComponents;
 	private final Map<String, Function<Player, NonNullList<ItemStack>>> inventoryProvider;
+	private final List<String> activeInventories;
 
 	@Nonnull
 	private static final Lazy<ResourceKey<? extends Registry<Anointment>>> ANOINTMENT_REGISTRY_NAME = registryKey(Anointment.class, "anointment");
@@ -57,6 +59,7 @@ public class BloodMagicAPI implements IBloodMagicAPI
 		this.valueManager = new BloodMagicValueManager();
 		this.altarComponents = ArrayListMultimap.create();
 		this.inventoryProvider = new HashMap<String, Function<Player, NonNullList<ItemStack>>>();
+		this.activeInventories = new ArrayList<String>();
 	}
 
 	// Copied from Mekanism. Again.
@@ -109,6 +112,20 @@ public class BloodMagicAPI implements IBloodMagicAPI
 	public Map<String, Function<Player, NonNullList<ItemStack>>> getInventoryProvider()
 	{
 		return inventoryProvider;
+	}
+
+	public Map<String, Function<Player, NonNullList<ItemStack>>> getActiveInventoryProvider()
+	{
+		Map<String, Function<Player, NonNullList<ItemStack>>> activeInventoryProvider = new HashMap<String, Function<Player, NonNullList<ItemStack>>>();
+
+		activeInventories.forEach(key -> activeInventoryProvider.put(key, inventoryProvider.get(key)));
+
+		return activeInventoryProvider;
+	}
+
+	public void registerActiveInventoryProvider(String inventoryIdentifier)
+	{
+		activeInventories.add(inventoryIdentifier);
 	}
 
 	@Override

--- a/src/main/java/wayoftime/bloodmagic/util/helper/InventoryHelper.java
+++ b/src/main/java/wayoftime/bloodmagic/util/helper/InventoryHelper.java
@@ -3,9 +3,10 @@ package wayoftime.bloodmagic.util.helper;
 import java.util.Map;
 import java.util.function.Function;
 
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.core.NonNullList;
 import wayoftime.bloodmagic.impl.BloodMagicAPI;
 
 public class InventoryHelper
@@ -25,5 +26,25 @@ public class InventoryHelper
 		inventoryProvider.forEach((identifier, provider) -> inventory.addAll(provider.apply(player)));
 
 		return inventory;
+	}
+
+	/**
+	 * Gets all items from all registered inventories marked as active as well as
+	 * main and off hand
+	 * 
+	 * @param player - The player who's inventories to check.
+	 * @return - NonNullList<ItemStack> of all items in those inventories.
+	 */
+	public static NonNullList<ItemStack> getActiveInventories(Player player)
+	{
+		Map<String, Function<Player, NonNullList<ItemStack>>> inventoryProviders = BloodMagicAPI.INSTANCE.getActiveInventoryProvider();
+		NonNullList<ItemStack> inventories = NonNullList.create();
+
+		inventoryProviders.forEach((identifier, provider) -> inventories.addAll(provider.apply(player)));
+
+		inventories.add(player.getItemInHand(InteractionHand.MAIN_HAND));
+		inventories.add(player.getItemInHand(InteractionHand.OFF_HAND));
+
+		return inventories;
 	}
 }

--- a/src/main/resources/data/curios/tags/items/charm.json
+++ b/src/main/resources/data/curios/tags/items/charm.json
@@ -6,6 +6,8 @@
     "bloodmagic:sigilofmagnetism",
     "bloodmagic:icesigil",
     "bloodmagic:sigilofholding",
+    "bloodmagic:divinationsigil",
+    "bloodmagic:seersigil",
     "bloodmagic:experiencebook"
   ]
 }

--- a/src/main/resources/data/curios/tags/items/living_armour_socket.json
+++ b/src/main/resources/data/curios/tags/items/living_armour_socket.json
@@ -6,6 +6,8 @@
     "bloodmagic:sigilofmagnetism",
     "bloodmagic:icesigil",
     "bloodmagic:sigilofholding",
+    "bloodmagic:divinationsigil",
+    "bloodmagic:seersigil",
     "bloodmagic:experiencebook",
     "bloodmagic:soulgempetty",
     "bloodmagic:soulgemlesser",


### PR DESCRIPTION
Changed `ElementDivinedInformation.shouldRender()` to consider Curios slots if the mod is loaded (`BloodMagic.curiosLoaded`) as well as the main and off hand

Changed the check for the sigils in above function a bit to avoid basically duplicating what's inside the if/else clause

Added the divination and seer sigil to the charm and living armour socket curios tags