### PR TITLE
Fix and Upgrade Routing Node Amount Text Box

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/client/screens/ScreenFilter.java
+++ b/src/main/java/wayoftime/bloodmagic/client/screens/ScreenFilter.java
@@ -221,10 +221,20 @@ public class ScreenFilter extends ScreenBase<ContainerFilter>
 	{
 		boolean testBool = super.mouseClicked(mouseX, mouseY, mouseButton);
 
-		if (this.textBox.mouseClicked(mouseX, mouseY, mouseButton))
-		{
-			return true;
+		if (container.lastGhostSlotClicked != -1) { // Text box only selectable if a ghost slot has been clicked.
+			if (this.textBox.mouseClicked(mouseX, mouseY, mouseButton)) { // Left-Clicked
+				this.textBox.setFocused(true);
+				return true;
+			}
+			if (this.textBox.isMouseOver(mouseX, mouseY) && mouseButton == 1) // Right-Clicked
+			{
+				this.textBox.setValue("");
+				setValueOfGhostItemInSlot(container.lastGhostSlotClicked, 0);
+				this.textBox.setFocused(true);
+				return true;
+			}
 		}
+		this.textBox.setFocused(false);
 
 		if (container.lastGhostSlotClicked != -1)
 		{


### PR DESCRIPTION
Made the Routing Node Amount Textbox selectable again.  Fixes #1980

Made the Text Box only selectable if a Ghost Filter Slot has been clicked.  Prevents players from typing in a value for nothing.

Added a Right-Click function to the text box.  This will clear it, set the ghost item value back to 0 ("Everything"), and select the Text Box for a new number.