### PR TITLE
Add .editorconfig for style guide hygiene

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+
+[*.{gradle,properties,toml,cfg,prefs}]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+
+[*.{json,mcmeta,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{Makefile,*.bat}]
+indent_style = tab


### PR DESCRIPTION
## Summary
- Adds a repo-root `.editorconfig` so most editors auto-apply the whitespace rules already documented in `STYLE_GUIDE.md`.
- Java: tabs (width 4) per the style guide.
- Data/build files: follow their ecosystem conventions (JSON/YAML 2-space, Markdown keeps trailing whitespace so hard line breaks aren't stripped).

## Why
`STYLE_GUIDE.md` asks contributors to use tabs and points out that spaces sneak in if IDEs aren't configured. `.editorconfig` is supported out-of-the-box by IntelliJ IDEA, Eclipse (via plugin), VS Code, and most other editors, so the rule is applied without each contributor having to change their global settings.

## Scope
`.editorconfig` only. **No existing files were reformatted** — this PR intentionally doesn't touch source to keep the diff reviewable and to avoid noisy blame churn. A separate pass (or gradual cleanup as files are touched) can normalize existing inconsistencies.

## What's enforced
- UTF-8, LF line endings, final newline, trim trailing whitespace (except Markdown)
- `*.java`: `indent_style = tab`, `tab_width = 4`
- `*.{gradle,properties,toml,cfg,prefs}`: same as Java
- `*.{json,mcmeta,yml,yaml}`: 2-space indent (standard for these formats)
- `*.md`: no trailing-whitespace trimming (preserves intentional two-space line breaks)
- `*.bat`: tabs (CRLF is left alone on Windows-only files via `.gitattributes` if needed)

## Test plan
- [ ] Open an arbitrary `.java` file in an editor that honors `.editorconfig` (IntelliJ, VS Code) — new indentation is tabs
- [ ] Open a `.json` — indentation is 2 spaces
- [ ] Save a `.md` file with trailing two-space line break — not stripped