### PR TITLE
Fix Sigil of Suppression

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/block/BlockSpectral.java
+++ b/src/main/java/wayoftime/bloodmagic/common/block/BlockSpectral.java
@@ -4,6 +4,7 @@ import java.util.Random;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
@@ -30,7 +31,8 @@ public class BlockSpectral extends Block implements EntityBlock
 		super(prop);
 	}
 
-	public void tick(BlockState state, ServerLevel world, BlockPos pos, Random rand)
+	@Override
+	public void tick(BlockState state, ServerLevel world, BlockPos pos, RandomSource rand)
 	{
 		switch (state.getValue(SPECTRAL_STATE))
 		{

--- a/src/main/java/wayoftime/bloodmagic/common/tile/TileSpectral.java
+++ b/src/main/java/wayoftime/bloodmagic/common/tile/TileSpectral.java
@@ -1,6 +1,7 @@
 package wayoftime.bloodmagic.common.tile;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
@@ -10,6 +11,7 @@ import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import wayoftime.bloodmagic.BloodMagic;
 import wayoftime.bloodmagic.common.block.BlockSpectral;
 import wayoftime.bloodmagic.common.block.BloodMagicBlocks;
 import wayoftime.bloodmagic.common.block.type.SpectralBlockType;
@@ -44,8 +46,11 @@ public class TileSpectral extends TileBase
 			BlockEntity spectralTile = world.getBlockEntity(pos);
 			if (spectralTile instanceof TileSpectral)
 			{
+				BloodMagic.LOGGER.info("was a spectral tile");
 				((TileSpectral) spectralTile).setContainedBlockInfo(potentialFluidBlockState);
 				world.scheduleTick(pos, spectralTile.getBlockState().getBlock(), BlockSpectral.DECAY_RATE);
+			} else {
+				BloodMagic.LOGGER.info("it was not, in fact, a spectral tile");
 			}
 		} else if (potentialFluidBlockState.getBlock() == BloodMagicBlocks.SPECTRAL.get() && potentialFluidBlockState.getValue(BlockSpectral.SPECTRAL_STATE) == SpectralBlockType.LEAKING)
 		{
@@ -73,7 +78,7 @@ public class TileSpectral extends TileBase
 	@Override
 	public void deserialize(CompoundTag tag)
 	{
-		storedBlock = NbtUtils.readBlockState(this.level.holderLookup(Registries.BLOCK), tag.getCompound("BlockState"));
+		storedBlock = NbtUtils.readBlockState(BuiltInRegistries.BLOCK.asLookup(), tag.getCompound("BlockState"));
 	}
 
 	@Override


### PR DESCRIPTION
The crashes came from the fact that BlockEntity's own level isnt set while its deserializing. Luckily the block registry lookup doesnt need the actual level.

It not reverting came from the fact that BlockSpectral#tick did no longer override BlockBehaviour#tick and had a wrong signature, fixing that too made the sigil work again. Tested on water as a vanilla fluid and Life Essence as a modded fluid

Only downside is that it doesnt appear to make old "vanished" fluids reappear but it does seem to at least be able to load the world when before it would crash