### PR TITLE
Fix Sigil of Holding being replaced by its inner sigil on use

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilHolding.java
+++ b/src/main/java/wayoftime/bloodmagic/common/item/sigil/ItemSigilHolding.java
@@ -143,8 +143,9 @@ public class ItemSigilHolding extends ItemSigilBase implements IKeybindable, IAl
 		InteractionResultHolder<ItemStack> result = itemUsing.getItem().use(world, player, hand);
 		saveInventory(stack, inv);
 
-		// dont throw away the internal sigils use result, didnt do that in useOn either
-		return result;
+		// Fluid sigils return success(innerHeldStack); propagating that directly would
+		// have vanilla replace the hand with the inner sigil and lose the holding.
+		return new InteractionResultHolder<>(result.getResult(), stack);
 	}
 
 	@Nonnull


### PR DESCRIPTION
## Summary
- `ItemSigilHolding.use()` was propagating the inner sigil's `InteractionResultHolder<ItemStack>` directly. Fluid sigils (Water, Lava, etc.) reassign their local `stack` variable to the inner held sigil and then `return InteractionResultHolder.success(stack)`, so vanilla's `ServerPlayerGameMode.useItem` calls `player.setItemInHand(hand, innerSigilStack)` — replacing the Sigil of Holding in the player's hand with a bare inner sigil and losing the other four held sigils.
- Keep the inner sigil's `InteractionResult` signal (the intent of `dcd2d830` "annoying item interactions") but always return the holding stack so vanilla never swaps the hand.

## Reproduction steps (before fix)
1. Craft a Sigil of Holding; place five bound sigils inside (Seer, Water, Lava, Air, Divination etc).
2. Shift-scroll to select Water (or Lava).
3. Right-click to place a source block, or right-click a waterloggable block (stairs/slab/fence) to waterlog it.
4. The Sigil of Holding in the hotbar is replaced by a bare Water/Lava Sigil; the other four sigils are gone.

## Root cause
- `dcd2d830` (Dec 24 2025, "annoying item interactions") changed `ItemSigilHolding.use()` to propagate the inner sigil's return instead of discarding it. The comment reasons "didnt do that in useOn either" — which is technically right but misleading: `useOn` returns `InteractionResult` (no carried stack), while `use` returns `InteractionResultHolder<ItemStack>` whose stack is passed to `player.setItemInHand(hand, ...)` by `ServerPlayerGameMode.useItem`.
- `ba90f199` (Apr 1 2026, waterlogging support) made the Water sigil's success path much more reachable via `tryWaterlogBlock`, which returns `InteractionResultHolder.success(stack)` where `stack` was reassigned to the inner held sigil at the top of `ItemSigilWater.use`. The Lava sigil and the other fluid sigils have the same latent pattern.
- Combined, any successful fluid placement from within the Sigil of Holding swaps the hand to a bare inner sigil.
