### PR TITLE
Fixed curio related logspam

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/compat/CuriosCompat.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/CuriosCompat.java
@@ -40,7 +40,14 @@ public class CuriosCompat
 
 	public int recalculateCuriosSlots(Player player)
 	{
-		ICurioStacksHandler livingArmourSockets = CuriosApi.getCuriosInventory(player).resolve().get().getCurios().get("living_armour_socket");
+		Optional<ICuriosItemHandler> curioInv = CuriosApi.getCuriosInventory(player).resolve();
+		if (curioInv.isEmpty()) {
+			return 0;
+		}
+		ICurioStacksHandler livingArmourSockets = curioInv.get().getCurios().get("living_armour_socket");
+		if (livingArmourSockets == null) {
+			return 0;
+		}
 		if (LivingUtil.hasFullSet(player))
 		{
 			LivingStats stats = LivingStats.fromPlayer(player);


### PR DESCRIPTION
#2085 and #2040
 Added null-safety checks:
  1. Check if curioInv.isEmpty() before calling .get()
  2. Check if livingArmourSockets == null before using it