### PR TITLE
Fixed plant leech effect issue

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/potion/BMPotionUtils.java
+++ b/src/main/java/wayoftime/bloodmagic/potion/BMPotionUtils.java
@@ -51,19 +51,24 @@ public class BMPotionUtils
 
 		for (BlockPos blockPos : growList)
 		{
-			Block block = world.getBlockState(blockPos).getBlock();
-//          if (world.rand.nextInt(50) == 0)
+			BlockState preBlockState = world.getBlockState(blockPos);
+			for (int n = 0; n < 10; n++)
 			{
-				BlockState preBlockState = world.getBlockState(blockPos);
-				for (int n = 0; n < 10; n++)
-					block.randomTick(world.getBlockState(blockPos), (ServerLevel) world, blockPos, world.random);
-
-				BlockState newState = world.getBlockState(blockPos);
-				if (!newState.equals(preBlockState))
+				BlockState currentState = world.getBlockState(blockPos);
+				// Stop if the block has changed (e.g., sapling grew into a tree)
+				// or if it's no longer a growable block
+				if (!currentState.is(preBlockState.getBlock()) || !(currentState.getBlock() instanceof BonemealableBlock))
 				{
-					world.levelEvent(2005, blockPos, 0);
-					incurredDamage += damageRatio;
+					break;
 				}
+				currentState.randomTick((ServerLevel) world, blockPos, world.random);
+			}
+
+			BlockState newState = world.getBlockState(blockPos);
+			if (!newState.equals(preBlockState))
+			{
+				world.levelEvent(2005, blockPos, 0);
+				incurredDamage += damageRatio;
 			}
 		}
 


### PR DESCRIPTION
#2130
The code now:
  1. Gets the BlockState fresh at each iteration of the inner loop
  2. Checks if the block has changed from the original block type
  3. Checks if the block is still a BonemealableBlock
  4. If either condition fails (block changed or no longer growable), it breaks out of the loop

  This prevents the crash when a sapling transforms into a tree mid-growth, as well as any other block transformations that might occur during random ticks.