### PR TITLE
Prevent tick acceleration from duping items in the alchemy array

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/tile/TileAlchemyArray.java
+++ b/src/main/java/wayoftime/bloodmagic/common/tile/TileAlchemyArray.java
@@ -135,6 +135,7 @@ public class TileAlchemyArray extends TileInventory
 				this.removeItem(0, 1);
 				this.removeItem(1, 1);
 				this.getLevel().setBlockAndUpdate(getBlockPos(), Blocks.AIR.defaultBlockState());
+				return false;
 			}
 
 			return true;


### PR DESCRIPTION
return false from attemptCraft() when the craft completes, so tick() takes the else branch and resets state immediately