### PR TITLE
fix geode_harvestable tag

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ AgriCraft is *not* installed.
 - forge:storage_blocks/hellforged block and item tags have been added to the respective forge:storage_blocks tag
 - prevent a crash when opening the Edit HUD position screen while looking at an entity
 - soft coating no longer voids the contents of shulker boxes (or other tile-entities)
+- bloodmagic:geode_harvestable now adds forge:clusters as a tag instead of a block, meaning it'll actually work with them
 
 ------------------------------------------------------
 Version 3.3.5

--- a/src/generated/resources/data/bloodmagic/tags/blocks/geode_harvestable.json
+++ b/src/generated/resources/data/bloodmagic/tags/blocks/geode_harvestable.json
@@ -2,7 +2,7 @@
   "values": [
     "minecraft:amethyst_cluster",
     {
-      "id": "forge:clusters",
+      "id": "#forge:clusters",
       "required": false
     },
     {

--- a/src/main/java/wayoftime/bloodmagic/common/data/GeneratorBlockTags.java
+++ b/src/main/java/wayoftime/bloodmagic/common/data/GeneratorBlockTags.java
@@ -121,7 +121,7 @@ public class GeneratorBlockTags extends IntrinsicHolderTagsProvider<Block>
 						.addOptionalTag(new ResourceLocation("forge:budding")),
 				this.tag(BloodMagicTags.Blocks.GEODE_HARVESTABLE)
 						.add(Blocks.AMETHYST_CLUSTER)
-						.addOptional(new ResourceLocation("forge:clusters"))
+						.addOptionalTag(new ResourceLocation("forge:clusters"))
                         .addOptional(new ResourceLocation("magichem", "cluster_signalite")) // budding blocks are already in forge:budding
                         .addOptional(new ResourceLocation("magichem", "cluster_vinteum"))
 		);


### PR DESCRIPTION
apparently I forgot to specify that forge:clusters was a tag, not a block, so currently its not harvesting certus (or anything else in the forge:clusters tag)