### PR TITLE
Add Sacrifice to "No Impact" Damage Type Tag

### DIFF
--- a/src/generated/resources/data/minecraft/tags/damage_type/no_impact.json
+++ b/src/generated/resources/data/minecraft/tags/damage_type/no_impact.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "bloodmagic:sacrifice"
+  ]
+}

--- a/src/main/java/wayoftime/bloodmagic/common/data/GeneratorDamageTags.java
+++ b/src/main/java/wayoftime/bloodmagic/common/data/GeneratorDamageTags.java
@@ -21,5 +21,6 @@ public class GeneratorDamageTags extends TagsProvider<DamageType> {
     protected void addTags(HolderLookup.Provider provider) {
         this.tag(DamageTypeTags.BYPASSES_ARMOR).add(BloodMagicDamageTypes.SACRIFICE).add(BloodMagicDamageTypes.RITUAL);
         this.tag(DamageTypeTags.BYPASSES_EFFECTS).add(BloodMagicDamageTypes.SACRIFICE);
+        this.tag(DamageTypeTags.NO_IMPACT).add(BloodMagicDamageTypes.SACRIFICE);
     }
 }


### PR DESCRIPTION
Added the BloodMagic:Sacrifice Damage Type to the "No Impact" Damage Type Tag.  This stops the game from resetting the player's momentum when this damage occurs.

Not having that Tag caused the Air Sigil to be ineffective if the associated Soul Network was empty.  They would use the Sigil, start moving, get damaged, then have their momentum reset.  See #1996