### PR TITLE
[1.20.1] Makes Living Evolution configurable

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/item/ItemLivingArmor.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/ItemLivingArmor.java
@@ -15,13 +15,11 @@ import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.extensions.IForgeItem;
-import wayoftime.bloodmagic.BloodMagic;
 import wayoftime.bloodmagic.core.LivingArmorRegistrar;
 import wayoftime.bloodmagic.core.living.ILivingContainer;
 import wayoftime.bloodmagic.core.living.LivingStats;
@@ -165,7 +163,12 @@ public class ItemLivingArmor extends ArmorItem implements ILivingContainer, Expa
 //        stack.damage((int) damage, livingEntity, entity -> {});
 	}
 
-	@Override
+    @Override
+    public boolean canLivingEvolve() {
+        return true;
+    }
+
+    @Override
 	@OnlyIn(Dist.CLIENT)
 	public void appendHoverText(ItemStack stack, Level world, List<Component> tooltip, TooltipFlag flag)
 	{

--- a/src/main/java/wayoftime/bloodmagic/core/living/ILivingContainer.java
+++ b/src/main/java/wayoftime/bloodmagic/core/living/ILivingContainer.java
@@ -82,4 +82,8 @@ public interface ILivingContainer
 			});
 		}
 	}
+
+    default boolean canLivingEvolve(){
+        return false;
+    }
 }

--- a/src/main/java/wayoftime/bloodmagic/core/living/LivingStats.java
+++ b/src/main/java/wayoftime/bloodmagic/core/living/LivingStats.java
@@ -17,9 +17,11 @@ public class LivingStats
 {
 
 	public static final int DEFAULT_UPGRADE_POINTS = 100;
+    public static final int DEFAULT_EVOLVED_UPGRADE_POINTS = 300;
 
 	protected final Map<LivingUpgrade, Double> upgrades;
 	protected int maxPoints = DEFAULT_UPGRADE_POINTS;
+    protected boolean evolved = false;
 
 	public LivingStats(Map<LivingUpgrade, Double> upgrades)
 	{
@@ -97,6 +99,18 @@ public class LivingStats
 		return this;
 	}
 
+    public boolean isEvolved()
+    {
+        return evolved;
+    }
+
+    public LivingStats setEvolved()
+    {
+        this.evolved = true;
+        this.setMaxPoints(DEFAULT_EVOLVED_UPGRADE_POINTS);
+        return this;
+    }
+
 	public CompoundTag serialize()
 	{
 		CompoundTag compound = new CompoundTag();
@@ -108,8 +122,8 @@ public class LivingStats
 			statList.add(upgrade);
 		});
 		compound.put("upgrades", statList);
-
 		compound.putInt("maxPoints", maxPoints);
+        compound.putBoolean("evolved", evolved);
 
 		return compound;
 	}
@@ -129,6 +143,7 @@ public class LivingStats
 		});
 
 		maxPoints = nbt.getInt("maxPoints");
+        evolved = nbt.getBoolean("evolved");
 	}
 
 	public static LivingStats fromNBT(CompoundTag statTag)

--- a/src/main/java/wayoftime/bloodmagic/ritual/types/RitualArmourEvolve.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/types/RitualArmourEvolve.java
@@ -7,10 +7,10 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LightningBolt;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import wayoftime.bloodmagic.BloodMagic;
+import wayoftime.bloodmagic.core.living.ILivingContainer;
 import wayoftime.bloodmagic.core.living.LivingStats;
 import wayoftime.bloodmagic.core.living.LivingUtil;
 import wayoftime.bloodmagic.ritual.AreaDescriptor;
@@ -51,12 +51,12 @@ public class RitualArmourEvolve extends Ritual
 		{
 			if (LivingUtil.hasFullSet(player))
 			{
-				ItemStack chestStack = player.getItemBySlot(EquipmentSlot.CHEST);
+				ILivingContainer chestpiece = (ILivingContainer) player.getItemBySlot(EquipmentSlot.CHEST).getItem();
 				LivingStats stats = LivingStats.fromPlayer(player);
 
-				if (stats != null && stats.getMaxPoints() < 300)
+				if (stats != null && chestpiece.canLivingEvolve() && !stats.isEvolved())
 				{
-					stats.setMaxPoints(300);
+					stats.setEvolved();
 					LivingStats.toPlayer(player, stats);
 //					((ItemLivingArmour) chestStack.getItem()).setLivingArmour(chestStack, armour, true);
 


### PR DESCRIPTION
`LivingStats` tag now contain a boolean `evolved` that stores whether the Item has evolved or not. Living evolution ritual now simply calls the `setEvolved` method in `LivingStats` which updates the tag to true. By default, this also updates the `maxPoints` to 300, but this can be overridden for custom behaviour.
For example, One could remove the points update during evolution for custom item but still retain the information that item has evolved or not.
`ILivingContainer` also now contains a method to control whether evolution is allowed or not.