### PR TITLE
Removed Some Log Spam

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/recipe/serializer/MeteorRecipeSerializer.java
+++ b/src/main/java/wayoftime/bloodmagic/common/recipe/serializer/MeteorRecipeSerializer.java
@@ -14,6 +14,8 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.fml.ModList;
+import wayoftime.bloodmagic.BloodMagic;
 import wayoftime.bloodmagic.common.meteor.MeteorLayer;
 import wayoftime.bloodmagic.recipe.RecipeMeteor;
 import wayoftime.bloodmagic.util.Constants;
@@ -31,6 +33,12 @@ public class MeteorRecipeSerializer<RECIPE extends RecipeMeteor>  implements Rec
 	@Override
 	public RECIPE fromJson(@Nonnull ResourceLocation recipeId, @Nonnull JsonObject json)
 	{
+
+		// "modid" is optional.  If not specified, use our modID.  If the modID isn't present, skip this recipe.
+		String modId = GsonHelper.getAsString(json, Constants.JSON.MODID, BloodMagic.MODID);
+		if (!ModList.get().isLoaded(modId)){
+			return null;
+		}
 
 		JsonElement input = GsonHelper.isArrayNode(json, Constants.JSON.INPUT)
 				? GsonHelper.getAsJsonArray(json, Constants.JSON.INPUT)

--- a/src/main/java/wayoftime/bloodmagic/common/recipe/serializer/MeteorRecipeSerializer.java
+++ b/src/main/java/wayoftime/bloodmagic/common/recipe/serializer/MeteorRecipeSerializer.java
@@ -14,8 +14,6 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraftforge.fml.ModList;
-import wayoftime.bloodmagic.BloodMagic;
 import wayoftime.bloodmagic.common.meteor.MeteorLayer;
 import wayoftime.bloodmagic.recipe.RecipeMeteor;
 import wayoftime.bloodmagic.util.Constants;
@@ -33,12 +31,6 @@ public class MeteorRecipeSerializer<RECIPE extends RecipeMeteor>  implements Rec
 	@Override
 	public RECIPE fromJson(@Nonnull ResourceLocation recipeId, @Nonnull JsonObject json)
 	{
-
-		// "modid" is optional.  If not specified, use our modID.  If the modID isn't present, skip this recipe.
-		String modId = GsonHelper.getAsString(json, Constants.JSON.MODID, BloodMagic.MODID);
-		if (!ModList.get().isLoaded(modId)){
-			return null;
-		}
 
 		JsonElement input = GsonHelper.isArrayNode(json, Constants.JSON.INPUT)
 				? GsonHelper.getAsJsonArray(json, Constants.JSON.INPUT)

--- a/src/main/java/wayoftime/bloodmagic/util/Constants.java
+++ b/src/main/java/wayoftime/bloodmagic/util/Constants.java
@@ -243,6 +243,7 @@ public class Constants
 		public static final String SHELL = "shell";
 		public static final String LAYER = "layers";
 		public static final String EXPLOSION = "explosion";
+		public static final String MODID = "modid";
 
 	}
 

--- a/src/main/java/wayoftime/bloodmagic/util/Constants.java
+++ b/src/main/java/wayoftime/bloodmagic/util/Constants.java
@@ -243,7 +243,6 @@ public class Constants
 		public static final String SHELL = "shell";
 		public static final String LAYER = "layers";
 		public static final String EXPLOSION = "explosion";
-		public static final String MODID = "modid";
 
 	}
 

--- a/src/main/resources/assets/bloodmagic/models/block/blockalchemyarray.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockalchemyarray.json
@@ -1,6 +1,6 @@
 {
   "parent": "block/cube_all",
   "textures": {
-    "all": "bloodmagic:models/AlchemyArrays/StupidArray"
+    "all": "bloodmagic:models/alchemyarrays/stupidarray"
   }
 }

--- a/src/main/resources/assets/bloodmagic/models/block/blockalchemyarray.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockalchemyarray.json
@@ -1,6 +1,0 @@
-{
-  "parent": "block/cube_all",
-  "textures": {
-    "all": "bloodmagic:models/alchemyarrays/stupidarray"
-  }
-}

--- a/src/main/resources/assets/bloodmagic/models/block/blockbloodtank.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockbloodtank.json
@@ -1,8 +1,8 @@
 {
   "__comment": "Copyright © InsomniaKitten 2017",
   "textures": {
-    "particle": "bloodmagic:blocks/BlankRune",
-    "texture": "bloodmagic:blocks/BloodTank"
+    "particle": "bloodmagic:block/blankrune",
+    "texture": "bloodmagic:block/bloodtank"
   },
   "elements": [
     {

--- a/src/main/resources/assets/bloodmagic/models/block/blockdimensionalportal.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockdimensionalportal.json
@@ -1,7 +1,7 @@
 {
   "textures": {
-    "particle": "bloodmagic:blocks/lifeEssenceFlowing",
-    "portal": "bloodmagic:blocks/lifeEssenceFlowing"
+    "particle": "bloodmagic:block/lifeessenceflowing",
+    "portal": "bloodmagic:block/lifeessenceflowing"
   },
   "elements": [
     {   "from": [ 6, 0, 0 ],

--- a/src/main/resources/assets/bloodmagic/models/block/blockdimensionalportalew.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockdimensionalportalew.json
@@ -1,7 +1,7 @@
 {
   "textures": {
-    "particle": "bloodmagic:blocks/lifeEssenceFlowing",
-    "portal": "bloodmagic:blocks/lifeEssenceFlowing"
+    "particle": "bloodmagic:block/lifeessenceflowing",
+    "portal": "bloodmagic:block/lifeessenceflowing"
   },
   "elements": [
     {   "from": [ 6, 0, 0 ],

--- a/src/main/resources/assets/bloodmagic/models/block/blockdimensionalportalns.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockdimensionalportalns.json
@@ -1,7 +1,7 @@
 {
   "textures": {
-    "particle": "bloodmagic:blocks/lifeEssenceFlowing",
-    "portal": "bloodmagic:blocks/lifeEssenceFlowing"
+    "particle": "bloodmagic:block/lifeessenceflowing",
+    "portal": "bloodmagic:block/lifeessenceflowing"
   },
   "elements": [
     {   "from": [ 0, 0, 6 ],

--- a/src/main/resources/assets/bloodmagic/models/block/blockinputroutingnode.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockinputroutingnode.json
@@ -1,7 +1,7 @@
 {
   "parent": "block/cube_all",
   "textures": {
-    "all": "bloodmagic:blocks/InputRoutingNode"
+    "all": "bloodmagic:block/inputroutingnode"
   }
 }
 

--- a/src/main/resources/assets/bloodmagic/models/block/blockinputroutingnode.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockinputroutingnode.json
@@ -1,7 +1,0 @@
-{
-  "parent": "block/cube_all",
-  "textures": {
-    "all": "bloodmagic:block/inputroutingnode"
-  }
-}
-

--- a/src/main/resources/assets/bloodmagic/models/block/blockmasterroutingnode.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockmasterroutingnode.json
@@ -1,7 +1,7 @@
 {
   "parent": "block/cube_all",
   "textures": {
-    "all": "bloodmagic:blocks/MasterRoutingNode"
+    "all": "bloodmagic:block/masterroutingnode"
   }
 }
 

--- a/src/main/resources/assets/bloodmagic/models/block/blockmasterroutingnode.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockmasterroutingnode.json
@@ -1,8 +1,0 @@
-{
-  "parent": "block/cube_all",
-  "textures": {
-    "all": "bloodmagic:block/masterroutingnode"
-  }
-}
-
-

--- a/src/main/resources/assets/bloodmagic/models/block/blockoutputroutingnode.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockoutputroutingnode.json
@@ -1,7 +1,7 @@
 {
   "parent": "block/cube_all",
   "textures": {
-    "all": "bloodmagic:blocks/OutputRoutingNode"
+    "all": "bloodmagic:block/outputroutingnode"
   }
 }
 

--- a/src/main/resources/assets/bloodmagic/models/block/blockoutputroutingnode.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockoutputroutingnode.json
@@ -1,7 +1,0 @@
-{
-  "parent": "block/cube_all",
-  "textures": {
-    "all": "bloodmagic:block/outputroutingnode"
-  }
-}
-

--- a/src/main/resources/assets/bloodmagic/models/block/blockphantom.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockphantom.json
@@ -1,6 +1,6 @@
 {
     "parent": "block/cube_all",
     "textures": {
-        "all": "bloodmagic:blocks/PhantomBlock"
+        "all": "bloodmagic:block/phantomblock"
     }
 }

--- a/src/main/resources/assets/bloodmagic/models/block/blocksoulforge.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blocksoulforge.json
@@ -1,9 +1,0 @@
-{
-  "parent": "bloodmagic:block/sub/blocksoulforge",
-  "textures": {
-    "base": "minecraft:blocks/iron_block",
-	"base_bottom": "minecraft:blocks/gold_block",
-	"glass": "minecraft:blocks/glass",
-	"attachment": "minecraft:blocks/stone"
-  }
-}

--- a/src/main/resources/assets/bloodmagic/models/block/blocksoulforge.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blocksoulforge.json
@@ -1,5 +1,5 @@
 {
-  "parent": "bloodmagic:block/sub/BlockSoulForge",
+  "parent": "bloodmagic:block/sub/blocksoulforge",
   "textures": {
     "base": "minecraft:blocks/iron_block",
 	"base_bottom": "minecraft:blocks/gold_block",

--- a/src/main/resources/assets/bloodmagic/models/block/blockspectral.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockspectral.json
@@ -1,6 +1,6 @@
 {
     "parent": "block/cube_all",
     "textures": {
-        "all": "bloodmagic:blocks/SpectralBlock"
+        "all": "bloodmagic:block/spectralblock"
     }
 }

--- a/src/main/resources/assets/bloodmagic/models/block/blockspectral.json
+++ b/src/main/resources/assets/bloodmagic/models/block/blockspectral.json
@@ -1,6 +1,0 @@
-{
-    "parent": "block/cube_all",
-    "textures": {
-        "all": "bloodmagic:block/spectralblock"
-    }
-}

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_corrosive.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_corrosive.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_corrosive"
+        "layer0": "bloodmagic:item/sentientbow_corrosive"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_corrosive_pulling_0.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_corrosive_pulling_0.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_corrosive_pulling_0"
+        "layer0": "bloodmagic:item/sentientbow_corrosive_pulling_0"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_corrosive_pulling_1.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_corrosive_pulling_1.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_corrosive_pulling_1"
+        "layer0": "bloodmagic:item/sentientbow_corrosive_pulling_1"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_corrosive_pulling_2.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_corrosive_pulling_2.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_corrosive_pulling_2"
+        "layer0": "bloodmagic:item/sentientbow_corrosive_pulling_2"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_destructive.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_destructive.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_destructive"
+        "layer0": "bloodmagic:item/sentientbow_destructive"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_destructive_pulling_0.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_destructive_pulling_0.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_destructive_pulling_0"
+        "layer0": "bloodmagic:item/sentientbow_destructive_pulling_0"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_destructive_pulling_1.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_destructive_pulling_1.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_destructive_pulling_1"
+        "layer0": "bloodmagic:item/sentientbow_destructive_pulling_1"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_destructive_pulling_2.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_destructive_pulling_2.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_destructive_pulling_2"
+        "layer0": "bloodmagic:item/sentientbow_destructive_pulling_2"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_pulling_0.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_pulling_0.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_pulling_0"
+        "layer0": "bloodmagic:item/sentientbow_pulling_0"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_pulling_1.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_pulling_1.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_pulling_1"
+        "layer0": "bloodmagic:item/sentientbow_pulling_1"
     },
     "display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_pulling_2.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_pulling_2.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_pulling_2"
+        "layer0": "bloodmagic:item/sentientbow_pulling_2"
     },
     "display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_steadfast.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_steadfast.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_steadfast"
+        "layer0": "bloodmagic:item/sentientbow_steadfast"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_steadfast_pulling_0.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_steadfast_pulling_0.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_steadfast_pulling_0"
+        "layer0": "bloodmagic:item/sentientbow_steadfast_pulling_0"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_steadfast_pulling_1.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_steadfast_pulling_1.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_steadfast_pulling_1"
+        "layer0": "bloodmagic:item/sentientbow_steadfast_pulling_1"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_steadfast_pulling_2.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_steadfast_pulling_2.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_steadfast_pulling_2"
+        "layer0": "bloodmagic:item/sentientbow_steadfast_pulling_2"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_vengeful.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_vengeful.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_vengeful"
+        "layer0": "bloodmagic:item/sentientbow_vengeful"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_vengeful_pulling_0.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_vengeful_pulling_0.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_vengeful_pulling_0"
+        "layer0": "bloodmagic:item/sentientbow_vengeful_pulling_0"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_vengeful_pulling_1.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_vengeful_pulling_1.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_vengeful_pulling_1"
+        "layer0": "bloodmagic:item/sentientbow_vengeful_pulling_1"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_vengeful_pulling_2.json
+++ b/src/main/resources/assets/bloodmagic/models/item/bow/itemsentientbow_vengeful_pulling_2.json
@@ -1,7 +1,7 @@
 {
     "parent": "builtin/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow_vengeful_pulling_2"
+        "layer0": "bloodmagic:item/sentientbow_vengeful_pulling_2"
     },
 	"display": {
         "thirdperson_righthand": {

--- a/src/main/resources/assets/bloodmagic/models/item/sentient_bow.json
+++ b/src/main/resources/assets/bloodmagic/models/item/sentient_bow.json
@@ -1,7 +1,7 @@
 {
     "parent": "item/generated",
     "textures": {
-        "layer0": "bloodmagic:items/SentientBow"
+        "layer0": "bloodmagic:item/sentientbow"
     },
     "display": {
         "thirdperson_righthand": {
@@ -30,60 +30,60 @@
             "predicate": {
                 "type": 1
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_corrosive"
+            "model": "bloodmagic:item/bow/itemsentientbow_corrosive"
         },
         {
             "predicate": {
                 "type": 2
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_destructive"
+            "model": "bloodmagic:item/bow/itemsentientbow_destructive"
         },
         {
             "predicate": {
                 "type": 3
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_vengeful"
+            "model": "bloodmagic:item/bow/itemsentientbow_vengeful"
         },
         {
             "predicate": {
                 "type": 4
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_steadfast"
+            "model": "bloodmagic:item/bow/itemsentientbow_steadfast"
         },
         {
             "predicate": {
             	"type": 0,
                 "pulling": 1
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_pulling_0"
+            "model": "bloodmagic:item/bow/itemsentientbow_pulling_0"
         },
         {
             "predicate": {
             	"type": 1,
                 "pulling": 1
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_corrosive_pulling_0"
+            "model": "bloodmagic:item/bow/itemsentientbow_corrosive_pulling_0"
         },
         {
             "predicate": {
             	"type": 2,
                 "pulling": 1
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_destructive_pulling_0"
+            "model": "bloodmagic:item/bow/itemsentientbow_destructive_pulling_0"
         },
         {
             "predicate": {
             	"type": 3,
                 "pulling": 1
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_vengeful_pulling_0"
+            "model": "bloodmagic:item/bow/itemsentientbow_vengeful_pulling_0"
         },
         {
             "predicate": {
             	"type": 4,
                 "pulling": 1
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_steadfast_pulling_0"
+            "model": "bloodmagic:item/bow/itemsentientbow_steadfast_pulling_0"
         },
         {
             "predicate": {
@@ -91,7 +91,7 @@
                 "pulling": 1,
                 "pull": 0.65
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_pulling_1"
+            "model": "bloodmagic:item/bow/itemsentientbow_pulling_1"
         },
         {
             "predicate": {
@@ -99,7 +99,7 @@
                 "pulling": 1,
                 "pull": 0.65
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_corrosive_pulling_1"
+            "model": "bloodmagic:item/bow/itemsentientbow_corrosive_pulling_1"
         },
         {
             "predicate": {
@@ -107,7 +107,7 @@
                 "pulling": 1,
                 "pull": 0.65
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_destructive_pulling_1"
+            "model": "bloodmagic:item/bow/itemsentientbow_destructive_pulling_1"
         },
         {
             "predicate": {
@@ -115,7 +115,7 @@
                 "pulling": 1,
                 "pull": 0.65
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_vengeful_pulling_1"
+            "model": "bloodmagic:item/bow/itemsentientbow_vengeful_pulling_1"
         },
         {
             "predicate": {
@@ -123,7 +123,7 @@
                 "pulling": 1,
                 "pull": 0.65
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_steadfast_pulling_1"
+            "model": "bloodmagic:item/bow/itemsentientbow_steadfast_pulling_1"
         },
         {
             "predicate": {
@@ -131,7 +131,7 @@
                 "pulling": 1,
                 "pull": 0.9               
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_pulling_2"
+            "model": "bloodmagic:item/bow/itemsentientbow_pulling_2"
         },
         {
             "predicate": {
@@ -139,7 +139,7 @@
                 "pulling": 1,
                 "pull": 0.9
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_corrosive_pulling_2"
+            "model": "bloodmagic:item/bow/itemsentientbow_corrosive_pulling_2"
         },
         {
             "predicate": {
@@ -147,7 +147,7 @@
                 "pulling": 1,
                 "pull": 0.9
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_destructive_pulling_2"
+            "model": "bloodmagic:item/bow/itemsentientbow_destructive_pulling_2"
         },
         {
             "predicate": {
@@ -155,7 +155,7 @@
                 "pulling": 1,
                 "pull": 0.9
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_vengeful_pulling_2"
+            "model": "bloodmagic:item/bow/itemsentientbow_vengeful_pulling_2"
         },
         {
             "predicate": {
@@ -163,7 +163,7 @@
                 "pulling": 1,
                 "pull": 0.9
             },
-            "model": "bloodmagic:item/bow/ItemSentientBow_steadfast_pulling_2"
+            "model": "bloodmagic:item/bow/itemsentientbow_steadfast_pulling_2"
         }
     ]
 }

--- a/src/main/resources/data/bloodmagic/recipes/meteor/ae2.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/ae2.json
@@ -1,5 +1,6 @@
 {
   "type": "bloodmagic:meteor",
+  "modid": "appliedenergistics2",
   "input": {
     "tag": "forge:gems/certus_quartz"
   },

--- a/src/main/resources/data/bloodmagic/recipes/meteor/ae2.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/ae2.json
@@ -1,6 +1,5 @@
 {
   "type": "bloodmagic:meteor",
-  "modid": "appliedenergistics2",
   "input": {
     "tag": "forge:gems/certus_quartz"
   },

--- a/src/main/resources/data/bloodmagic/recipes/meteor/ae2.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/ae2.json
@@ -1,39 +1,52 @@
 {
-  "type": "bloodmagic:meteor",
-  "input": {
-    "tag": "forge:gems/certus_quartz"
-  },
-  "syphon": 500000,
-  "explosion": 24.0,
-  "layers": [
+  "type": "forge:conditional",
+  "recipes": [
     {
-      "radius": 2,
-      "additionalWeight": 0,
-      "minWeight": 0,
-      "weightMap": [
+      "conditions": [
         {
-          "tag": "appliedenergistics2:fluix_block",
-          "weight": 100
+          "type": "forge:mod_loaded",
+          "modid": "appliedenergistics2"
         }
       ],
-      "fill": "appliedenergistics2:sky_stone_block"
-    },
-    {
-      "radius": 7,
-      "additionalWeight": 200,
-      "minWeight": 0,
-      "weightMap": [
-        {
-          "tag": "#forge:ores/certus_quartz#0",
-          "weight": 100
+      "recipe": {
+        "type": "bloodmagic:meteor",
+        "input": {
+          "tag": "forge:gems/certus_quartz"
         },
-        {
-          "tag": "#forge:storage_blocks/quartz#0",
-          "weight": 50
-        }
-      ],
-      "fill": "appliedenergistics2:sky_stone_block",
-      "shell": "appliedenergistics2:sky_stone_block"
+        "syphon": 500000,
+        "explosion": 24.0,
+        "layers": [
+          {
+            "radius": 2,
+            "additionalWeight": 0,
+            "minWeight": 0,
+            "weightMap": [
+              {
+                "tag": "appliedenergistics2:fluix_block",
+                "weight": 100
+              }
+            ],
+            "fill": "appliedenergistics2:sky_stone_block"
+          },
+          {
+            "radius": 7,
+            "additionalWeight": 200,
+            "minWeight": 0,
+            "weightMap": [
+              {
+                "tag": "#forge:ores/certus_quartz#0",
+                "weight": 100
+              },
+              {
+                "tag": "#forge:storage_blocks/quartz#0",
+                "weight": 50
+              }
+            ],
+            "fill": "appliedenergistics2:sky_stone_block",
+            "shell": "appliedenergistics2:sky_stone_block"
+          }
+        ]
+      }
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/recipes/meteor/create.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/create.json
@@ -1,6 +1,5 @@
 {
   "type": "bloodmagic:meteor",
-  "modid": "create",
   "input": {
     "item": "create:andesite_alloy"
   },

--- a/src/main/resources/data/bloodmagic/recipes/meteor/create.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/create.json
@@ -1,30 +1,43 @@
 {
-  "type": "bloodmagic:meteor",
-  "input": {
-    "item": "create:andesite_alloy"
-  },
-  "syphon": 500000,
-  "explosion": 24.0,
-  "layers": [
+  "type": "forge:conditional",
+  "recipes": [
     {
-      "radius": 6,
-      "additionalWeight": 200,
-      "minWeight": 0,
-      "weightMap": [
+      "conditions": [
         {
-          "tag": "#forge:ores/copper#0",
-          "weight": 100
-        },
-        {
-          "tag": "#forge:ores/zinc#0",
-          "weight": 100
-        },
-        {
-          "tag": "minecraft:iron_ore",
-          "weight": 50
+          "type": "forge:mod_loaded",
+          "modid": "create"
         }
       ],
-      "fill": "minecraft:andesite"
+      "recipe": {
+        "type": "bloodmagic:meteor",
+        "input": {
+          "item": "create:andesite_alloy"
+        },
+        "syphon": 500000,
+        "explosion": 24.0,
+        "layers": [
+          {
+            "radius": 6,
+            "additionalWeight": 200,
+            "minWeight": 0,
+            "weightMap": [
+              {
+                "tag": "#forge:ores/copper#0",
+                "weight": 100
+              },
+              {
+                "tag": "#forge:ores/zinc#0",
+                "weight": 100
+              },
+              {
+                "tag": "minecraft:iron_ore",
+                "weight": 50
+              }
+            ],
+            "fill": "minecraft:andesite"
+          }
+        ]
+      }
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/recipes/meteor/create.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/create.json
@@ -1,5 +1,6 @@
 {
   "type": "bloodmagic:meteor",
+  "modid": "create",
   "input": {
     "item": "create:andesite_alloy"
   },

--- a/src/main/resources/data/bloodmagic/recipes/meteor/immersive_engineering.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/immersive_engineering.json
@@ -1,42 +1,55 @@
 {
-  "type": "bloodmagic:meteor",
-  "input": {
-    "item": "immersiveengineering:wirecoil_copper"
-  },
-  "syphon": 500000,
-  "explosion": 24.0,
-  "layers": [
+  "type": "forge:conditional",
+  "recipes": [
     {
-      "radius": 8,
-      "additionalWeight": 200,
-      "minWeight": 0,
-      "weightMap": [
+      "conditions": [
         {
-          "tag": "#forge:ores/copper#0",
-          "weight": 100
-        },
-        {
-          "tag": "#forge:ores/lead#0",
-          "weight": 60
-        },
-        {
-          "tag": "#forge:ores/nickel#0",
-          "weight": 50
-        },
-        {
-          "tag": "#forge:ores/aluminum#0",
-          "weight": 50
-        },
-        {
-          "tag": "#forge:ores/silver#0",
-          "weight": 50
-        },
-        {
-          "tag": "#forge:ores/uranium#0",
-          "weight": 50
+          "type": "forge:mod_loaded",
+          "modid": "immersiveengineering"
         }
       ],
-      "fill": "minecraft:stone"
+      "recipe": {
+        "type": "bloodmagic:meteor",
+        "input": {
+          "item": "immersiveengineering:wirecoil_copper"
+        },
+        "syphon": 500000,
+        "explosion": 24.0,
+        "layers": [
+          {
+            "radius": 8,
+            "additionalWeight": 200,
+            "minWeight": 0,
+            "weightMap": [
+              {
+                "tag": "#forge:ores/copper#0",
+                "weight": 100
+              },
+              {
+                "tag": "#forge:ores/lead#0",
+                "weight": 60
+              },
+              {
+                "tag": "#forge:ores/nickel#0",
+                "weight": 50
+              },
+              {
+                "tag": "#forge:ores/aluminum#0",
+                "weight": 50
+              },
+              {
+                "tag": "#forge:ores/silver#0",
+                "weight": 50
+              },
+              {
+                "tag": "#forge:ores/uranium#0",
+                "weight": 50
+              }
+            ],
+            "fill": "minecraft:stone"
+          }
+        ]
+      }
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/recipes/meteor/immersive_engineering.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/immersive_engineering.json
@@ -1,5 +1,6 @@
 {
   "type": "bloodmagic:meteor",
+  "modid": "immersiveengineering",
   "input": {
     "item": "immersiveengineering:wirecoil_copper"
   },

--- a/src/main/resources/data/bloodmagic/recipes/meteor/immersive_engineering.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/immersive_engineering.json
@@ -1,6 +1,5 @@
 {
   "type": "bloodmagic:meteor",
-  "modid": "immersiveengineering",
   "input": {
     "item": "immersiveengineering:wirecoil_copper"
   },

--- a/src/main/resources/data/bloodmagic/recipes/meteor/myst_ag.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/myst_ag.json
@@ -1,6 +1,5 @@
 {
   "type": "bloodmagic:meteor",
-  "modid": "mysticalagriculture",
   "input": {
     "item": "mysticalagriculture:prosperity_shard"
   },

--- a/src/main/resources/data/bloodmagic/recipes/meteor/myst_ag.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/myst_ag.json
@@ -1,5 +1,6 @@
 {
   "type": "bloodmagic:meteor",
+  "modid": "mysticalagriculture",
   "input": {
     "item": "mysticalagriculture:prosperity_shard"
   },

--- a/src/main/resources/data/bloodmagic/recipes/meteor/myst_ag.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/myst_ag.json
@@ -1,46 +1,59 @@
 {
-  "type": "bloodmagic:meteor",
-  "input": {
-    "item": "mysticalagriculture:prosperity_shard"
-  },
-  "syphon": 500000,
-  "explosion": 24.0,
-  "layers": [
+  "type": "forge:conditional",
+  "recipes": [
     {
-      "radius": 7,
-      "additionalWeight": 200,
-      "minWeight": 0,
-      "weightMap": [
+      "conditions": [
         {
-          "tag": "#forge:ores/prosperity#0",
-          "weight": 100
-        },
-        {
-          "tag": "#forge:ores/inferium#0",
-          "weight": 100
+          "type": "forge:mod_loaded",
+          "modid": "mysticalagriculture"
         }
       ],
-      "fill": "minecraft:stone"
-    },
-    {
-      "radius": 3,
-      "additionalWeight": 0,
-      "minWeight": 0,
-      "weightMap": [
-        {
-          "tag": "#forge:ores/soulium#0",
-          "weight": 100
+      "recipe": {
+        "type": "bloodmagic:meteor",
+        "input": {
+          "item": "mysticalagriculture:prosperity_shard"
         },
-        {
-          "tag": "minecraft:soul_sand",
-          "weight": 50
-        },
-        {
-          "tag": "minecraft:soul_soil",
-          "weight": 50
-        }
-      ],
-      "fill": "minecraft:stone"
+        "syphon": 500000,
+        "explosion": 24.0,
+        "layers": [
+          {
+            "radius": 7,
+            "additionalWeight": 200,
+            "minWeight": 0,
+            "weightMap": [
+              {
+                "tag": "#forge:ores/prosperity#0",
+                "weight": 100
+              },
+              {
+                "tag": "#forge:ores/inferium#0",
+                "weight": 100
+              }
+            ],
+            "fill": "minecraft:stone"
+          },
+          {
+            "radius": 3,
+            "additionalWeight": 0,
+            "minWeight": 0,
+            "weightMap": [
+              {
+                "tag": "#forge:ores/soulium#0",
+                "weight": 100
+              },
+              {
+                "tag": "minecraft:soul_sand",
+                "weight": 50
+              },
+              {
+                "tag": "minecraft:soul_soil",
+                "weight": 50
+              }
+            ],
+            "fill": "minecraft:stone"
+          }
+        ]
+      }
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/recipes/meteor/thermal.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/thermal.json
@@ -1,59 +1,72 @@
 {
-  "type": "bloodmagic:meteor",
-  "input": {
-    "item": "thermal:rf_coil"
-  },
-  "syphon": 500000,
-  "explosion": 30.0,
-  "layers": [
+  "type": "forge:conditional",
+  "recipes": [
     {
-      "radius": 9,
-      "additionalWeight": 200,
-      "minWeight": 0,
-      "weightMap": [
+      "conditions": [
         {
-          "tag": "#forge:ores/copper#0",
-          "weight": 100
-        },
-        {
-          "tag": "#forge:ores/tin#0",
-          "weight": 80
-        },
-        {
-          "tag": "#forge:ores/lead#0",
-          "weight": 60
-        },
-        {
-          "tag": "#forge:ores/sulfur#0",
-          "weight": 60
-        },
-        {
-          "tag": "#forge:ores/apatite#0",
-          "weight": 50
-        },
-        {
-          "tag": "#forge:ores/silver#0",
-          "weight": 50
-        },
-        {
-          "tag": "#forge:ores/nickel#0",
-          "weight": 40
-        },
-        {
-          "tag": "#forge:ores/cinnabar#0",
-          "weight": 30
-        },
-        {
-          "tag": "#forge:ores/niter#0",
-          "weight": 30
-        },
-        {
-          "tag": "#forge:ores/ruby#0",
-          "weight": 20
+          "type": "forge:mod_loaded",
+          "modid": "thermal"
         }
       ],
-      "fill": "minecraft:stone",
-      "shell": "#forge:storage_blocks/slag#0"
+      "recipe": {
+        "type": "bloodmagic:meteor",
+        "input": {
+          "item": "thermal:rf_coil"
+        },
+        "syphon": 500000,
+        "explosion": 30.0,
+        "layers": [
+          {
+            "radius": 9,
+            "additionalWeight": 200,
+            "minWeight": 0,
+            "weightMap": [
+              {
+                "tag": "#forge:ores/copper#0",
+                "weight": 100
+              },
+              {
+                "tag": "#forge:ores/tin#0",
+                "weight": 80
+              },
+              {
+                "tag": "#forge:ores/lead#0",
+                "weight": 60
+              },
+              {
+                "tag": "#forge:ores/sulfur#0",
+                "weight": 60
+              },
+              {
+                "tag": "#forge:ores/apatite#0",
+                "weight": 50
+              },
+              {
+                "tag": "#forge:ores/silver#0",
+                "weight": 50
+              },
+              {
+                "tag": "#forge:ores/nickel#0",
+                "weight": 40
+              },
+              {
+                "tag": "#forge:ores/cinnabar#0",
+                "weight": 30
+              },
+              {
+                "tag": "#forge:ores/niter#0",
+                "weight": 30
+              },
+              {
+                "tag": "#forge:ores/ruby#0",
+                "weight": 20
+              }
+            ],
+            "fill": "minecraft:stone",
+            "shell": "#forge:storage_blocks/slag#0"
+          }
+        ]
+      }
     }
   ]
 }

--- a/src/main/resources/data/bloodmagic/recipes/meteor/thermal.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/thermal.json
@@ -1,5 +1,6 @@
 {
   "type": "bloodmagic:meteor",
+  "modid": "thermal",
   "input": {
     "item": "thermal:rf_coil"
   },

--- a/src/main/resources/data/bloodmagic/recipes/meteor/thermal.json
+++ b/src/main/resources/data/bloodmagic/recipes/meteor/thermal.json
@@ -1,6 +1,5 @@
 {
   "type": "bloodmagic:meteor",
-  "modid": "thermal",
   "input": {
     "item": "thermal:rf_coil"
   },


### PR DESCRIPTION
Changed several unused Models to use the new Resource Locations.  The previous ones had several UpperCase letters which are no longer valid and were throwing "Invalid Resource Location" errors.  The only models which didn't have assets in the new location were the Routing Nodes, which appear to have a different Model already.  Consider removing their unused models?

~~Made the Meteor Recipe check to see if a listed Mod ID is loaded.  This "modid" is optional and will use our ID (which is obviously loaded) if not listed.  If the supplied Mod ID is not loaded the recipe supplier returns null, which skips it with a single line in the log.  Added Mod IDs to the 5 mod-compat Meteors based on what was used for 1.16 documentation.~~

New: The Mod-Compat Meteor Recipes were changed to use Forge's Conditional loading system.  The Mod IDs used were pulled from the 1.16 documentation.

These changes remove 31 Stack Traces during startup (Invalid Resource Location), and 4 more on World Join and Data Pack Reloads (invalid recipe missing item; the AE2 one used a Tag that didn't throw an error) if those mods are missing (invalid recipe missing item), removing nearly 1,000 lines of log spam.