### PR TITLE
Add .editorconfig for style guide hygiene

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+
+[*.{gradle,properties,toml,cfg,prefs}]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+
+[*.{json,mcmeta,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{Makefile,*.bat}]
+indent_style = tab


### PR DESCRIPTION
Codifies the indent, line-ending, and whitespace rules from STYLE_GUIDE.md so editors apply them automatically. Java uses tabs conventions (JSON/YAML 2-space, Markdown keeps trailing whitespace for hard line breaks as reqired).