### PR TITLE
Make Curio and Elytra-render Item checks generalized

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/client/render/entity/layers/BloodElytraLayer.java
+++ b/src/main/java/wayoftime/bloodmagic/client/render/entity/layers/BloodElytraLayer.java
@@ -10,6 +10,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import wayoftime.bloodmagic.common.item.ItemLivingArmor;
 import wayoftime.bloodmagic.core.LivingArmorRegistrar;
+import wayoftime.bloodmagic.core.living.ILivingContainer;
 import wayoftime.bloodmagic.core.living.LivingStats;
 import wayoftime.bloodmagic.core.living.LivingUtil;
 
@@ -25,7 +26,7 @@ public class BloodElytraLayer<T extends LivingEntity, M extends EntityModel<T>> 
 	@Override
 	public boolean shouldRender(ItemStack stack, T entity)
 	{
-		if (stack.getItem() instanceof ItemLivingArmor && entity instanceof Player && LivingUtil.hasFullSet((Player) entity))
+		if (stack.getItem() instanceof ILivingContainer && entity instanceof Player && LivingUtil.hasFullSet((Player) entity))
 			return LivingStats.fromPlayer((Player) entity, true).getLevel(LivingArmorRegistrar.UPGRADE_ELYTRA.get().getKey()) > 0;
 		return false;
 	}

--- a/src/main/java/wayoftime/bloodmagic/util/handler/event/GenericHandler.java
+++ b/src/main/java/wayoftime/bloodmagic/util/handler/event/GenericHandler.java
@@ -40,6 +40,7 @@ import wayoftime.bloodmagic.core.AnointmentRegistrar;
 import wayoftime.bloodmagic.core.LivingArmorRegistrar;
 import wayoftime.bloodmagic.core.data.Binding;
 import wayoftime.bloodmagic.core.data.SoulNetwork;
+import wayoftime.bloodmagic.core.living.ILivingContainer;
 import wayoftime.bloodmagic.core.living.LivingStats;
 import wayoftime.bloodmagic.core.living.LivingUtil;
 import wayoftime.bloodmagic.demonaura.WorldDemonWillHandler;
@@ -1143,7 +1144,7 @@ public class GenericHandler
 	{
 		if (BloodMagic.curiosLoaded)
 		{ // Without Curios, there is nothing this cares about.
-			if (event.getFrom().getItem() instanceof ItemLivingArmor || event.getTo().getItem() instanceof ItemLivingArmor)
+			if (event.getFrom().getItem() instanceof ILivingContainer || event.getTo().getItem() instanceof ILivingContainer)
 			{ // Armor change involves Living Armor
 				LivingEntity entity = event.getEntity();
 				if (entity instanceof Player)


### PR DESCRIPTION
Curios and BloodElytra specifically check for `ItemLivingArmor`. This PR makes the check generalized so that addons can easily use this behaviour
