### PR TITLE
Update Spectral Block/Tile

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/block/BlockSpectral.java
+++ b/src/main/java/wayoftime/bloodmagic/common/block/BlockSpectral.java
@@ -3,12 +3,14 @@ package wayoftime.bloodmagic.common.block;
 import java.util.Random;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
@@ -30,22 +32,14 @@ public class BlockSpectral extends Block implements EntityBlock
 		super(prop);
 	}
 
-	public void tick(BlockState state, ServerLevel world, BlockPos pos, Random rand)
-	{
-		switch (state.getValue(SPECTRAL_STATE))
-		{
-		case SOLID:
-			world.setBlock(pos, state.setValue(SPECTRAL_STATE, SpectralBlockType.LEAKING), 3);
-			world.scheduleTick(pos, this, BlockSpectral.DECAY_RATE);
-			break;
-		case LEAKING:
-			BlockEntity tile = world.getBlockEntity(pos);
+	@Override
+	public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> type) {
+		return (level1, blockPos, blockState, tile) -> {
 			if (tile instanceof TileSpectral)
 			{
-				((TileSpectral) tile).revertToFluid();
+				((TileSpectral) tile).tick();
 			}
-			break;
-		}
+		};
 	}
 
 	@Override

--- a/src/main/java/wayoftime/bloodmagic/common/tile/TileSpectral.java
+++ b/src/main/java/wayoftime/bloodmagic/common/tile/TileSpectral.java
@@ -15,6 +15,10 @@ import wayoftime.bloodmagic.common.block.BloodMagicBlocks;
 import wayoftime.bloodmagic.common.block.type.SpectralBlockType;
 import wayoftime.bloodmagic.common.tile.base.TileBase;
 
+import java.util.Random;
+
+import static wayoftime.bloodmagic.common.block.BlockSpectral.SPECTRAL_STATE;
+
 public class TileSpectral extends TileBase
 {
 	public BlockState storedBlock;
@@ -81,5 +85,24 @@ public class TileSpectral extends TileBase
 	{
 		tag.put("BlockState", NbtUtils.writeBlockState(storedBlock));
 		return tag;
+	}
+
+	public void tick()
+	{
+		BlockState state = this.getBlockState();
+		BlockPos pos = this.getBlockPos();
+		Level level = this.getLevel();
+		switch (state.getValue(SPECTRAL_STATE)) {
+			case SOLID -> {
+				level.setBlock(pos, state.setValue(SPECTRAL_STATE, SpectralBlockType.LEAKING), 3);
+				level.scheduleTick(pos, state.getBlock(), BlockSpectral.DECAY_RATE);
+			}
+			case LEAKING -> {
+				BlockEntity tile = level.getBlockEntity(pos);
+				if (tile instanceof TileSpectral) {
+					((TileSpectral) tile).revertToFluid();
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
`BlockSpectral.tick` was no longer being called.  Set up `BlockSpectra.getTicker` and moved tick logic to `TileSpectral.tick`.  This makes the Spectral Block decay back into the fluid block.

Currently needs review to ensure it works as intended.  Other changes may be required (ex. `canBeReplaced` is depreciated).

Fixes #1978.