### PR TITLE
Fix ARC not respecting unbreakable items

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/tile/TileAlchemicalReactionChamber.java
+++ b/src/main/java/wayoftime/bloodmagic/common/tile/TileAlchemicalReactionChamber.java
@@ -381,10 +381,10 @@ public class TileAlchemicalReactionChamber extends TileInventory implements Menu
 		ItemStack toolStack = getItem(ARC_TOOL_SLOT);
 		if (!toolStack.isEmpty())
 		{
-			if (toolStack.isDamageableItem())
+			if (toolStack.getItem().isDamageable(toolStack))
 			{
 				int unbreakingLevel = EnchantmentHelper.getItemEnchantmentLevel(Enchantments.UNBREAKING, toolStack);
-				if (unbreakingLevel == 0 || level.random.nextInt(unbreakingLevel + 1) == 0)
+				if (toolStack.isDamageableItem() && (unbreakingLevel == 0 || level.random.nextInt(unbreakingLevel + 1) == 0))
 				{
 					toolStack.setDamageValue(toolStack.getDamageValue() + 1);
 					if (toolStack.getDamageValue() >= toolStack.getMaxDamage() && breakTool)


### PR DESCRIPTION
ItemStack.isDamageableItem returns false if the NBT tag Unbreakable is set to true so it should not be used to check if the item theoretically has durability, Item.isDamageable(ItemStack) returns true if the item has maxDamage set to anything more than 0 so it should return true for anything that would have durability, even if Unbreakable is set to true (or a Forbidden & Arcanus Eternal Stella is applied)
Fixes #1754 