### PR TITLE
add check for empty block in fluid sigil placement, and waterlogging

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilFluidBase.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilFluidBase.java
@@ -100,6 +100,8 @@ public abstract class ItemSigilFluidBase extends ItemSigilBase
 	 */
 	protected boolean tryPlaceSigilFluid(Player player, Level world, BlockPos blockPos)
 	{
+        if (!world.isEmptyBlock(blockPos) && !world.getBlockState(blockPos).canBeReplaced()) return false;
+
 		FluidStack resource = sigilFluid;
 		BlockState state = sigilFluid.getFluid().getFluidType().getBlockForFluidState(world, blockPos, sigilFluid.getFluid().defaultFluidState());
 

--- a/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilLava.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilLava.java
@@ -19,8 +19,6 @@ import wayoftime.bloodmagic.util.helper.NetworkHelper;
 import wayoftime.bloodmagic.util.helper.PlayerHelper;
 import wayoftime.bloodmagic.ConfigManager;
 
-import wayoftime.bloodmagic.common.item.sigil.ISigil.Holding;
-
 public class ItemSigilLava extends ItemSigilFluidBase implements IAlchemyItem
 {
 	public ItemSigilLava()
@@ -82,8 +80,7 @@ public class ItemSigilLava extends ItemSigilFluidBase implements IAlchemyItem
 				// Place fluid in world
 				if (destination == null && destinationSide == null)
 				{
-					BlockPos targetPos = blockPos.relative(sideHit);
-					if (tryPlaceSigilFluid(player, world, targetPos) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess())
+					if (tryPlaceSigilFluid(player, world, blockpos1) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess())
 					{
 						return InteractionResultHolder.success(stack);
 					}

--- a/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilWater.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilWater.java
@@ -8,6 +8,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.SimpleWaterloggedBlock;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
@@ -82,13 +84,18 @@ public class ItemSigilWater extends ItemSigilFluidBase implements IAlchemyItem
 //					world.setBlockAndUpdate(blockPos, Blocks.CAULDRON.defaultBlockState().setValue(CauldronBlock., 3));
 //					return InteractionResultHolder.success(stack);
 //				}
+                //waterlog block if possible
+                if (tryWaterlogBlock(world, player, stack, blockPos)
+                        || tryWaterlogBlock(world, player, stack, blockpos1))
+                {
+                    return InteractionResultHolder.success(stack);
+                }
 
 				// Case for if block at blockPos is not a tank
 				// Place fluid in world
 				if (destination == null && destinationSide == null)
 				{
-					BlockPos targetPos = blockPos.relative(sideHit);
-					if (tryPlaceSigilFluid(player, world, targetPos) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess())
+					if (tryPlaceSigilFluid(player, world, blockpos1) && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess())
 					{
 						return InteractionResultHolder.success(stack);
 					}
@@ -98,6 +105,17 @@ public class ItemSigilWater extends ItemSigilFluidBase implements IAlchemyItem
 
 		return super.use(world, player, hand);
 	}
+
+    private boolean tryWaterlogBlock(Level world, Player player, ItemStack stack, BlockPos blockPos) {
+        if (world.getBlockState(blockPos).getBlock() instanceof SimpleWaterloggedBlock
+                && world.setBlock(blockPos, world.getBlockState(blockPos).setValue(BlockStateProperties.WATERLOGGED, true), 3)
+                && NetworkHelper.getSoulNetwork(getBinding(stack)).syphonAndDamage(player, SoulTicket.item(stack, world, player, getLpUsed())).isSuccess())
+        {
+            world.scheduleTick(blockPos, Fluids.WATER, Fluids.WATER.getTickDelay(world));
+            return true;
+        }
+        return false;
+    }
 
 	@Override
 	public ItemStack onConsumeInput(ItemStack stack)


### PR DESCRIPTION
1. Fixes Issue [1862](https://github.com/WayofTime/BloodMagic/issues/1862)
2. Added waterlogging to the water sigil

I edited the changelog as well since I saw some other PRs do that -- just let me know if you'd prefer I don't touch that.