### PR TITLE
Fix server lag from WillHandler creating empty WillChunks for every loaded chunk (#2151)

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/util/handler/event/WillHandler.java
+++ b/src/main/java/wayoftime/bloodmagic/util/handler/event/WillHandler.java
@@ -247,9 +247,6 @@ public class WillHandler
 			DemonWillHolder current = new DemonWillHolder();
 			current.readFromNBT(nbt, "current");
 			WorldDemonWillHandler.addWillChunk(rl, event.getChunk(), base, current);
-		} else
-		{
-			WorldDemonWillHandler.generateWill(event.getChunk(), (Level) event.getLevel());
 		}
 	}
 }


### PR DESCRIPTION
Closes #2151. 

From the discord discussion;

WillHandler.chunkLoad at src/main/java/wayoftime/bloodmagic/util/handler/event/WillHandler.java:250ish fires on every chunk load. When a chunk has no BloodMagic NBT, it falls into:
```
  } else {
      WorldDemonWillHandler.generateWill(event.getChunk(), (Level) event.getLevel());
  }
```
so `generateWill (WorldDemonWillHandler.java:210)` creates an empty WillChunk (base=1, empty DemonWillHolder) and puts it into the per-world ConcurrentHashMap. Every chunk unload removes it. In a server with lots of chunk churn (many players, chunk loaders, dimension hops or fast fliers), this is a constant stream of put/remove on the map for chunks that have no actual demon will activity. Which is consistent with the profiler results, should be easy enough to fix by just  dropping the else { generateWill(...) } in chunkLoad. Chunks with real will NBT still flow through the if branch and everything else is lazy-loaded on demand.