### PR TITLE
Adds block protection for all BM world interaction

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/block/BlockShapedExplosive.java
+++ b/src/main/java/wayoftime/bloodmagic/common/block/BlockShapedExplosive.java
@@ -4,7 +4,9 @@ import javax.annotation.Nullable;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
@@ -113,6 +115,20 @@ public class BlockShapedExplosive extends Block implements EntityBlock
 		case UP:
 		default:
 			return UP;
+		}
+	}
+
+	@Override
+	public void setPlacedBy(Level level, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack)
+	{
+		super.setPlacedBy(level, pos, state, placer, stack);
+		if (placer instanceof Player player)
+		{
+			BlockEntity tile = level.getBlockEntity(pos);
+			if (tile instanceof TileExplosiveCharge explosiveCharge)
+			{
+				explosiveCharge.setOwnerUUID(player.getUUID());
+			}
 		}
 	}
 

--- a/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilBloodLight.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilBloodLight.java
@@ -15,6 +15,7 @@ import wayoftime.bloodmagic.core.data.SoulNetwork;
 import wayoftime.bloodmagic.core.data.SoulTicket;
 import wayoftime.bloodmagic.entity.projectile.EntityBloodLight;
 import wayoftime.bloodmagic.util.Constants;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 import wayoftime.bloodmagic.util.helper.NBTHelper;
 import wayoftime.bloodmagic.util.helper.NetworkHelper;
 import wayoftime.bloodmagic.util.helper.PlayerHelper;
@@ -54,14 +55,16 @@ public class ItemSigilBloodLight extends ItemSigilBase
 
 			if (world.isEmptyBlock(blockPos))
 			{
-				world.setBlockAndUpdate(blockPos, BloodMagicBlocks.BLOOD_LIGHT.get().defaultBlockState());
-				if (!world.isClientSide)
+				if (BlockProtectionHelper.tryPlaceBlock(world, blockPos, BloodMagicBlocks.BLOOD_LIGHT.get().defaultBlockState(), player))
 				{
-					SoulNetwork network = NetworkHelper.getSoulNetwork(getBinding(stack));
-					network.syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed()));
+					if (!world.isClientSide)
+					{
+						SoulNetwork network = NetworkHelper.getSoulNetwork(getBinding(stack));
+						network.syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed()));
+					}
+					resetCooldown(stack);
+					player.swing(hand);
 				}
-				resetCooldown(stack);
-				player.swing(hand);
 				return super.use(world, player, hand);
 			}
 		} else

--- a/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilFluidBase.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilFluidBase.java
@@ -13,6 +13,7 @@ import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 import net.minecraftforge.fluids.capability.wrappers.BlockWrapper;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 public abstract class ItemSigilFluidBase extends ItemSigilBase
 {
@@ -101,6 +102,13 @@ public abstract class ItemSigilFluidBase extends ItemSigilBase
 	{
 		FluidStack resource = sigilFluid;
 		BlockState state = sigilFluid.getFluid().getFluidType().getBlockForFluidState(world, blockPos, sigilFluid.getFluid().defaultFluidState());
+
+		// Check protection before placing fluid
+		if (!BlockProtectionHelper.canPlaceBlock(world, blockPos, player))
+		{
+			return false;
+		}
+
 		BlockWrapper wrapper = new BlockWrapper(state, world, blockPos);
 
 		if (world.dimensionType().ultraWarm() && resource.getFluid().getFluidType().isVaporizedOnPlacement(world, blockPos, resource))

--- a/src/main/java/wayoftime/bloodmagic/common/tile/TileDeforesterCharge.java
+++ b/src/main/java/wayoftime/bloodmagic/common/tile/TileDeforesterCharge.java
@@ -28,6 +28,7 @@ import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.Vec3;
 import wayoftime.bloodmagic.common.block.BlockShapedExplosive;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 public class TileDeforesterCharge extends TileExplosiveCharge
 {
@@ -191,6 +192,13 @@ public class TileDeforesterCharge extends TileExplosiveCharge
 //				this.world.getProfiler().startSection("explosion_blocks");
 					if (this.level instanceof ServerLevel)
 					{
+						// Check protection before breaking - use strict mode to prevent breaking
+						// if owner is unknown (e.g., placed by dispenser) or offline
+						if (!BlockProtectionHelper.canBreakBlockStrict(level, blockPos, getOwnerUUID()))
+						{
+							continue;
+						}
+
 						BlockEntity tileentity = blockstate.getBlock() instanceof EntityBlock
 								? this.level.getBlockEntity(blockPos)
 								: null;

--- a/src/main/java/wayoftime/bloodmagic/common/tile/TileExplosiveCharge.java
+++ b/src/main/java/wayoftime/bloodmagic/common/tile/TileExplosiveCharge.java
@@ -14,9 +14,14 @@ import net.minecraft.world.level.block.state.BlockState;
 import wayoftime.bloodmagic.anointment.AnointmentHolder;
 import wayoftime.bloodmagic.common.tile.base.TileTicking;
 
+import javax.annotation.Nullable;
+import java.util.UUID;
+
 public class TileExplosiveCharge extends TileTicking
 {
 	public AnointmentHolder anointmentHolder = new AnointmentHolder();
+	@Nullable
+	protected UUID ownerUUID = null;
 
 	public TileExplosiveCharge(BlockEntityType<?> type, BlockPos pos, BlockState state)
 	{
@@ -60,6 +65,10 @@ public class TileExplosiveCharge extends TileTicking
 		{
 			anointmentHolder = AnointmentHolder.fromNBT(tag.getCompound("holder"));
 		}
+		if (tag.hasUUID("ownerUUID"))
+		{
+			ownerUUID = tag.getUUID("ownerUUID");
+		}
 
 	}
 
@@ -70,6 +79,10 @@ public class TileExplosiveCharge extends TileTicking
 		{
 			tag.put("holder", anointmentHolder.serialize());
 		}
+		if (ownerUUID != null)
+		{
+			tag.putUUID("ownerUUID", ownerUUID);
+		}
 
 		return tag;
 	}
@@ -77,6 +90,17 @@ public class TileExplosiveCharge extends TileTicking
 	public void setAnointmentHolder(AnointmentHolder holder)
 	{
 		this.anointmentHolder = holder;
+	}
+
+	@Nullable
+	public UUID getOwnerUUID()
+	{
+		return ownerUUID;
+	}
+
+	public void setOwnerUUID(@Nullable UUID ownerUUID)
+	{
+		this.ownerUUID = ownerUUID;
 	}
 
 	public void dropSelf()

--- a/src/main/java/wayoftime/bloodmagic/common/tile/TileShapedExplosive.java
+++ b/src/main/java/wayoftime/bloodmagic/common/tile/TileShapedExplosive.java
@@ -23,6 +23,7 @@ import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.Vec3;
 import wayoftime.bloodmagic.common.block.BlockShapedExplosive;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 public class TileShapedExplosive extends TileExplosiveCharge
 {
@@ -131,6 +132,13 @@ public class TileShapedExplosive extends TileExplosiveCharge
 //							this.world.getProfiler().startSection("explosion_blocks");
 							if (this.level instanceof ServerLevel)
 							{
+								// Check protection before breaking - use strict mode to prevent breaking
+								// if owner is unknown (e.g., placed by dispenser) or offline
+								if (!BlockProtectionHelper.canBreakBlockStrict(level, blockpos, getOwnerUUID()))
+								{
+									continue;
+								}
+
 								BlockEntity tileentity = blockstate.getBlock() instanceof EntityBlock
 										? this.level.getBlockEntity(blockpos)
 										: null;

--- a/src/main/java/wayoftime/bloodmagic/common/tile/TileVeinMineCharge.java
+++ b/src/main/java/wayoftime/bloodmagic/common/tile/TileVeinMineCharge.java
@@ -29,6 +29,7 @@ import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.Vec3;
 import wayoftime.bloodmagic.common.block.BlockShapedExplosive;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 public class TileVeinMineCharge extends TileExplosiveCharge
 {
@@ -229,6 +230,13 @@ public class TileVeinMineCharge extends TileExplosiveCharge
 //				this.world.getProfiler().startSection("explosion_blocks");
 					if (this.level instanceof ServerLevel)
 					{
+						// Check protection before breaking - use strict mode to prevent breaking
+						// if owner is unknown (e.g., placed by dispenser) or offline
+						if (!BlockProtectionHelper.canBreakBlockStrict(level, blockPos, getOwnerUUID()))
+						{
+							continue;
+						}
+
 						BlockEntity tileentity = blockstate.getBlock() instanceof EntityBlock
 								? this.level.getBlockEntity(blockPos)
 								: null;

--- a/src/main/java/wayoftime/bloodmagic/entity/projectile/EntityBloodLight.java
+++ b/src/main/java/wayoftime/bloodmagic/entity/projectile/EntityBloodLight.java
@@ -23,6 +23,7 @@ import net.minecraftforge.network.NetworkHooks;
 import wayoftime.bloodmagic.common.block.BloodMagicBlocks;
 import wayoftime.bloodmagic.common.item.BloodMagicItems;
 import wayoftime.bloodmagic.common.registries.BloodMagicEntityTypes;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 public class EntityBloodLight extends ThrowableItemProjectile
 {
@@ -64,8 +65,11 @@ public class EntityBloodLight extends ThrowableItemProjectile
 			BlockState blockstate = this.level().getBlockState(blockpos);
 			if (blockstate.isAir() || blockstate.is(BlockTags.FIRE) || blockstate.canBeReplaced() || blockstate.liquid())
 			{
-				this.getCommandSenderWorld().setBlockAndUpdate(blockpos, BloodMagicBlocks.BLOOD_LIGHT.get().defaultBlockState());
-				this.removeAfterChangingDimensions();
+				// Check block protection before placing
+				if (BlockProtectionHelper.tryPlaceBlock(this.level(), blockpos, BloodMagicBlocks.BLOOD_LIGHT.get().defaultBlockState(), this.getOwner()))
+				{
+					this.removeAfterChangingDimensions();
+				}
 			}
 		}
 	}

--- a/src/main/java/wayoftime/bloodmagic/entity/projectile/EntityPotionFlask.java
+++ b/src/main/java/wayoftime/bloodmagic/entity/projectile/EntityPotionFlask.java
@@ -33,6 +33,8 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.network.NetworkHooks;
 
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
+
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Predicate;
@@ -240,12 +242,20 @@ public class EntityPotionFlask extends ThrowableItemProjectile implements ItemSu
 		BlockState blockstate = this.level().getBlockState(pos);
 		if (blockstate.is(BlockTags.FIRE))
 		{
-			this.level().removeBlock(pos, false);
+			// Check protection before removing fire
+			if (BlockProtectionHelper.tryRemoveBlock(this.level(), pos, this.getOwner()))
+			{
+				// Block already removed by tryRemoveBlock
+			}
 		} else if (CampfireBlock.isLitCampfire(blockstate))
 		{
-			this.level().levelEvent((Player) null, 1009, pos, 0);
-			CampfireBlock.dowse(null, this.level(), pos, blockstate);
-			this.level().setBlockAndUpdate(pos, blockstate.setValue(CampfireBlock.LIT, Boolean.valueOf(false)));
+			// Check protection before modifying campfire
+			if (BlockProtectionHelper.canPlaceBlock(this.level(), pos, this.getOwner()))
+			{
+				this.level().levelEvent((Player) null, 1009, pos, 0);
+				CampfireBlock.dowse(null, this.level(), pos, blockstate);
+				this.level().setBlockAndUpdate(pos, blockstate.setValue(CampfireBlock.LIT, Boolean.valueOf(false)));
+			}
 		}
 
 	}

--- a/src/main/java/wayoftime/bloodmagic/entity/projectile/EntityShapedCharge.java
+++ b/src/main/java/wayoftime/bloodmagic/entity/projectile/EntityShapedCharge.java
@@ -11,8 +11,10 @@ import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.ProjectileUtil;
 import net.minecraft.world.entity.projectile.ThrowableProjectile;
 import net.minecraft.world.level.Level;
@@ -30,6 +32,7 @@ import wayoftime.bloodmagic.common.block.BlockShapedExplosive;
 import wayoftime.bloodmagic.common.block.BloodMagicBlocks;
 import wayoftime.bloodmagic.common.registries.BloodMagicEntityTypes;
 import wayoftime.bloodmagic.common.tile.TileExplosiveCharge;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 public class EntityShapedCharge extends ThrowableProjectile
 {
@@ -85,13 +88,27 @@ public class EntityShapedCharge extends ThrowableProjectile
 			BlockState fallTile = this.getBlockState();
 			if (blockstate.isAir() || blockstate.is(BlockTags.FIRE) || blockstate.liquid() || blockstate.canBeReplaced())
 			{
-				this.getCommandSenderWorld().setBlockAndUpdate(blockpos, fallTile.setValue(BlockShapedExplosive.ATTACHED, faceHit));
-				BlockEntity tile = this.getCommandSenderWorld().getBlockEntity(blockpos);
-				if (tile instanceof TileExplosiveCharge)
+				// Check block protection before placing
+				if (BlockProtectionHelper.tryPlaceBlock(this.level(), blockpos, fallTile.setValue(BlockShapedExplosive.ATTACHED, faceHit), this.getOwner()))
 				{
-					((TileExplosiveCharge) tile).setAnointmentHolder(holder);
+					BlockEntity tile = this.getCommandSenderWorld().getBlockEntity(blockpos);
+					if (tile instanceof TileExplosiveCharge explosiveCharge)
+					{
+						explosiveCharge.setAnointmentHolder(holder);
+						// Set the owner from the entity that threw this projectile
+						Entity owner = this.getOwner();
+						if (owner instanceof Player player)
+						{
+							explosiveCharge.setOwnerUUID(player.getUUID());
+						}
+					}
+					this.removeAfterChangingDimensions();
+				} else
+				{
+					// Protection prevented placement, drop the item
+					this.spawnAtLocation(fallTile.getBlock());
+					this.removeAfterChangingDimensions();
 				}
-				this.removeAfterChangingDimensions();
 			} else
 			{
 //				BlockItem d;

--- a/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerAgricraft.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerAgricraft.java
@@ -5,14 +5,21 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.UUID;
 
 public class HarvestHandlerAgricraft implements IHarvestHandler {
 
     @Override
-    public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops) {
+    public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable UUID ownerUUID) {
         if (world.getBlockEntity(pos) instanceof CropBlockEntity crop) {
+            // Check protection before allowing harvest (Agricraft handles block modification internally)
+            if (!BlockProtectionHelper.canPlaceBlock(world, pos, ownerUUID)) {
+                return false;
+            }
             return crop.harvest(drops::add, null);
         }
 

--- a/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerBerryBush.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerBerryBush.java
@@ -1,6 +1,9 @@
 package wayoftime.bloodmagic.ritual.harvest;
 
 import java.util.List;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.sounds.SoundEvents;
@@ -12,18 +15,23 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SweetBerryBushBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 public class HarvestHandlerBerryBush implements IHarvestHandler
 {
 	@Override
-	public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops)
+	public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable UUID ownerUUID)
 	{
 		if (test(world, pos, state))
 		{
+			BlockState newState = state.setValue(SweetBerryBushBlock.AGE, Integer.valueOf(1));
+			if (!BlockProtectionHelper.tryPlaceBlock(world, pos, newState, ownerUUID))
+			{
+				return false;
+			}
 			int berries = 2 + world.random.nextInt(2);
 			Block.popResource(world, pos, new ItemStack(Items.SWEET_BERRIES, berries));
 			world.playSound((Player) null, pos, SoundEvents.SWEET_BERRY_BUSH_PICK_BERRIES, SoundSource.BLOCKS, 1.0F, 0.8F + world.random.nextFloat() * 0.4F);
-			world.setBlock(pos, state.setValue(SweetBerryBushBlock.AGE, Integer.valueOf(1)), 2);
 
 			return true;
 		}

--- a/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerGrowingPlant.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerGrowingPlant.java
@@ -13,20 +13,25 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.Vec3;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.UUID;
 
 public class HarvestHandlerGrowingPlant implements IHarvestHandler {
 
     private static final ItemStack mockHoe = new ItemStack(Items.DIAMOND_HOE, 1);
 
     @Override
-    public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops) {
+    public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable UUID ownerUUID) {
+        if (!BlockProtectionHelper.tryBreakBlockNoDrops(world, pos, ownerUUID)) {
+            return false;
+        }
         LootParams.Builder lootBuilder = new LootParams.Builder((ServerLevel) world);
         Vec3 blockCenter = new Vec3(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
         List<ItemStack> blockDrops = state.getDrops(lootBuilder.withParameter(LootContextParams.ORIGIN, blockCenter).withParameter(LootContextParams.TOOL, mockHoe));
         drops.addAll(blockDrops);
-        world.destroyBlock(pos, false);
         return true;
     }
 

--- a/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerJungleVines.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerJungleVines.java
@@ -10,20 +10,25 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.Vec3;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.UUID;
 
 public class HarvestHandlerJungleVines implements IHarvestHandler {
 
     private static final ItemStack mockShear = new ItemStack(Items.SHEARS, 1);
 
     @Override
-    public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops) {
+    public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable UUID ownerUUID) {
+        if (!BlockProtectionHelper.tryBreakBlockNoDrops(world, pos, ownerUUID)) {
+            return false;
+        }
         LootParams.Builder lootBuilder = new LootParams.Builder((ServerLevel) world);
         Vec3 blockCenter = new Vec3(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
         List<ItemStack> blockDrops = state.getDrops(lootBuilder.withParameter(LootContextParams.ORIGIN, blockCenter).withParameter(LootContextParams.TOOL, mockShear));
         drops.addAll(blockDrops);
-        world.destroyBlock(pos, false);
         return true;
     }
 

--- a/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerNetherWart.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerNetherWart.java
@@ -1,6 +1,9 @@
 package wayoftime.bloodmagic.ritual.harvest;
 
 import java.util.List;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
@@ -14,13 +17,14 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.Vec3;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 public class HarvestHandlerNetherWart implements IHarvestHandler
 {
 	private static final ItemStack mockHoe = new ItemStack(Items.DIAMOND_HOE, 1);
 
 	@Override
-	public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops)
+	public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable UUID ownerUUID)
 	{
 		boolean foundSeed = false;
 		LootParams.Builder lootBuilder = new LootParams.Builder((ServerLevel) world);
@@ -43,7 +47,10 @@ public class HarvestHandlerNetherWart implements IHarvestHandler
 
 		if (foundSeed)
 		{
-			world.setBlockAndUpdate(pos, state.getBlock().defaultBlockState());
+			if (!BlockProtectionHelper.tryPlaceBlock(world, pos, state.getBlock().defaultBlockState(), ownerUUID))
+			{
+				return false;
+			}
 			world.levelEvent(2001, pos, Block.getId(state));
 			for (ItemStack stack : blockDrops)
 			{

--- a/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerPlantable.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerPlantable.java
@@ -4,6 +4,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
 
 import com.blakebr0.mysticalagriculture.api.MysticalAgricultureAPI;
 import com.blakebr0.mysticalagriculture.api.crop.Crop;
@@ -26,6 +29,7 @@ import net.minecraftforge.fml.ModList;
 import net.minecraftforge.registries.ForgeRegistries;
 import wayoftime.bloodmagic.common.block.BloodMagicBlocks;
 import wayoftime.bloodmagic.util.BMLog;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 /**
  * Harvest handler for standard plantable crops such as Wheat, Potatoes, and
@@ -68,7 +72,7 @@ public class HarvestHandlerPlantable implements IHarvestHandler
 	}
 
 	@Override
-	public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops)
+	public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable UUID ownerUUID)
 	{
 //		NonNullList<ItemStack> blockDrops = NonNullList.create();
 //		state.getBlock().getDrops(blockDrops, world, pos, state, 0);
@@ -97,7 +101,10 @@ public class HarvestHandlerPlantable implements IHarvestHandler
 
 		if (foundSeed)
 		{
-			world.setBlockAndUpdate(pos, state.getBlock().defaultBlockState());
+			if (!BlockProtectionHelper.tryPlaceBlock(world, pos, state.getBlock().defaultBlockState(), ownerUUID))
+			{
+				return false;
+			}
 			world.levelEvent(2001, pos, Block.getId(state));
 			for (ItemStack stack : blockDrops)
 			{

--- a/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerStem.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerStem.java
@@ -2,6 +2,9 @@ package wayoftime.bloodmagic.ritual.harvest;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
 
 import net.minecraft.world.level.block.AttachedStemBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -16,6 +19,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.level.Level;
 import net.minecraft.server.level.ServerLevel;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 /**
  * Harvest handler for crops with stems such as Pumpkins and Melons. Rotation
@@ -38,7 +42,7 @@ public class HarvestHandlerStem implements IHarvestHandler
 	}
 
 	@Override
-	public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops)
+	public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable UUID ownerUUID)
 	{
 		Direction cropDir = state.getValue(AttachedStemBlock.FACING);
 
@@ -52,11 +56,14 @@ public class HarvestHandlerStem implements IHarvestHandler
 			{
 				if (registeredCrop == probableCrop)
 				{
+					if (!BlockProtectionHelper.tryBreakBlockNoDrops(world, cropPos, ownerUUID))
+					{
+						return false;
+					}
 					LootParams.Builder lootBuilder = new LootParams.Builder((ServerLevel) world);
 					Vec3 blockCenter = new Vec3(cropPos.getX() + 0.5, cropPos.getY() + 0.5, cropPos.getZ() + 0.5);
 					List<ItemStack> blockDrops = registeredCrop.getDrops(lootBuilder.withParameter(LootContextParams.ORIGIN, blockCenter).withParameter(LootContextParams.TOOL, mockHoe));
 					drops.addAll(blockDrops);
-					world.destroyBlock(cropPos, false);
 					return true;
 				}
 			}

--- a/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerTall.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/harvest/HarvestHandlerTall.java
@@ -1,6 +1,9 @@
 package wayoftime.bloodmagic.ritual.harvest;
 
 import java.util.List;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
 
 import net.minecraft.world.level.block.BambooStalkBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -17,6 +20,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.level.Level;
 import net.minecraft.server.level.ServerLevel;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 /**
  * Harvest handler for crops that grow vertically such as Sugar Cane and Cactus.
@@ -38,16 +42,19 @@ public class HarvestHandlerTall implements IHarvestHandler
 	}
 
 	@Override
-	public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops)
+	public boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable UUID ownerUUID)
 	{
 		BlockState up = world.getBlockState(pos.above());
 		if (up.getBlock() == state.getBlock())
 		{
+			if (!BlockProtectionHelper.tryBreakBlockNoDrops(world, pos.above(), ownerUUID))
+			{
+				return false;
+			}
 			LootParams.Builder lootBuilder = new LootParams.Builder((ServerLevel) world);
 			Vec3 blockCenter = new Vec3(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
 			List<ItemStack> blockDrops = state.getDrops(lootBuilder.withParameter(LootContextParams.ORIGIN, blockCenter).withParameter(LootContextParams.TOOL, mockHoe));
 			drops.addAll(blockDrops);
-			world.destroyBlock(pos.above(), false);
 			return true;
 		}
 

--- a/src/main/java/wayoftime/bloodmagic/ritual/harvest/IHarvestHandler.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/harvest/IHarvestHandler.java
@@ -1,6 +1,9 @@
 package wayoftime.bloodmagic.ritual.harvest;
 
 import java.util.List;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
 
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.item.ItemStack;
@@ -18,13 +21,14 @@ public interface IHarvestHandler
 	 * Use this to break the block and plant a new one. <br>
 	 * Add the items to be dropped to the drops list. <br>
 	 *
-	 * @param world - The world
-	 * @param pos   - The position of the {@link BlockState} being checked
-	 * @param state - The {@link BlockState} being checked
-	 * @param drops - The items to be dropped
+	 * @param world     - The world
+	 * @param pos       - The position of the {@link BlockState} being checked
+	 * @param state     - The {@link BlockState} being checked
+	 * @param drops     - The items to be dropped
+	 * @param ownerUUID - The UUID of the ritual owner for protection checks
 	 * @return If the block was successfully harvested.
 	 */
-	boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops);
+	boolean harvest(Level world, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable UUID ownerUUID);
 
 	/**
 	 * Tests to see if the block is valid for harvest.

--- a/src/main/java/wayoftime/bloodmagic/ritual/types/RitualCrushing.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/types/RitualCrushing.java
@@ -25,6 +25,7 @@ import wayoftime.bloodmagic.common.block.BlockMasterRitualStone;
 import wayoftime.bloodmagic.demonaura.WorldDemonWillHandler;
 import wayoftime.bloodmagic.ritual.*;
 import wayoftime.bloodmagic.util.Utils;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 import java.util.HashMap;
 import java.util.List;
@@ -260,17 +261,19 @@ public class RitualCrushing extends Ritual
 				}
 			}
 
-			world.destroyBlock(newPos, false);
-			masterRitualStone.getOwnerNetwork().syphon(masterRitualStone.ticket(getRefreshCost()));
-			hasOperated = true;
-
-			if (consumeRawWill)
+			if (BlockProtectionHelper.tryBreakBlockNoDrops(world, newPos, masterRitualStone.getOwner()))
 			{
-				rawDrain += rawWillDrain;
-				rawWill -= rawWillDrain;
-			}
+				masterRitualStone.getOwnerNetwork().syphon(masterRitualStone.ticket(getRefreshCost()));
+				hasOperated = true;
 
-			break;
+				if (consumeRawWill)
+				{
+					rawDrain += rawWillDrain;
+					rawWill -= rawWillDrain;
+				}
+
+				break;
+			}
 		}
 
 //		if (hasOperated && tile != null && vengefulWill >= vengefulWillDrain)

--- a/src/main/java/wayoftime/bloodmagic/ritual/types/RitualCrystalSplit.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/types/RitualCrystalSplit.java
@@ -12,6 +12,9 @@ import wayoftime.bloodmagic.api.compat.EnumDemonWillType;
 import wayoftime.bloodmagic.common.block.BloodMagicBlocks;
 import wayoftime.bloodmagic.common.tile.TileDemonCrystal;
 import wayoftime.bloodmagic.ritual.*;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
+
+import java.util.UUID;
 
 import java.util.function.Consumer;
 
@@ -110,10 +113,11 @@ public class RitualCrystalSplit extends Ritual
 
 			rawTile.setCrystalCount(rawTile.getCrystalCount() - 4);
 
-			growCrystal(world, vengefulPos, EnumDemonWillType.VENGEFUL, vengefulCrystals);
-			growCrystal(world, corrosivePos, EnumDemonWillType.CORROSIVE, corrosiveCrystals);
-			growCrystal(world, steadfastPos, EnumDemonWillType.STEADFAST, steadfastCrystals);
-			growCrystal(world, destructivePos, EnumDemonWillType.DESTRUCTIVE, destructiveCrystals);
+			UUID ownerUUID = masterRitualStone.getOwner();
+			growCrystal(world, vengefulPos, EnumDemonWillType.VENGEFUL, vengefulCrystals, ownerUUID);
+			growCrystal(world, corrosivePos, EnumDemonWillType.CORROSIVE, corrosiveCrystals, ownerUUID);
+			growCrystal(world, steadfastPos, EnumDemonWillType.STEADFAST, steadfastCrystals, ownerUUID);
+			growCrystal(world, destructivePos, EnumDemonWillType.DESTRUCTIVE, destructiveCrystals, ownerUUID);
 			rawTile.setChanged();
 			world.sendBlockUpdated(rawPos, rawState, rawState, 3);
 		}
@@ -135,7 +139,7 @@ public class RitualCrystalSplit extends Ritual
 		}
 	}
 
-	public void growCrystal(Level world, BlockPos pos, EnumDemonWillType type, int currentCrystalCount)
+	public void growCrystal(Level world, BlockPos pos, EnumDemonWillType type, int currentCrystalCount, UUID ownerUUID)
 	{
 		if (currentCrystalCount <= 0)
 		{
@@ -160,7 +164,7 @@ public class RitualCrystalSplit extends Ritual
 			default:
 				state = BloodMagicBlocks.RAW_CRYSTAL_BLOCK.get().defaultBlockState();
 			}
-			world.setBlock(pos, state, 3);
+			BlockProtectionHelper.tryPlaceBlock(world, pos, state, ownerUUID);
 		} else
 		{
 			TileDemonCrystal tile = (TileDemonCrystal) world.getBlockEntity(pos);

--- a/src/main/java/wayoftime/bloodmagic/ritual/types/RitualEllipsoid.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/types/RitualEllipsoid.java
@@ -20,6 +20,7 @@ import wayoftime.bloodmagic.ritual.IMasterRitualStone;
 import wayoftime.bloodmagic.ritual.Ritual;
 import wayoftime.bloodmagic.ritual.RitualComponent;
 import wayoftime.bloodmagic.ritual.RitualRegister;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 @RitualRegister("ellipsoid")
 public class RitualEllipsoid extends Ritual
@@ -138,7 +139,11 @@ public class RitualEllipsoid extends Ritual
 								}
 
 								BlockState placeState = Block.byItem(itemHandler.getStackInSlot(blockSlot).getItem()).defaultBlockState();
-								world.setBlockAndUpdate(newPos, placeState);
+								if (!BlockProtectionHelper.tryPlaceBlock(world, newPos, placeState, masterRitualStone.getOwner()))
+								{
+									k++;
+									continue;
+								}
 
 								itemHandler.extractItem(blockSlot, 1, false);
 								tileInventory.setChanged();

--- a/src/main/java/wayoftime/bloodmagic/ritual/types/RitualFelling.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/types/RitualFelling.java
@@ -39,6 +39,7 @@ import wayoftime.bloodmagic.ritual.Ritual;
 import wayoftime.bloodmagic.ritual.RitualComponent;
 import wayoftime.bloodmagic.ritual.RitualRegister;
 import wayoftime.bloodmagic.util.Utils;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 @RitualRegister("felling")
 public class RitualFelling extends Ritual
@@ -109,8 +110,16 @@ public class RitualFelling extends Ritual
 
 		if (blockPosIterator.hasNext() && tileInventory != null)
 		{
-			masterRitualStone.getOwnerNetwork().syphon(masterRitualStone.ticket(getRefreshCost()));
 			currentPos = blockPosIterator.next();
+
+			// Check protection before breaking
+			if (!BlockProtectionHelper.canBreakBlock(world, currentPos, masterRitualStone.getOwner()))
+			{
+				blockPosIterator.remove();
+				return;
+			}
+
+			masterRitualStone.getOwnerNetwork().syphon(masterRitualStone.ticket(getRefreshCost()));
 			IItemHandler inventory = Utils.getInventory(tileInventory, Direction.DOWN);
 			BlockState state = world.getBlockState(currentPos);
 			placeInInventory(state, world, currentPos, inventory);

--- a/src/main/java/wayoftime/bloodmagic/ritual/types/RitualGeode.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/types/RitualGeode.java
@@ -24,6 +24,7 @@ import wayoftime.bloodmagic.common.tags.BloodMagicTags;
 import wayoftime.bloodmagic.demonaura.WorldDemonWillHandler;
 import wayoftime.bloodmagic.ritual.*;
 import wayoftime.bloodmagic.util.Utils;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -135,7 +136,7 @@ public class RitualGeode extends Ritual {
                 Vec3 blockCenter = new Vec3(harvestPos.getX() + 0.5, harvestPos.getY() + 0.5, harvestPos.getZ() + 0.5);
                 List<ItemStack> blockDrops = state.getDrops(lootBuilder.withParameter(LootContextParams.ORIGIN, blockCenter).withParameter(LootContextParams.TOOL, toolStack));
                 drops.addAll(blockDrops);
-                world.destroyBlock(harvestPos, false);
+                BlockProtectionHelper.tryBreakBlockNoDrops(world, harvestPos, masterRitualStone.getOwner());
                 if (doFortune) {
                     fortuneWill -= WILL_PER_FORTUNE;
                 }

--- a/src/main/java/wayoftime/bloodmagic/ritual/types/RitualGreenGrove.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/types/RitualGreenGrove.java
@@ -18,6 +18,7 @@ import wayoftime.bloodmagic.impl.BloodMagicAPI;
 import wayoftime.bloodmagic.potion.BloodMagicPotions;
 import wayoftime.bloodmagic.ritual.*;
 import wayoftime.bloodmagic.util.Utils;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 import wayoftime.bloodmagic.will.DemonWillHolder;
 
 import java.util.List;
@@ -175,15 +176,19 @@ public class RitualGreenGrove extends Ritual
 				boolean hydratedBlock = false;
 				if (block == Blocks.DIRT || block == Blocks.GRASS)
 				{
-					world.setBlockAndUpdate(newPos, farmlandState);
-					hydratedBlock = true;
+					if (BlockProtectionHelper.tryPlaceBlock(world, newPos, farmlandState, masterRitualStone.getOwner()))
+					{
+						hydratedBlock = true;
+					}
 				} else if (block == Blocks.FARMLAND)
 				{
 					int meta = state.getValue(FarmBlock.MOISTURE);
 					if (meta < 7)
 					{
-						world.setBlockAndUpdate(newPos, farmlandState);
-						hydratedBlock = true;
+						if (BlockProtectionHelper.tryPlaceBlock(world, newPos, farmlandState, masterRitualStone.getOwner()))
+						{
+							hydratedBlock = true;
+						}
 					}
 				}
 

--- a/src/main/java/wayoftime/bloodmagic/ritual/types/RitualHarvest.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/types/RitualHarvest.java
@@ -1,7 +1,10 @@
 package wayoftime.bloodmagic.ritual.types;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
 
 import com.google.common.collect.Lists;
 
@@ -68,7 +71,7 @@ public class RitualHarvest extends Ritual
 		while (harvestArea.hasNext())
 		{
 			BlockPos nextPos = harvestArea.next().offset(pos);
-			if (harvestBlock(world, nextPos, masterRitualStone.getMasterBlockPos()))
+			if (harvestBlock(world, nextPos, masterRitualStone.getMasterBlockPos(), masterRitualStone.getOwner()))
 			{
 				harvested++;
 			}
@@ -104,7 +107,7 @@ public class RitualHarvest extends Ritual
 		return new RitualHarvest();
 	}
 
-	public static boolean harvestBlock(Level world, BlockPos cropPos, BlockPos controllerPos)
+	public static boolean harvestBlock(Level world, BlockPos cropPos, BlockPos controllerPos, @Nullable UUID ownerUUID)
 	{
 		BlockState harvestState = world.getBlockState(cropPos);
 		BlockEntity potentialInventory = world.getBlockEntity(controllerPos.above());
@@ -117,7 +120,7 @@ public class RitualHarvest extends Ritual
 			if (handler.test(world, cropPos, harvestState))
 			{
 				List<ItemStack> drops = Lists.newArrayList();
-				if (handler.harvest(world, cropPos, harvestState, drops))
+				if (handler.harvest(world, cropPos, harvestState, drops, ownerUUID))
 				{
 					for (ItemStack stack : drops)
 					{

--- a/src/main/java/wayoftime/bloodmagic/ritual/types/RitualLava.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/types/RitualLava.java
@@ -24,6 +24,7 @@ import wayoftime.bloodmagic.demonaura.WorldDemonWillHandler;
 import wayoftime.bloodmagic.potion.BloodMagicPotions;
 import wayoftime.bloodmagic.ritual.*;
 import wayoftime.bloodmagic.util.Utils;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 import wayoftime.bloodmagic.will.DemonWillHolder;
 
 import java.util.List;
@@ -99,14 +100,16 @@ public class RitualLava extends Ritual
 				{
 					break;
 				}
-				world.setBlockAndUpdate(newPos, Blocks.LAVA.defaultBlockState());
-				currentEssence -= lpCost;
-				lpDrain += lpCost;
-				if (rawWill > 0)
+				if (BlockProtectionHelper.tryPlaceBlock(world, newPos, Blocks.LAVA.defaultBlockState(), masterRitualStone.getOwner()))
 				{
-					double drain = getWillCostForRawWill(rawWill);
-					rawWill -= drain;
-					rawDrained += drain;
+					currentEssence -= lpCost;
+					lpDrain += lpCost;
+					if (rawWill > 0)
+					{
+						double drain = getWillCostForRawWill(rawWill);
+						rawWill -= drain;
+						rawDrained += drain;
+					}
 				}
 			}
 		}

--- a/src/main/java/wayoftime/bloodmagic/ritual/types/RitualPlacer.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/types/RitualPlacer.java
@@ -6,7 +6,6 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.InteractionResult;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.core.BlockPos;
@@ -22,6 +21,8 @@ import wayoftime.bloodmagic.ritual.Ritual;
 import wayoftime.bloodmagic.ritual.RitualComponent;
 import wayoftime.bloodmagic.ritual.RitualRegister;
 import wayoftime.bloodmagic.util.Utils;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
+import net.minecraft.world.level.block.Block;
 
 @RitualRegister("placer")
 public class RitualPlacer extends Ritual
@@ -78,18 +79,16 @@ public class RitualPlacer extends Ritual
 					if (stack.isEmpty() || !(stack.getItem() instanceof BlockItem))
 						continue;
 
-					InteractionResult result = ((BlockItem) stack.getItem()).place(ctx);
-					if (result.consumesAction())
+					Block blockToPlace = Block.byItem(stack.getItem());
+					if (!BlockProtectionHelper.tryPlaceBlock(world, blockPos, blockToPlace.defaultBlockState(), masterRitualStone.getOwner()))
 					{
-						itemHandler.extractItem(invSlot, 1, false);
-						tileEntity.setChanged();
-						masterRitualStone.getOwnerNetwork().syphon(masterRitualStone.ticket(getRefreshCost()));
-						break posLoop; // Break instead of return in case we add things later
+						continue posLoop; // Skip to next position if protection prevents placement
 					}
 
-//					BlockState placeState = Block.getBlockFromItem(itemHandler.getStackInSlot(invSlot).getItem()).getDefaultState();
-//					world.setBlockState(blockPos, placeState);
-
+					itemHandler.extractItem(invSlot, 1, false);
+					tileEntity.setChanged();
+					masterRitualStone.getOwnerNetwork().syphon(masterRitualStone.ticket(getRefreshCost()));
+					break posLoop; // Break instead of return in case we add things later
 				}
 			}
 		}

--- a/src/main/java/wayoftime/bloodmagic/ritual/types/RitualWater.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/types/RitualWater.java
@@ -22,6 +22,7 @@ import wayoftime.bloodmagic.ritual.IMasterRitualStone;
 import wayoftime.bloodmagic.ritual.Ritual;
 import wayoftime.bloodmagic.ritual.RitualComponent;
 import wayoftime.bloodmagic.ritual.RitualRegister;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 @RitualRegister("water")
 public class RitualWater extends Ritual
@@ -64,8 +65,10 @@ public class RitualWater extends Ritual
 		{
 			if (world.isEmptyBlock(newPos))
 			{
-				world.setBlockAndUpdate(newPos, Blocks.WATER.defaultBlockState());
-				totalEffects++;
+				if (BlockProtectionHelper.tryPlaceBlock(world, newPos, Blocks.WATER.defaultBlockState(), masterRitualStone.getOwner()))
+				{
+					totalEffects++;
+				}
 			}
 
 			if (totalEffects >= maxEffects)

--- a/src/main/java/wayoftime/bloodmagic/ritual/types/RitualYawningVoid.java
+++ b/src/main/java/wayoftime/bloodmagic/ritual/types/RitualYawningVoid.java
@@ -18,6 +18,7 @@ import wayoftime.bloodmagic.demonaura.WorldDemonWillHandler;
 import wayoftime.bloodmagic.ritual.*;
 import wayoftime.bloodmagic.util.Constants;
 import wayoftime.bloodmagic.util.Utils;
+import wayoftime.bloodmagic.util.helper.BlockProtectionHelper;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -197,13 +198,18 @@ public class RitualYawningVoid extends Ritual
 
 							if (destroy)
 							{
-								world.setBlock(newPos, Blocks.AIR.defaultBlockState(), 3);
-								masterRitualStone.getOwnerNetwork().syphon(masterRitualStone.ticket(getRefreshCost()));
-								k++;
-								this.lastPos = new BlockPos(i, j, k);
-								isDone = true;
-								// Block wasn't protected
-								consumeSteadfastWill = false;
+								if (BlockProtectionHelper.tryRemoveBlock(world, newPos, masterRitualStone.getOwner()))
+								{
+									masterRitualStone.getOwnerNetwork().syphon(masterRitualStone.ticket(getRefreshCost()));
+									k++;
+									this.lastPos = new BlockPos(i, j, k);
+									isDone = true;
+									// Block wasn't protected
+									consumeSteadfastWill = false;
+								} else
+								{
+									k++;
+								}
 							} else if (replace)
 							{
 								Utils.swapLocations(world, newPos, world, replacement);

--- a/src/main/java/wayoftime/bloodmagic/util/helper/BlockProtectionHelper.java
+++ b/src/main/java/wayoftime/bloodmagic/util/helper/BlockProtectionHelper.java
@@ -1,0 +1,514 @@
+package wayoftime.bloodmagic.util.helper;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.BlockSnapshot;
+import net.minecraftforge.event.level.BlockEvent;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Helper class for safe block operations that respect protection mods like FTB Chunks.
+ * <p>
+ * Protection mods listen to BlockEvent.BreakEvent and BlockEvent.EntityPlaceEvent to
+ * prevent unauthorized block modifications in claimed chunks. This helper fires these
+ * events before performing block operations, allowing protection mods to cancel them.
+ * <p>
+ * Use these methods whenever Blood Magic needs to:
+ * - Break or remove blocks (rituals, sigils, explosives)
+ * - Place blocks (rituals, sigils, diviner)
+ * - Modify blocks (changing block state, replacing fluids)
+ */
+public class BlockProtectionHelper {
+
+    /**
+     * Attempts to break a block, respecting protection events.
+     * Fires BlockEvent.BreakEvent and returns false if cancelled.
+     *
+     * @param level  The level
+     * @param pos    The block position to break
+     * @param player The player responsible for the break (null for machine/ritual operations)
+     * @return true if the block was successfully broken, false if cancelled or failed
+     */
+    public static boolean tryBreakBlock(Level level, BlockPos pos, @Nullable Player player) {
+        if (level.isClientSide()) {
+            return false;
+        }
+
+        BlockState state = level.getBlockState(pos);
+        if (state.isAir()) {
+            return true; // Already air, nothing to break
+        }
+
+        // Fire break event - protection mods can cancel this
+        if (!fireBreakEvent(level, pos, state, player)) {
+            return false;
+        }
+
+        // Perform the break
+        return level.destroyBlock(pos, true, player);
+    }
+
+    /**
+     * Attempts to break a block without dropping items, respecting protection events.
+     *
+     * @param level  The level
+     * @param pos    The block position to break
+     * @param player The player responsible for the break
+     * @return true if the block was successfully broken, false if cancelled or failed
+     */
+    public static boolean tryBreakBlockNoDrops(Level level, BlockPos pos, @Nullable Player player) {
+        if (level.isClientSide()) {
+            return false;
+        }
+
+        BlockState state = level.getBlockState(pos);
+        if (state.isAir()) {
+            return true;
+        }
+
+        if (!fireBreakEvent(level, pos, state, player)) {
+            return false;
+        }
+
+        return level.destroyBlock(pos, false, player);
+    }
+
+    /**
+     * Attempts to remove a block (set to air) without breaking animation/drops.
+     *
+     * @param level  The level
+     * @param pos    The block position
+     * @param player The player responsible
+     * @return true if successful
+     */
+    public static boolean tryRemoveBlock(Level level, BlockPos pos, @Nullable Player player) {
+        if (level.isClientSide()) {
+            return false;
+        }
+
+        BlockState state = level.getBlockState(pos);
+        if (state.isAir()) {
+            return true;
+        }
+
+        if (!fireBreakEvent(level, pos, state, player)) {
+            return false;
+        }
+
+        return level.removeBlock(pos, false);
+    }
+
+    /**
+     * Attempts to place a block, respecting protection events.
+     * Fires BlockEvent.EntityPlaceEvent and returns false if cancelled.
+     *
+     * @param level    The level
+     * @param pos      The block position
+     * @param newState The block state to place
+     * @param player   The player responsible (null for machine/ritual operations)
+     * @return true if the block was successfully placed, false if cancelled
+     */
+    public static boolean tryPlaceBlock(Level level, BlockPos pos, BlockState newState, @Nullable Player player) {
+        return tryPlaceBlock(level, pos, newState, player, Block.UPDATE_ALL);
+    }
+
+    /**
+     * Attempts to place a block with custom update flags, respecting protection events.
+     *
+     * @param level       The level
+     * @param pos         The block position
+     * @param newState    The block state to place
+     * @param player      The player responsible
+     * @param updateFlags Block update flags
+     * @return true if the block was successfully placed, false if cancelled
+     */
+    public static boolean tryPlaceBlock(Level level, BlockPos pos, BlockState newState, @Nullable Player player, int updateFlags) {
+        if (level.isClientSide()) {
+            return false;
+        }
+
+        BlockState oldState = level.getBlockState(pos);
+
+        // Fire place event - protection mods can cancel this
+        if (!firePlaceEvent(level, pos, oldState, newState, player)) {
+            return false;
+        }
+
+        return level.setBlock(pos, newState, updateFlags);
+    }
+
+    /**
+     * Attempts to replace a block (break old, place new), respecting protection events.
+     * This is useful for operations like fluid replacement or block transformation.
+     *
+     * @param level    The level
+     * @param pos      The block position
+     * @param newState The new block state
+     * @param player   The player responsible
+     * @return true if successful
+     */
+    public static boolean tryReplaceBlock(Level level, BlockPos pos, BlockState newState, @Nullable Player player) {
+        if (level.isClientSide()) {
+            return false;
+        }
+
+        BlockState oldState = level.getBlockState(pos);
+
+        // For replacement, we need to check both break and place permissions
+        if (!oldState.isAir()) {
+            if (!fireBreakEvent(level, pos, oldState, player)) {
+                return false;
+            }
+        }
+
+        if (!firePlaceEvent(level, pos, oldState, newState, player)) {
+            return false;
+        }
+
+        return level.setBlock(pos, newState, Block.UPDATE_ALL);
+    }
+
+    /**
+     * Fires a BlockEvent.BreakEvent and returns whether it was allowed (not cancelled).
+     *
+     * @param level  The level
+     * @param pos    The block position
+     * @param state  The current block state
+     * @param player The player (can be null for non-player breaks)
+     * @return true if the event was not cancelled
+     */
+    public static boolean fireBreakEvent(Level level, BlockPos pos, BlockState state, @Nullable Player player) {
+        if (level.isClientSide() || !(level instanceof ServerLevel serverLevel)) {
+            return true;
+        }
+
+        // If no player context, we can't fire the event properly
+        // Some mods may still block based on chunk claims, but we can't simulate a player
+        if (player == null) {
+            // For non-player operations (rituals/machines), we still want protection
+            // Use a fake player approach or just allow it
+            // Most protection mods require a player to check permissions
+            return true;
+        }
+
+        BlockEvent.BreakEvent event = new BlockEvent.BreakEvent(serverLevel, pos, state, player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return !event.isCanceled();
+    }
+
+    /**
+     * Fires a BlockEvent.EntityPlaceEvent and returns whether it was allowed (not cancelled).
+     *
+     * @param level    The level
+     * @param pos      The block position
+     * @param oldState The previous block state (before placement)
+     * @param newState The new block state being placed
+     * @param player   The player (can be null)
+     * @return true if the event was not cancelled
+     */
+    public static boolean firePlaceEvent(Level level, BlockPos pos, BlockState oldState, BlockState newState, @Nullable Player player) {
+        if (level.isClientSide() || !(level instanceof ServerLevel serverLevel)) {
+            return true;
+        }
+
+        if (player == null) {
+            return true;
+        }
+
+        // Create a snapshot of the old state before placement
+        BlockSnapshot snapshot = BlockSnapshot.create(serverLevel.dimension(), serverLevel, pos);
+
+        // Fire the place event
+        BlockEvent.EntityPlaceEvent event = new BlockEvent.EntityPlaceEvent(snapshot, oldState, player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return !event.isCanceled();
+    }
+
+    /**
+     * Checks if a player can break a block at the given position without actually breaking it.
+     * Useful for preview/validation before performing an operation.
+     *
+     * @param level  The level
+     * @param pos    The block position
+     * @param player The player
+     * @return true if breaking is allowed
+     */
+    public static boolean canBreakBlock(Level level, BlockPos pos, @Nullable Player player) {
+        if (level.isClientSide()) {
+            return true; // Client-side always returns true, server will validate
+        }
+
+        BlockState state = level.getBlockState(pos);
+        return fireBreakEvent(level, pos, state, player);
+    }
+
+    /**
+     * Checks if a player can place a block at the given position without actually placing it.
+     *
+     * @param level    The level
+     * @param pos      The block position
+     * @param newState The block state to place
+     * @param player   The player
+     * @return true if placing is allowed
+     */
+    public static boolean canPlaceBlock(Level level, BlockPos pos, BlockState newState, @Nullable Player player) {
+        if (level.isClientSide()) {
+            return true;
+        }
+
+        BlockState oldState = level.getBlockState(pos);
+        return firePlaceEvent(level, pos, oldState, newState, player);
+    }
+
+    /**
+     * Helper to get a block's drops before breaking it.
+     * This can be useful when you need to capture drops but want to check protection first.
+     *
+     * @param level  The server level
+     * @param pos    The block position
+     * @param player The player
+     * @param tool   The tool being used to break (affects drops)
+     * @return The drops, or empty list if break was denied
+     */
+    public static List<ItemStack> getDropsIfBreakAllowed(ServerLevel level, BlockPos pos, @Nullable Player player, ItemStack tool) {
+        BlockState state = level.getBlockState(pos);
+
+        if (!fireBreakEvent(level, pos, state, player)) {
+            return Collections.emptyList();
+        }
+
+        BlockEntity be = level.getBlockEntity(pos);
+        return Block.getDrops(state, level, pos, be, player, tool);
+    }
+
+    // ==================== UUID-based methods for rituals/machines ====================
+
+    /**
+     * Gets a player from their UUID if they are online.
+     *
+     * @param level     The level
+     * @param ownerUUID The player's UUID
+     * @return The player if online, null otherwise
+     */
+    @Nullable
+    public static Player getPlayerFromUUID(Level level, @Nullable UUID ownerUUID) {
+        if (ownerUUID == null || !(level instanceof ServerLevel serverLevel)) {
+            return null;
+        }
+        return serverLevel.getServer().getPlayerList().getPlayer(ownerUUID);
+    }
+
+    /**
+     * Attempts to break a block using owner UUID for protection checks.
+     * If the owner is offline, the operation proceeds without protection checks.
+     *
+     * @param level     The level
+     * @param pos       The block position
+     * @param ownerUUID The UUID of the owner (e.g., ritual owner)
+     * @return true if successful
+     */
+    public static boolean tryBreakBlock(Level level, BlockPos pos, @Nullable UUID ownerUUID) {
+        return tryBreakBlock(level, pos, getPlayerFromUUID(level, ownerUUID));
+    }
+
+    /**
+     * Attempts to break a block without drops, using owner UUID.
+     *
+     * @param level     The level
+     * @param pos       The block position
+     * @param ownerUUID The UUID of the owner
+     * @return true if successful
+     */
+    public static boolean tryBreakBlockNoDrops(Level level, BlockPos pos, @Nullable UUID ownerUUID) {
+        return tryBreakBlockNoDrops(level, pos, getPlayerFromUUID(level, ownerUUID));
+    }
+
+    /**
+     * Attempts to remove a block, using owner UUID.
+     *
+     * @param level     The level
+     * @param pos       The block position
+     * @param ownerUUID The UUID of the owner
+     * @return true if successful
+     */
+    public static boolean tryRemoveBlock(Level level, BlockPos pos, @Nullable UUID ownerUUID) {
+        return tryRemoveBlock(level, pos, getPlayerFromUUID(level, ownerUUID));
+    }
+
+    /**
+     * Attempts to place a block, using owner UUID.
+     *
+     * @param level     The level
+     * @param pos       The block position
+     * @param newState  The block state to place
+     * @param ownerUUID The UUID of the owner
+     * @return true if successful
+     */
+    public static boolean tryPlaceBlock(Level level, BlockPos pos, BlockState newState, @Nullable UUID ownerUUID) {
+        return tryPlaceBlock(level, pos, newState, getPlayerFromUUID(level, ownerUUID));
+    }
+
+    /**
+     * Attempts to replace a block, using owner UUID.
+     *
+     * @param level     The level
+     * @param pos       The block position
+     * @param newState  The new block state
+     * @param ownerUUID The UUID of the owner
+     * @return true if successful
+     */
+    public static boolean tryReplaceBlock(Level level, BlockPos pos, BlockState newState, @Nullable UUID ownerUUID) {
+        return tryReplaceBlock(level, pos, newState, getPlayerFromUUID(level, ownerUUID));
+    }
+
+    /**
+     * Checks if an owner can break a block at the given position.
+     * If owner is offline, defaults to allowing the operation.
+     * Use {@link #canBreakBlockStrict} if you want to deny when owner is offline.
+     *
+     * @param level     The level
+     * @param pos       The block position
+     * @param ownerUUID The owner's UUID
+     * @return true if allowed (or owner is offline, which defaults to allowing)
+     */
+    public static boolean canBreakBlock(Level level, BlockPos pos, @Nullable UUID ownerUUID) {
+        return canBreakBlock(level, pos, getPlayerFromUUID(level, ownerUUID));
+    }
+
+    /**
+     * Checks if an owner can break a block at the given position (strict mode).
+     * Returns false if the owner UUID is null or the owner is offline.
+     * Use this for operations that should only work when the owner is online.
+     *
+     * @param level     The level
+     * @param pos       The block position
+     * @param ownerUUID The owner's UUID
+     * @return true if allowed and owner is online, false otherwise
+     */
+    public static boolean canBreakBlockStrict(Level level, BlockPos pos, @Nullable UUID ownerUUID) {
+        if (ownerUUID == null) {
+            return false;
+        }
+        Player player = getPlayerFromUUID(level, ownerUUID);
+        if (player == null) {
+            return false; // Owner offline - deny operation
+        }
+        return canBreakBlock(level, pos, player);
+    }
+
+    /**
+     * Checks if an owner can place a block at the given position.
+     *
+     * @param level     The level
+     * @param pos       The block position
+     * @param newState  The block state to place
+     * @param ownerUUID The owner's UUID
+     * @return true if allowed
+     */
+    public static boolean canPlaceBlock(Level level, BlockPos pos, BlockState newState, @Nullable UUID ownerUUID) {
+        return canPlaceBlock(level, pos, newState, getPlayerFromUUID(level, ownerUUID));
+    }
+
+    // ==================== Entity-based methods for projectiles ====================
+
+    /**
+     * Gets a player from an entity - either directly if the entity is a player,
+     * or from projectile owner if applicable.
+     *
+     * @param entity The entity
+     * @return The player, or null if not a player
+     */
+    @Nullable
+    public static Player getPlayerFromEntity(@Nullable Entity entity) {
+        if (entity instanceof Player player) {
+            return player;
+        }
+        return null;
+    }
+
+    /**
+     * Attempts to place a block, using entity for protection checks.
+     * If the entity is a player, uses that player for protection.
+     * Otherwise, allows the operation (no protection check).
+     *
+     * @param level    The level
+     * @param pos      The block position
+     * @param newState The block state to place
+     * @param entity   The entity responsible (player or projectile owner)
+     * @return true if successful
+     */
+    public static boolean tryPlaceBlock(Level level, BlockPos pos, BlockState newState, @Nullable Entity entity) {
+        return tryPlaceBlock(level, pos, newState, getPlayerFromEntity(entity));
+    }
+
+    /**
+     * Attempts to remove a block, using entity for protection checks.
+     *
+     * @param level  The level
+     * @param pos    The block position
+     * @param entity The entity responsible
+     * @return true if successful
+     */
+    public static boolean tryRemoveBlock(Level level, BlockPos pos, @Nullable Entity entity) {
+        return tryRemoveBlock(level, pos, getPlayerFromEntity(entity));
+    }
+
+    /**
+     * Checks if an entity can place a block at the given position.
+     *
+     * @param level  The level
+     * @param pos    The block position
+     * @param entity The entity
+     * @return true if allowed
+     */
+    public static boolean canPlaceBlock(Level level, BlockPos pos, @Nullable Entity entity) {
+        if (level.isClientSide()) {
+            return true;
+        }
+        BlockState oldState = level.getBlockState(pos);
+        return firePlaceEvent(level, pos, oldState, oldState, getPlayerFromEntity(entity));
+    }
+
+    // ==================== Convenience methods without BlockState ====================
+
+    /**
+     * Checks if a player can place a block at the given position (without specifying state).
+     * Uses current state as both old and new state for event firing.
+     *
+     * @param level  The level
+     * @param pos    The block position
+     * @param player The player
+     * @return true if allowed
+     */
+    public static boolean canPlaceBlock(Level level, BlockPos pos, @Nullable Player player) {
+        if (level.isClientSide()) {
+            return true;
+        }
+        BlockState oldState = level.getBlockState(pos);
+        return firePlaceEvent(level, pos, oldState, oldState, player);
+    }
+
+    /**
+     * Checks if an owner UUID can place a block at the given position (without specifying state).
+     *
+     * @param level     The level
+     * @param pos       The block position
+     * @param ownerUUID The owner's UUID
+     * @return true if allowed
+     */
+    public static boolean canPlaceBlock(Level level, BlockPos pos, @Nullable UUID ownerUUID) {
+        return canPlaceBlock(level, pos, getPlayerFromUUID(level, ownerUUID));
+    }
+}


### PR DESCRIPTION
Fixes #2024 Implemented block protection to prevent unauthorized block breaking and placing in protected chunks.

Introduces a BlockProtectionHelper class with methods to fire BlockEvent.BreakEvent and BlockEvent.EntityPlaceEvent before block modifications.

This allows protection mods like FTB Chunks or Xaeros Parties to prevent unauthorized operations by rituals, sigils, projectiles and other automated systems.

Adds owner tracking to explosive charges to allow protection against griefing.