### PR TITLE
fix HUD element saving

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/client/hud/ElementRegistry.java
+++ b/src/main/java/wayoftime/bloodmagic/client/hud/ElementRegistry.java
@@ -96,6 +96,7 @@ public class ElementRegistry
 			toWrite.put(entry.getKey().toString(), entry.getValue().getPosition());
 
 		String json = GSON.toJson(toWrite);
+		FMLPaths.getOrCreateGameRelativePath(FMLPaths.CONFIGDIR.get().resolve(BloodMagic.MODID));
 		try (FileWriter writer = new FileWriter(CONFIG))
 		{
 			writer.write(json);


### PR DESCRIPTION
fixes #2050 fixes #2084 
Makes sure the config/bloodmagic folder exists so the config for the HUD element positions can be saved there