### PR TITLE
Update Guidebook's Creative Tab + JEI

### DIFF
--- a/src/main/resources/data/bloodmagic/patchouli_books/guide/book.json
+++ b/src/main/resources/data/bloodmagic/patchouli_books/guide/book.json
@@ -4,7 +4,7 @@
   "landing_text": "guide.bloodmagic.landing_text",
   "book_texture": "patchouli:textures/gui/book_red.png",
   "filler_texture": "bloodmagic:textures/gui/patchouli_book/page_filler.png",
-  "creative_tab": "bloodmagictab",
+  "creative_tab": "bloodmagic:bloodmagic",
   "model": "bloodmagic:book",
   "show_progress": false,
   "use_resource_pack": true,


### PR DESCRIPTION
Update the Sanguine Scientiem's Creative Tab setting.  This makes it appear in the proper spot in the Creative Menu, and makes it show up in JEI again.