### PR TITLE
Gilded Living Armour Upgrade (1.20.1)

### DIFF
--- a/src/generated/resources/assets/bloodmagic/lang/en_us.json
+++ b/src/generated/resources/assets/bloodmagic/lang/en_us.json
@@ -419,6 +419,7 @@
   "living_upgrade.bloodmagic.experienced": "Experienced",
   "living_upgrade.bloodmagic.fall_protect": "Soft Fall",
   "living_upgrade.bloodmagic.fire_resist": "Gift of Ignis",
+  "living_upgrade.bloodmagic.gilded": "Gilded",
   "living_upgrade.bloodmagic.grave_digger": "Grave Digger",
   "living_upgrade.bloodmagic.grim_reaper": "Grim Reaper's Sprint",
   "living_upgrade.bloodmagic.health": "Healthy",

--- a/src/main/java/wayoftime/bloodmagic/common/data/GeneratorLanguage.java
+++ b/src/main/java/wayoftime/bloodmagic/common/data/GeneratorLanguage.java
@@ -445,6 +445,7 @@ public class GeneratorLanguage extends LanguageProvider
 		add("living_upgrade.bloodmagic.repair", "Repairing");
 		add("living_upgrade.bloodmagic.curios_socket", "Socketed");
 		add("living_upgrade.bloodmagic.diamond_protect", "Brilliance");
+		add("living_upgrade.bloodmagic.gilded", "Gilded");
 
 		add("living_upgrade.bloodmagic.slowness", "Limp Leg");
 		add("living_upgrade.bloodmagic.crippled_arm", "Crippled Arm");

--- a/src/main/java/wayoftime/bloodmagic/common/item/ItemLivingArmor.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/ItemLivingArmor.java
@@ -7,17 +7,13 @@ import java.util.function.Consumer;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
-import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.*;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.item.ArmorItem;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
@@ -196,5 +192,13 @@ public class ItemLivingArmor extends ArmorItem implements ILivingContainer, Expa
 			return LivingStats.fromPlayer((Player) entity, true).getLevel(LivingArmorRegistrar.UPGRADE_ELYTRA.get().getKey()) > 0;
 		else
 			return false;
+	}
+
+	public boolean makesPiglinsNeutral(ItemStack stack, LivingEntity wearer)
+	{
+		if (stack.getItem() instanceof ItemLivingArmor && wearer instanceof Player && LivingUtil.hasFullSet((Player) wearer)) {
+			return LivingStats.fromPlayer((Player) wearer, true).getLevel(LivingArmorRegistrar.UPGRADE_GILDED.get().getKey()) > 0;
+		}
+		return false;
 	}
 }

--- a/src/main/java/wayoftime/bloodmagic/core/LivingArmorRegistrar.java
+++ b/src/main/java/wayoftime/bloodmagic/core/LivingArmorRegistrar.java
@@ -63,6 +63,7 @@ public class LivingArmorRegistrar
 		def.put("curios_socket", BloodMagic.rl("curios_socket"));
 		def.put("diamond_protect", BloodMagic.rl("diamond_protect"));
 		def.put("repair", BloodMagic.rl("repair"));
+		def.put("gilded", BloodMagic.rl("gilded"));
 		def.put("downgrade/quenched", BloodMagic.rl("downgrade/quenched"));
 		def.put("downgrade/storm_trooper", BloodMagic.rl("downgrade/storm_trooper"));
 		def.put("downgrade/battle_hungry", BloodMagic.rl("downgrade/battle_hungry"));
@@ -145,7 +146,7 @@ public class LivingArmorRegistrar
 		attributeMap.put(Attributes.ATTACK_DAMAGE, new AttributeModifier(uuid, "Damage Modifier 3", upgrade.getBonusValue("damage", level).doubleValue(), AttributeModifier.Operation.ADDITION));
 	}));
 	public static final LivingUpgradeRegistryObject<LivingUpgrade> UPGRADE_REPAIR = UPGRADES.register("repair", () -> parseDefinition("repair"));
-
+	public static final LivingUpgradeRegistryObject<LivingUpgrade> UPGRADE_GILDED = UPGRADES.register("gilded", () -> parseDefinition("gilded"));
 	public static final LivingUpgradeRegistryObject<LivingUpgrade> DOWNGRADE_QUENCHED = UPGRADES.register("downgrade/quenched", () -> parseDefinition("downgrade/quenched").asDowngrade());
 	public static final LivingUpgradeRegistryObject<LivingUpgrade> DOWNGRADE_STORM_TROOPER = UPGRADES.register("downgrade/storm_trooper", () -> parseDefinition("downgrade/storm_trooper").asDowngrade());
 	public static final LivingUpgradeRegistryObject<LivingUpgrade> DOWNGRADE_BATTLE_HUNGRY = UPGRADES.register("downgrade/battle_hungry", () -> parseDefinition("downgrade/battle_hungry").asDowngrade());
@@ -198,6 +199,7 @@ public class LivingArmorRegistrar
 		registerUpgrade(UPGRADE_DIAMOND.get());
 		registerUpgrade(UPGRADE_MELEE_DAMAGE.get());
 		registerUpgrade(UPGRADE_REPAIR.get());
+		registerUpgrade(UPGRADE_GILDED.get());
 		registerUpgrade(DOWNGRADE_QUENCHED.get());
 		registerUpgrade(DOWNGRADE_STORM_TROOPER.get());
 		registerUpgrade(DOWNGRADE_BATTLE_HUNGRY.get());

--- a/src/main/java/wayoftime/bloodmagic/util/handler/event/GenericHandler.java
+++ b/src/main/java/wayoftime/bloodmagic/util/handler/event/GenericHandler.java
@@ -13,6 +13,7 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.goal.MeleeAttackGoal;
 import net.minecraft.world.entity.ai.goal.target.TargetGoal;
+import net.minecraft.world.entity.monster.piglin.Piglin;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.Arrow;
 import net.minecraft.world.entity.projectile.ThrowableProjectile;
@@ -1189,5 +1190,17 @@ public class GenericHandler
 	{
 		int i = EnchantmentHelper.getItemEnchantmentLevel(Enchantments.QUICK_CHARGE, stack);
 		return i == 0 ? 25 : 25 - 5 * i;
+	}
+
+	@SubscribeEvent
+	public void onEntityInteract(PlayerInteractEvent.EntityInteract event){
+		if (event.getTarget() instanceof Piglin && event.getItemStack().is(Items.GOLD_INGOT))
+		{
+			Player player = event.getEntity();
+			if (LivingUtil.hasFullSet(player))
+			{
+				LivingUtil.applyNewExperience(player, LivingArmorRegistrar.UPGRADE_GILDED.get(), 1);
+			}
+		}
 	}
 }

--- a/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armor_upgrades/gilded.json
+++ b/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/alchemy_array/living_equipment/armor_upgrades/gilded.json
@@ -1,0 +1,15 @@
+{
+  "name": "Gilded",
+  "icon": "minecraft:golden_chestplate",
+  "category": "bloodmagic:alchemy_array/living_equipment/armor_upgrades",
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "Effect: Passivises Piglins as if you were wearing Golden Armor.$(br2)Trained by: Giving a Piglin a $(item)Gold Ingot$(). You must give it to them directly, it cannot be dropped on the ground.$(br2)Maximum level: 1"
+    },
+    {
+      "type": "bloodmagic:living_armour_upgrade_table",
+      "upgrade": "bloodmagic:gilded"
+    }
+  ]
+}

--- a/src/main/resources/data/bloodmagic/living_armor/gilded.json
+++ b/src/main/resources/data/bloodmagic/living_armor/gilded.json
@@ -1,0 +1,6 @@
+{
+  "id": "bloodmagic:gilded",
+  "levels": [
+    { "xp": 1, "cost": 5 }
+  ]
+}


### PR DESCRIPTION
A Living Armour Upgrade that makes Piglins passive (as if the player is wearing a piece of Gold armor).  Only works with a full set of Living Armour.

Replaces #1926.

~~Still working out how to obtain/train the upgrade.~~ The upgrade is now trained by giving a Piglin a Gold Ingot while wearing a full set of Living Armour (and having enough Upgrade Points available).  This works, but might be possible to be better.