### PR TITLE
stop teleposer from crashing when activated with unbound focus in it

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/tile/TileTeleposer.java
+++ b/src/main/java/wayoftime/bloodmagic/common/tile/TileTeleposer.java
@@ -196,9 +196,12 @@ public class TileTeleposer extends TileInventory implements MenuProvider, Comman
 	private SoulNetwork getNetwork()
 	{
 		ItemStack focusStack = this.getItem(FOCUS_SLOT);
-		if (!focusStack.isEmpty() && focusStack.getItem() instanceof ITeleposerFocus)
+		if (!focusStack.isEmpty() && focusStack.getItem() instanceof ITeleposerFocus focus)
 		{
-			return NetworkHelper.getSoulNetwork(((ITeleposerFocus) focusStack.getItem()).getBinding(focusStack));
+			if (focus.getBinding(focusStack) != null)
+			{
+				return NetworkHelper.getSoulNetwork(focus.getBinding(focusStack));
+			}
 		}
 
 		return null;


### PR DESCRIPTION
fixes #2028 though I only managed to get a crash when the source has an unbound focus, not the destination. It doesnt seem like the destination is used at all except to make sure there is a teleposer there
- add a check for the binding not to be null before using it