### PR TITLE
fix soul network reference for single player

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/util/helper/NetworkHelper.java
+++ b/src/main/java/wayoftime/bloodmagic/util/helper/NetworkHelper.java
@@ -9,7 +9,11 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.storage.DimensionDataStorage;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.server.ServerStoppedEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.server.ServerLifecycleHooks;
+import wayoftime.bloodmagic.BloodMagic;
 import wayoftime.bloodmagic.common.item.BloodOrb;
 import wayoftime.bloodmagic.common.item.IBindable;
 import wayoftime.bloodmagic.common.item.IBloodOrb;
@@ -20,13 +24,11 @@ import wayoftime.bloodmagic.core.data.SoulTicket;
 import wayoftime.bloodmagic.core.registry.OrbRegistry;
 import wayoftime.bloodmagic.event.SoulNetworkEvent;
 
+@Mod.EventBusSubscriber(modid = BloodMagic.MODID)
 public class NetworkHelper
 {
 	@Nullable
 	private static BMWorldSavedData dataHandler;
-
-	@Nullable
-	private static DimensionDataStorage cachedDataStorage; // for updating dataHandler Reference
 
 	/**
 	 * Gets the SoulNetwork for the player.
@@ -36,13 +38,13 @@ public class NetworkHelper
 	 */
 	public static SoulNetwork getSoulNetwork(String uuid)
 	{
-		if (ServerLifecycleHooks.getCurrentServer() == null)
-			return null;
-
-		DimensionDataStorage savedData = ServerLifecycleHooks.getCurrentServer().overworld().getDataStorage();
-
-		if (dataHandler == null || cachedDataStorage != savedData)
+		if (dataHandler == null)
 		{
+			if (ServerLifecycleHooks.getCurrentServer() == null)
+				return null;
+
+			DimensionDataStorage savedData = ServerLifecycleHooks.getCurrentServer().overworld().getDataStorage();
+
 			dataHandler = savedData.computeIfAbsent(BMWorldSavedData::load, () -> new BMWorldSavedData(), BMWorldSavedData.ID);
 		}
 
@@ -252,5 +254,10 @@ public class NetworkHelper
 		int currentNumberOfDungeons = dataHandler.getNumberOfDungeons();
 		dataHandler.setNumberOfDungeons(currentNumberOfDungeons + 1);
 		dataHandler.setDirty();
+	}
+
+	@SubscribeEvent
+	public static void resetDatahandler(ServerStoppedEvent event) {
+		dataHandler = null;
 	}
 }

--- a/src/main/java/wayoftime/bloodmagic/util/helper/NetworkHelper.java
+++ b/src/main/java/wayoftime/bloodmagic/util/helper/NetworkHelper.java
@@ -25,6 +25,9 @@ public class NetworkHelper
 	@Nullable
 	private static BMWorldSavedData dataHandler;
 
+	@Nullable
+	private static DimensionDataStorage cachedDataStorage; // for updating dataHandler Reference
+
 	/**
 	 * Gets the SoulNetwork for the player.
 	 *
@@ -33,16 +36,14 @@ public class NetworkHelper
 	 */
 	public static SoulNetwork getSoulNetwork(String uuid)
 	{
-		if (dataHandler == null)
+		if (ServerLifecycleHooks.getCurrentServer() == null)
+			return null;
+
+		DimensionDataStorage savedData = ServerLifecycleHooks.getCurrentServer().overworld().getDataStorage();
+
+		if (dataHandler == null || cachedDataStorage != savedData)
 		{
-			if (ServerLifecycleHooks.getCurrentServer() == null)
-				return null;
-
-			DimensionDataStorage savedData = ServerLifecycleHooks.getCurrentServer().overworld().getDataStorage();
-
 			dataHandler = savedData.computeIfAbsent(BMWorldSavedData::load, () -> new BMWorldSavedData(), BMWorldSavedData.ID);
-//			dataHandler = savedData.computeIfAbsent(() -> new BMWorldSavedData(), BMWorldSavedData.ID);
-//			dataHandler = BMWorldSavedData.load(tagCompound);
 		}
 
 		return dataHandler.getNetwork(UUID.fromString(uuid));


### PR DESCRIPTION
Fixes #1982 
adds a variable that caches the reference to DimensionDataStorage and updates savedDatahandler when references are updated 
