### PR TITLE
Arc tools can be extracted from top

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/tile/TileAlchemicalReactionChamber.java
+++ b/src/main/java/wayoftime/bloodmagic/common/tile/TileAlchemicalReactionChamber.java
@@ -466,6 +466,11 @@ public class TileAlchemicalReactionChamber extends TileInventory implements Menu
 	@Override
 	public boolean canTakeItemThroughFace(int index, ItemStack stack, Direction direction)
 	{
+		if (index == ARC_TOOL_SLOT)
+		{
+			return true;
+		}
+		
 		return index >= OUTPUT_SLOT && index < OUTPUT_SLOT + NUM_OUTPUTS;
 	}
 


### PR DESCRIPTION
Added the Arc Tool Slot to the list of slots items can be extracted from. 

The Patchouli Book already states this is possible.