### PR TITLE
fix spectral sight with mixins (backport #2005 to 1.18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ run
 
 # Files from Forge MDK
 forge*changelog.txt
+/src/generated/resources/.cache/
+/run-data/

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
-        classpath group: 'org.spongepowered', name: 'mixingradle', version: '0.7-SNAPSHOT'
+        classpath group: 'org.spongepowered', name: 'mixingradle', version: '0.7+'
     }
 }
 apply plugin: 'net.minecraftforge.gradle'
@@ -30,7 +30,7 @@ minecraft {
     runs {
         client {
             workingDirectory project.file('run')
-            
+
 //            properties 'mixin.env.disableRefMap': 'true'
 
             // Recommended logging data for a userdev environment
@@ -38,7 +38,7 @@ minecraft {
 
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
-            
+
             property 'mixin.env.remapRefMap', 'true'
             property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
 
@@ -51,7 +51,7 @@ minecraft {
 
         server {
             workingDirectory project.file('run')
-            
+
 //            properties 'mixin.env.disableRefMap': 'true'
 
             // Recommended logging data for a userdev environment
@@ -59,7 +59,7 @@ minecraft {
 
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
-            
+
             property 'mixin.env.remapRefMap', 'true'
             property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
 
@@ -72,7 +72,7 @@ minecraft {
 
         data {
             workingDirectory project.file('run')
-            
+
 //            properties 'mixin.env.disableRefMap': 'true'
 
             // Recommended logging data for a userdev environment
@@ -116,16 +116,22 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.18.2-40.1.51'
-    
+    minecraft 'net.minecraftforge:forge:1.18.2-40.2.4'
+
+    annotationProcessor "org.spongepowered:mixin:${mixin_version}:processor"
+    implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:${mixin_extras}"))
+    implementation(jarJar("io.github.llamalad7:mixinextras-forge:${mixin_extras}")) {
+        jarJar.ranged(it, "[${mixin_extras},)")
+    }
+
     // compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}:api")
     // runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}:${jei_version}")
-        
-    
-    
+
+
+
     compileOnly fg.deobf("mezz.jei:jei-1.18.2:9.5.5.174:api")
     runtimeOnly fg.deobf("mezz.jei:jei-1.18.2:9.5.5.174")
-    
+
     compileOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}:api")
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,8 @@ org.gradle.daemon=false
 minecraft_version=1.16.5
 
 #Mod dependencies
+mixin_version=0.8.5
+mixin_extras=0.2.0
 jei_version=7.6.0.49
 curios_version=1.18.2-5.0.7.1
 patchouli_version=1.18.2-71.1

--- a/src/main/java/wayoftime/bloodmagic/mixin/client/MixinEntity.java
+++ b/src/main/java/wayoftime/bloodmagic/mixin/client/MixinEntity.java
@@ -1,0 +1,17 @@
+package wayoftime.bloodmagic.mixin.client;
+
+import net.minecraft.world.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+
+@Mixin(Entity.class)
+public class MixinEntity
+{
+
+    @Shadow
+    public double distanceToSqr(Entity p_20281_)
+    {
+       throw new IllegalStateException("Failed to shadow distanceToSqr()");
+    }
+}

--- a/src/main/java/wayoftime/bloodmagic/mixin/client/MixinLivingEntity.java
+++ b/src/main/java/wayoftime/bloodmagic/mixin/client/MixinLivingEntity.java
@@ -1,0 +1,34 @@
+package wayoftime.bloodmagic.mixin.client;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import wayoftime.bloodmagic.potion.BloodMagicPotions;
+
+@Mixin(LivingEntity.class)
+public abstract class MixinLivingEntity extends MixinEntity
+{
+    @ModifyReturnValue(
+            method = "isCurrentlyGlowing",
+            at = @At(value = "RETURN")
+    )
+    public boolean isCurrentlyGlowing(boolean original){
+        Player player = Minecraft.getInstance().player;
+
+        if(player != null && player.hasEffect(BloodMagicPotions.SPECTRAL_SIGHT))
+        {
+            double distance = (player.getEffect(BloodMagicPotions.SPECTRAL_SIGHT).getAmplifier() * 32 + 24);
+            if (distanceToSqr(Minecraft.getInstance().player) <= (distance * distance))
+            {
+                return true;
+            }
+        }
+        return original;
+    }
+
+
+
+}

--- a/src/main/resources/bloodmagic.mixins.json
+++ b/src/main/resources/bloodmagic.mixins.json
@@ -2,10 +2,12 @@
   "required": true,
   "minVersion": "0.8",
   "package": "wayoftime.bloodmagic.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
   ],
   "client": [
+    "client.MixinEntity",
+    "client.MixinLivingEntity"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
(cherry picked from commit 48fa7bf81707475269ebcc185b67475100fd947f)
backport #2005 to 1.18
reimplements Spectral sight mixins and also adds MixinExtras