### PR TITLE
Reconfigured the jar and jarjar task for dep inclusion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,13 @@ tasks.named('jar', Jar).configure {
             "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
         ])
     }
+    archiveClassifier = 'slim'  // Rename slim jar without JarJar dependencies
     finalizedBy 'reobfJar'
+}
+
+// Make the jarJar (with bundled dependencies like MixinExtras) the default jar
+tasks.named('jarJar', Jar).configure {
+    archiveClassifier = ''
 }
 
 


### PR DESCRIPTION
Reconfigured the 'jar' and 'jarJar' tasks to clearly define
their roles. The default jar will now include bundled dependencies,
while the slim jar will exclude them, indicated by the 'slim' classifier.
