### PR TITLE
fix: save te data

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/tile/TileInventory.java
+++ b/src/main/java/wayoftime/bloodmagic/common/tile/TileInventory.java
@@ -226,6 +226,7 @@ public class TileInventory extends TileBase implements Container
 	public void clearContent()
 	{
 		this.inventory = NonNullList.withSize(size, ItemStack.EMPTY);
+		setChanged();
 	}
 
 	@Override


### PR DESCRIPTION
In some cases, the inventory doesn't have time to save, which leads to dupe.