### PR TITLE
annoying item interactions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,8 @@ AgriCraft is *not* installed.
 - prevent a crash when opening the Edit HUD position screen while looking at an entity
 - soft coating no longer voids the contents of shulker boxes (or other tile-entities)
 - bloodmagic:geode_harvestable now adds forge:clusters as a tag instead of a block, meaning it'll actually work with them
+- teleposition sigil now teleports you when clicking on a non-teleposer block as well. it also now checks itself for a destination when inside a sigil of holding
+- ritual diviner and tinkerer can now be cycled even when looking at a (non master ritual stone) block
 
 ------------------------------------------------------
 Version 3.3.5

--- a/src/main/java/wayoftime/bloodmagic/common/item/ItemRitualDiviner.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/ItemRitualDiviner.java
@@ -145,6 +145,11 @@ public class ItemRitualDiviner extends Item
 	@Override
 	public InteractionResult useOn(UseOnContext context)
 	{
+		// the things in this method only care about it being used on a MRS, if thats not the case we ignore
+		if (!(context.getLevel().getBlockEntity(context.getClickedPos()) instanceof TileMasterRitualStone)) {
+			return InteractionResult.PASS;
+		}
+
 		ItemStack stack = context.getPlayer().getItemInHand(context.getHand());
 		if (context.getPlayer().isShiftKeyDown())
 		{
@@ -362,13 +367,6 @@ public class ItemRitualDiviner extends Item
 	{
 		ItemStack stack = player.getItemInHand(hand);
 		setActivatedState(stack, false);
-
-		HitResult ray = getPlayerPOVHitResult(world, player, ClipContext.Fluid.NONE);
-
-		if (ray != null && ray.getType() == HitResult.Type.BLOCK)
-		{
-			return new InteractionResultHolder<>(InteractionResult.PASS, stack);
-		}
 
 		if (player.isShiftKeyDown())
 		{

--- a/src/main/java/wayoftime/bloodmagic/common/item/ItemRitualReader.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/ItemRitualReader.java
@@ -79,11 +79,6 @@ public class ItemRitualReader extends Item
 	public InteractionResultHolder<ItemStack> use(Level world, Player player, InteractionHand hand)
 	{
 		ItemStack stack = player.getItemInHand(hand);
-		HitResult ray = Item.getPlayerPOVHitResult(world, player, Fluid.NONE);
-		if (ray != null && ray.getType() == HitResult.Type.BLOCK)
-		{
-			return new InteractionResultHolder<>(InteractionResult.PASS, stack);
-		}
 
 		if (player.isShiftKeyDown())
 		{
@@ -114,10 +109,9 @@ public class ItemRitualReader extends Item
 		{
 			EnumRitualReaderState state = this.getState(stack);
 			BlockEntity tile = world.getBlockEntity(pos);
-			if (tile instanceof IMasterRitualStone)
+			if (tile instanceof IMasterRitualStone master)
 			{
-				IMasterRitualStone master = (IMasterRitualStone) tile;
-				if (master.getCurrentRitual() == null)
+                if (master.getCurrentRitual() == null)
 					super.useOn(context);
 				this.setMasterBlockPos(stack, pos);
 				this.setBlockPos(stack, BlockPos.ZERO);
@@ -195,10 +189,9 @@ public class ItemRitualReader extends Item
 						} else
 						{
 							tile = world.getBlockEntity(masterPos);
-							if (tile instanceof IMasterRitualStone)
+							if (tile instanceof IMasterRitualStone master)
 							{
-								IMasterRitualStone master = (IMasterRitualStone) tile;
-								BlockPos pos2 = pos.subtract(masterPos);
+                                BlockPos pos2 = pos.subtract(masterPos);
 								String range = this.getCurrentBlockRange(stack);
 								if (range == null || range.isEmpty())
 								{

--- a/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilHolding.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilHolding.java
@@ -140,11 +140,11 @@ public class ItemSigilHolding extends ItemSigilBase implements IKeybindable, IAl
 		if (itemUsing.isEmpty() || ((IBindable) itemUsing.getItem()).getBinding(itemUsing) == null)
 			return InteractionResultHolder.pass(stack);
 
-		itemUsing.getItem().use(world, player, hand);
-
+		InteractionResultHolder<ItemStack> result = itemUsing.getItem().use(world, player, hand);
 		saveInventory(stack, inv);
 
-		return InteractionResultHolder.pass(stack);
+		// dont throw away the internal sigils use result, didnt do that in useOn either
+		return result;
 	}
 
 	@Nonnull

--- a/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilTeleposition.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilTeleposition.java
@@ -89,6 +89,10 @@ public class ItemSigilTeleposition extends ItemSigilBase
 	public InteractionResult useOn(UseOnContext context)
 	{
 		ItemStack stack = context.getItemInHand();
+		// need this to work in holding sigil
+		if (stack.getItem() instanceof ISigil.Holding) {
+			stack = ((Holding) stack.getItem()).getHeldItem(stack, context.getPlayer());
+		}
 		BlockPos pos = context.getClickedPos();
 		Level world = context.getLevel();
 		Player player = context.getPlayer();
@@ -108,9 +112,10 @@ public class ItemSigilTeleposition extends ItemSigilBase
 						BindableHelper.applyBinding(stack, player);
 				}
 			}
+			return InteractionResult.SUCCESS;
 		}
 
-		return InteractionResult.SUCCESS;
+		return InteractionResult.PASS;
 	}
 
 	public void setStoredPos(ItemStack stack, BlockPos pos)

--- a/src/main/java/wayoftime/bloodmagic/util/handler/event/GenericHandler.java
+++ b/src/main/java/wayoftime/bloodmagic/util/handler/event/GenericHandler.java
@@ -202,6 +202,16 @@ public class GenericHandler
 	}
 
 	@SubscribeEvent
+	// make cycling the diviner also work on clicking on a block instead of only on clicking nothing
+	public void onPlayerLeftClickBlock(PlayerInteractEvent.LeftClickBlock event)
+	{
+		if (event.getItemStack().getItem() instanceof ItemRitualDiviner)
+		{
+			BloodMagicPacketHandler.INSTANCE.sendToServer(new CycleRitualDivinerPacket(event.getEntity().getInventory().selected));
+		}
+	}
+
+	@SubscribeEvent
 	// Called when an entity is set to be hurt. Called before vanilla armour
 	// calculations.
 	public void onLivingHurt(LivingHurtEvent event)

--- a/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/rituals/ritual_diviner.json
+++ b/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/rituals/ritual_diviner.json
@@ -5,7 +5,7 @@
   "pages": [
     {
       "type": "patchouli:text",
-      "text": "Crafting rituals is an intricate business; Even if you have the correct $(item)Inscription Tools$(), you can't just slap runic inscriptions down any old how and expect things to happen. Luckily, the $(item)Ritual Diviner$() is here to help. $(br2)Hold [$(k:sneak)] and press [$(k:use)] or [$(k:attack)] while looking at empty air to cycle through the avaliable rituals in either direction."
+      "text": "Crafting rituals is an intricate business; Even if you have the correct $(item)Inscription Tools$(), you can't just slap runic inscriptions down any old how and expect things to happen. Luckily, the $(item)Ritual Diviner$() is here to help. $(br2)Hold [$(k:sneak)] and press [$(k:use)] or [$(k:attack)] to cycle through the avaliable rituals in either direction."
     },
     {
       "type": "patchouli:text",

--- a/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/utility/changelog.json
+++ b/src/main/resources/assets/bloodmagic/patchouli_books/guide/en_us/entries/utility/changelog.json
@@ -43,6 +43,10 @@
     },
     {
       "type": "patchouli:text",
+      "text": "$(li)teleposition sigil now teleports you when clicking on a non-teleposer block as well. it also now checks itself for a destination when inside a sigil of holding$()$(li)ritual diviner and tinkerer can now be cycled even when looking at a (non master ritual stone) block"
+    },
+    {
+      "type": "patchouli:text",
       "title": "3.3.5",
       "text": "$(li)Missing Recipe Serializer prevented people from joining servers. Its been found and put where it belongs"
     },


### PR DESCRIPTION
- Teleposition sigil didnt let you teleport when clicking any block, instead of just resetting its target on teleposers
- ritual diviner and tinkerer didnt let you cycle through their things when looking at a block
- Teleposition sigil didnt work properly when inside of a sigil of holding
- Holding sigil didnt care about the result from the contained sigils use method (but did for useOn)